### PR TITLE
feat(nucleus): improve configurability

### DIFF
--- a/packages/nucleus/src/index.js
+++ b/packages/nucleus/src/index.js
@@ -11,81 +11,120 @@ import get from './object/get-object';
 import { create as types } from './sn/types';
 import logger from './utils/logger';
 
-function nucleus(app, cfg = {}) {
-  createAppSelectionAPI(app);
+const DEFAULT_CONFIG = {
+  theme: 'light',
+  load: () => undefined,
+  locale: {
+    language: 'en-US',
+  },
+  log: {
+    level: 4,
+  },
+  types: [],
+  env: {},
+};
 
-  const lgr = logger({ level: 4 });
+const mergeConfigs = (base, c) => ({
+  theme: c.theme || base.theme,
+  load: c.load || base.load,
+  locale: {
+    language: (c.locale ? c.locale.language : '') || base.locale.language,
+  },
+  types: [ // TODO - filter to avoid duplicates
+    ...(base.types || []),
+    ...(c.types || []),
+  ],
+  env: {
+    ...(base.env || {}),
+    ...(c.env || {}),
+  },
+});
 
-  const locale = localeFn(cfg.locale);
+function nuked(configuration = {}) {
+  function nucleus(app, instanceConfig = {}) {
+    const currentConfig = mergeConfigs(configuration, instanceConfig);
+    const lgr = logger(currentConfig.log);
+    const locale = localeFn(currentConfig.locale);
 
-  const config = {
-    env: {
-      Promise,
+    const config = {
+      env: {
+        Promise,
+        translator: locale.translator(),
+      },
+      load: currentConfig.load,
+    };
+
+    createAppSelectionAPI(app);
+
+    const root = App({
+      app,
       translator: locale.translator(),
-    },
-    load: cfg.load || (() => undefined),
-  };
+      theme: currentConfig.theme,
+    });
 
-  const root = App({
-    app,
-    translator: locale.translator(),
-    theme: cfg.theme || 'light',
-  });
+    const context = {
+      nebbie: null,
+      app,
+      config,
+      logger: lgr,
+      types: types({ logger: lgr, config }),
+      root,
+    };
 
-  const context = {
-    nebbie: null,
-    app,
-    config,
-    logger: lgr,
-    types: types({ logger: lgr, config }),
-    root,
-  };
+    currentConfig.types.forEach(t => context.types.register({
+      name: t.name,
+      version: t.version,
+    }, {
+      meta: t.meta,
+      load: t.load,
+    }));
 
-  let selectionsApi = null;
-  let selectionsComponentReference = null;
+    let selectionsApi = null;
+    let selectionsComponentReference = null;
 
-  const api = {
-    get: (getCfg, userProps) => get(getCfg, userProps, context),
-    create: (createCfg, userProps) => create(createCfg, userProps, context),
-    env: (e) => {
-      Object.assign(config.env, e);
-      return api;
-    },
-    theme(t) {
-      root.theme(t);
-      return api;
-    },
-    selections: () => {
-      if (!selectionsApi) {
-        selectionsApi = {
-          ...app._selections, // eslint-disable-line no-underscore-dangle
-          mount(element) {
-            if (selectionsComponentReference) {
-              console.error('Already mounted');
-              return;
-            }
-            selectionsComponentReference = AppSelectionsPortal({
-              element,
-              api: app._selections,
-            });
-            root.add(selectionsComponentReference);
-          },
-          unmount() {
-            if (selectionsComponentReference) {
-              root.remove(selectionsComponentReference);
-              selectionsComponentReference = null;
-            }
-          },
-        };
-      }
-      return selectionsApi;
-    },
-    types: context.types,
-  };
+    const api = {
+      get: (getCfg, userProps) => get(getCfg, userProps, context),
+      create: (createCfg, userProps) => create(createCfg, userProps, context),
+      theme(t) {
+        root.theme(t);
+        return api;
+      },
+      selections: () => {
+        if (!selectionsApi) {
+          selectionsApi = {
+            ...app._selections, // eslint-disable-line no-underscore-dangle
+            mount(element) {
+              if (selectionsComponentReference) {
+                console.error('Already mounted');
+                return;
+              }
+              selectionsComponentReference = AppSelectionsPortal({
+                element,
+                api: app._selections,
+              });
+              root.add(selectionsComponentReference);
+            },
+            unmount() {
+              if (selectionsComponentReference) {
+                root.remove(selectionsComponentReference);
+                selectionsComponentReference = null;
+              }
+            },
+          };
+        }
+        return selectionsApi;
+      },
+      types: context.types,
+    };
 
-  context.nebbie = api;
+    context.nebbie = api;
 
-  return api;
+    return api;
+  }
+
+  nucleus.configured = c => nuked(mergeConfigs(configuration, c));
+
+  return nucleus;
 }
 
-export default nucleus;
+export default nuked(DEFAULT_CONFIG);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Makes the nucleus API configurable to simplify reuse of same config for multiple apps:

The new `configured` method returns a new `nucleus` object that is preconfigured with the specified config.

**Before**:
```js
import nucleus from '@nebula.js/nucleus';

const n1 = nucleus(salesApp, {
  theme: 'dark',
  locale: {
    language: 'en-US',
  },
});

const n2 = nucleus(productsApp, {
  theme: 'dark',
  locale: {
    language: 'en-US',
  },
});
```

**After**:
```js
import nucleus from '@nebula.js/nucleus';

const darkEnglish = nucleus.configured({
  theme: 'dark',
  locale: {
    language: 'en-US',
  },
});

const n1 = darkEnglish(salesApp);
const n2 = darkEnglish(productsApp);
```