### PR TITLE
fix: handle env variable on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The `package.json` contains a few built-in npm commands:
   The server needs to connect to a running instance of Qlik Engine and by default assumes it's already running on port `9076`. If you don't have Qlik Sense desktop installed you can opt-in to start a Docker image of Qlik Engine by accepting the [Qlik Core EULA](https://core.qlik.com/eula/):
 
   ```sh
-  ACCEPT_EULA=yes npm start
+  cross-env ACCEPT_EULA=yes npm start
   ```
 
 - `npm run build`

--- a/packages/serve/lib/engine.js
+++ b/packages/serve/lib/engine.js
@@ -8,7 +8,7 @@ const startEngine = () => {
   }
   console.log('Starting engine container ...');
   return new Promise((resolve, reject) => {
-    const c = execa.shell('ACCEPT_EULA=yes docker-compose up -d --build', {
+    const c = execa.shell('cross-env ACCEPT_EULA=yes docker-compose up -d --build', {
       cwd: path.resolve(__dirname, '../'),
       stdio: 'inherit',
     });

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@nebula.js/cli-build": "0.1.0-alpha.13",
     "chalk": "^2.4.2",
+    "cross-env": "^5.2.0",
     "execa": "^1.0.0",
     "html-webpack-plugin": "^3.2.0",
     "portfinder": "^1.0.20",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Starting `serve` should work on windows.

closes #44 