### PR TITLE
feat: add direction to api

### DIFF
--- a/apis/nucleus/src/components/NebulaApp.jsx
+++ b/apis/nucleus/src/components/NebulaApp.jsx
@@ -4,12 +4,13 @@ import ReactDOM from 'react-dom';
 import { createTheme, ThemeProvider, StylesProvider, createGenerateClassName } from '@nebula.js/ui/theme';
 
 import LocaleContext from '../contexts/LocaleContext';
+import DirectionContext from '../contexts/DirectionContext';
 
 const THEME_PREFIX = (process.env.NEBULA_VERSION || '').replace(/[.-]/g, '_');
 
 let counter = 0;
 
-function NebulaApp({ children, themeName, translator }) {
+function NebulaApp({ children, themeName, translator, direction }) {
   const { theme, generator } = useMemo(
     () => ({
       theme: createTheme(themeName),
@@ -26,14 +27,16 @@ function NebulaApp({ children, themeName, translator }) {
     <StylesProvider generateClassName={generator}>
       <ThemeProvider theme={theme}>
         <LocaleContext.Provider value={translator}>
-          <>{children}</>
+          <DirectionContext.Provider value={direction}>
+            <>{children}</>
+          </DirectionContext.Provider>
         </LocaleContext.Provider>
       </ThemeProvider>
     </StylesProvider>
   );
 }
 
-export default function boot({ app, theme = 'light', translator }) {
+export default function boot({ app, theme = 'light', translator, direction }) {
   const element = document.createElement('div');
   element.style.display = 'none';
   element.setAttribute('data-nebulajs-version', process.env.NEBULA_VERSION || '');
@@ -41,10 +44,11 @@ export default function boot({ app, theme = 'light', translator }) {
   document.body.appendChild(element);
   const components = [];
   let themeName = theme;
+  let dir = direction;
 
   const update = () => {
     ReactDOM.render(
-      <NebulaApp themeName={themeName} app={app} translator={translator}>
+      <NebulaApp themeName={themeName} app={app} translator={translator} direction={dir}>
         {components}
       </NebulaApp>,
       element
@@ -71,6 +75,10 @@ export default function boot({ app, theme = 'light', translator }) {
     },
     theme(name) {
       themeName = name;
+      update();
+    },
+    direction(d) {
+      dir = d;
       update();
     },
   };

--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -15,7 +15,7 @@ import useLayout from '../../hooks/useLayout';
 
 import Row from './ListBoxRow';
 
-export default function ListBox({ model, selections }) {
+export default function ListBox({ model, selections, direction }) {
   const [layout] = useLayout(model);
   const [pages, setPages] = useState(null);
   const loaderRef = useRef(null);
@@ -123,6 +123,7 @@ export default function ListBox({ model, selections }) {
         local.current.listRef = ref;
         return (
           <FixedSizeList
+            direction={direction}
             useIsScrolling
             style={{}}
             height={8 * ITEM_HEIGHT}

--- a/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -16,6 +16,7 @@ import { createObjectSelectionAPI } from '../../selections';
 import SelectionToolbarWithDefault, { SelectionToolbar } from '../SelectionToolbar';
 
 import LocaleContext from '../../contexts/LocaleContext';
+import DirectionContext from '../../contexts/DirectionContext';
 
 import ListBoxSearch from './ListBoxSearch';
 
@@ -65,6 +66,7 @@ export default function ListBoxPopover({ alignTo, show, close, app, fieldName, s
   const [layout] = useLayout(model);
 
   const translator = useContext(LocaleContext);
+  const direction = useContext(DirectionContext);
 
   const moreAlignTo = useRef();
   const [showSelectionsMenu, setShowSelectionsMenu] = useState(false);
@@ -143,7 +145,7 @@ export default function ListBoxPopover({ alignTo, show, close, app, fieldName, s
         <Grid item xs>
           <div ref={moreAlignTo} />
           <ListBoxSearch model={model} />
-          <ListBox model={model} selections={sel} />
+          <ListBox model={model} selections={sel} direction={direction} />
           {showSelectionsMenu && (
             <Popover
               open={showSelectionsMenu}

--- a/apis/nucleus/src/contexts/DirectionContext.js
+++ b/apis/nucleus/src/contexts/DirectionContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const DirectionContext = React.createContext();
+
+export default DirectionContext;

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -25,6 +25,7 @@ const DEFAULT_CONFIG = {
 };
 
 const mergeConfigs = (base, c) => ({
+  direction: c.direction || base.direction,
   theme: c.theme || base.theme,
   load: c.load || base.load,
   locale: {
@@ -61,6 +62,7 @@ function nuked(configuration = {}) {
       app,
       translator: locale.translator(),
       theme: currentConfig.theme,
+      direction: currentConfig.direction,
     });
 
     const context = {
@@ -94,6 +96,9 @@ function nuked(configuration = {}) {
       theme(t) {
         root.theme(t);
         return api;
+      },
+      direction(d) {
+        root.direction(d);
       },
       selections: () => {
         if (!selectionsApi) {

--- a/commands/serve/web/components/App.jsx
+++ b/commands/serve/web/components/App.jsx
@@ -38,6 +38,7 @@ import Stage from './Stage';
 
 import AppContext from '../contexts/AppContext';
 import NebulaContext from '../contexts/NebulaContext';
+import DirectionContext from '../contexts/DirectionContext';
 
 const rtlShape = {
   size: 'large',
@@ -99,6 +100,7 @@ export default function App({
     const n = nucleus(app, {
       load: (type, config) => config.Promise.resolve(window.snDefinition || snDefinition),
       theme: themeName,
+      direction,
     });
     return n;
   }, [app]);
@@ -177,6 +179,7 @@ export default function App({
         nextDir = 'ltr';
       }
       document.body.setAttribute('dir', nextDir);
+      nebbie.direction(nextDir);
       return nextDir;
     });
   };
@@ -184,58 +187,60 @@ export default function App({
   return (
     <AppContext.Provider value={app}>
       <ThemeProvider theme={theme}>
-        <NebulaContext.Provider value={nebbie}>
-          <Grid container wrap="nowrap" direction="column" style={{ background: theme.palette.background.darkest }}>
-            <Grid item>
-              <Toolbar variant="dense" style={{ background: theme.palette.background.paper }}>
-                <Grid container>
-                  <Grid item>
-                    <Button variant="outlined" href={window.location.origin}>
-                      {/* <IconButton style={{ padding: '0px' }}>
+        <DirectionContext.Provider value={direction}>
+          <NebulaContext.Provider value={nebbie}>
+            <Grid container wrap="nowrap" direction="column" style={{ background: theme.palette.background.darkest }}>
+              <Grid item>
+                <Toolbar variant="dense" style={{ background: theme.palette.background.paper }}>
+                  <Grid container>
+                    <Grid item>
+                      <Button variant="outlined" href={window.location.origin}>
+                        {/* <IconButton style={{ padding: '0px' }}>
                         <ChevronLeft style={{ verticalAlign: 'middle' }} />
                       </IconButton> */}
                       Go to Hub
-                    </Button>
-                  </Grid>
-                  <Grid item xs />
-                  <Grid item>
-                    <Grid container>
-                      <Grid item>
-                        <Typography component="span">Cache</Typography>
-                        <Switch checked={isReadCacheEnabled} onChange={handleCacheChange} value="isReadFromCacheEnabled" />
-                      </Grid>
-                      <Grid item>
-                        <WbSunny fontSize="small" style={{ color: theme.palette.text.secondary, marginLeft: theme.spacing(2), verticalAlign: 'middle' }} />
-                        <Switch checked={darkMode} onChange={handleThemeChange} value="darkMode" />
-                        <Brightness3 fontSize="small" style={{ color: theme.palette.text.secondary, verticalAlign: 'middle' }} />
-                      </Grid>
-                      <Grid item>
-                        <IconButton title="Toggle right-to-left/left-to-right" onClick={toggleDirection}>
-                          {SvgIcon(directionShape[direction])}
-                        </IconButton>
+                      </Button>
+                    </Grid>
+                    <Grid item xs />
+                    <Grid item>
+                      <Grid container>
+                        <Grid item>
+                          <Typography component="span">Cache</Typography>
+                          <Switch checked={isReadCacheEnabled} onChange={handleCacheChange} value="isReadFromCacheEnabled" />
+                        </Grid>
+                        <Grid item>
+                          <WbSunny fontSize="small" style={{ color: theme.palette.text.secondary, marginLeft: theme.spacing(2), verticalAlign: 'middle' }} />
+                          <Switch checked={darkMode} onChange={handleThemeChange} value="darkMode" />
+                          <Brightness3 fontSize="small" style={{ color: theme.palette.text.secondary, verticalAlign: 'middle' }} />
+                        </Grid>
+                        <Grid item>
+                          <IconButton title="Toggle right-to-left/left-to-right" onClick={toggleDirection}>
+                            {SvgIcon(directionShape[direction])}
+                          </IconButton>
+                        </Grid>
                       </Grid>
                     </Grid>
                   </Grid>
-                </Grid>
-              </Toolbar>
-              <Divider />
-            </Grid>
-            <Grid item>
-              <div ref={currentSelectionsRef} style={{ flex: '0 0 auto' }} />
-              <Divider />
-            </Grid>
-            <Grid item xs>
-              <Grid container wrap="nowrap" style={{ height: '100%' }}>
-                <Grid item xs style={{ overflow: 'hidden' }}>
-                  <Stage viz={viz} />
-                </Grid>
-                <Grid item style={{ background: theme.palette.background.paper }}>
-                  <Properties sn={sn} viz={viz} />
+                </Toolbar>
+                <Divider />
+              </Grid>
+              <Grid item>
+                <div ref={currentSelectionsRef} style={{ flex: '0 0 auto' }} />
+                <Divider />
+              </Grid>
+              <Grid item xs>
+                <Grid container wrap="nowrap" style={{ height: '100%' }}>
+                  <Grid item xs style={{ overflow: 'hidden' }}>
+                    <Stage viz={viz} />
+                  </Grid>
+                  <Grid item style={{ background: theme.palette.background.paper }}>
+                    <Properties sn={sn} viz={viz} />
+                  </Grid>
                 </Grid>
               </Grid>
             </Grid>
-          </Grid>
-        </NebulaContext.Provider>
+          </NebulaContext.Provider>
+        </DirectionContext.Provider>
       </ThemeProvider>
     </AppContext.Provider>
   );

--- a/commands/serve/web/contexts/DirectionContext.js
+++ b/commands/serve/web/contexts/DirectionContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const DirectionContext = React.createContext();
+
+export default DirectionContext;


### PR DESCRIPTION
## Motivation

Add `direction` to api so we can handle it for example in the listbox popover

![image](https://user-images.githubusercontent.com/682243/65150796-1f94c780-da25-11e9-8dfe-ddd6f6e0e306.png)

Notice that the tick is on the left side when using `rtl`
