### PR TITLE
build: ignore node_modules

### DIFF
--- a/packages/serve/lib/webpack.serve.js
+++ b/packages/serve/lib/webpack.serve.js
@@ -67,6 +67,9 @@ module.exports = async ({ host, port, enigmaConfig, snPath, snName, dev = false,
         ignorePath: true,
       },
     ],
+    watchOptions: {
+      ignored: /node_modules/,
+    },
   };
 
   console.log('Starting development server...');


### PR DESCRIPTION
The `yarn start` included node_modules which yielded high cpu usage so let's ignore it.