### PR TITLE
fix(nucleus): exit object modal state before modifying app state

### DIFF
--- a/packages/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/packages/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -21,6 +21,7 @@ export default function ListBoxPopover({
   show,
   close,
   app,
+  selections,
   fieldName,
   stateName = '$',
 }) {
@@ -63,6 +64,10 @@ export default function ListBoxPopover({
   const isLocked = layout ? layout.qListObject.qDimensionInfo.qLocked === true : false;
 
   const open = show && Boolean(alignTo.current);
+
+  if (open) {
+    selections.switchModal();
+  }
 
   return (
     <Popover

--- a/packages/nucleus/src/components/selections/OneField.jsx
+++ b/packages/nucleus/src/components/selections/OneField.jsx
@@ -130,6 +130,7 @@ export default function OneField({
           alignTo={alignTo}
           show={isActive}
           close={() => setIsActive(false)}
+          selections={api}
           app={api.model}
           fieldName={selection.qField}
           stateName={field.states[0]}

--- a/packages/nucleus/src/selections/app-selections.js
+++ b/packages/nucleus/src/selections/app-selections.js
@@ -61,19 +61,16 @@ const create = (app) => {
       return lyt;
     },
     forward() {
-      this.switchModal();
-      return app.forward();
+      return this.switchModal().then(() => app.forward());
     },
     back() {
-      this.switchModal();
-      return app.back();
+      return this.switchModal().then(() => app.back());
     },
     clear() {
-      this.switchModal();
-      return app.clearAll();
+      return this.switchModal().then(() => app.clearAll());
     },
     clearField(field, state = '$') {
-      return app.getField(field, state).then(f => f.clear());
+      return this.switchModal().then(() => app.getField(field, state).then(f => f.clear()));
     },
   };
 


### PR DESCRIPTION
Fixes error being thrown because we're trying to change app selection state when an object is in modal state. 
