### PR TITLE
fix(nucleus): wait for curr selections

### DIFF
--- a/apis/nucleus/src/object/get-object.js
+++ b/apis/nucleus/src/object/get-object.js
@@ -1,19 +1,6 @@
 import vizualizationAPI from '../viz';
 import ObjectAPI from './object-api';
-
-export function observe(model, objectAPI) {
-  const onChanged = () =>
-    model.getLayout().then(layout => {
-      objectAPI.setLayout(layout);
-    });
-  model.on('changed', onChanged);
-  model.once('closed', () => {
-    model.removeListener('changed', onChanged);
-    objectAPI.close();
-  });
-
-  onChanged();
-}
+import { observe } from './observer';
 
 export default function initiate(getCfg, optional, context) {
   return context.app.getObject(getCfg.id).then(model => {
@@ -24,7 +11,7 @@ export default function initiate(getCfg, optional, context) {
 
     const objectAPI = new ObjectAPI(model, context, viz);
 
-    observe(model, objectAPI);
+    observe(model, layout => objectAPI.setLayout(layout)); // TODO - call unobserve when viz is destroyed
 
     const api = objectAPI.getPublicAPI();
 

--- a/apis/nucleus/src/object/observer.js
+++ b/apis/nucleus/src/object/observer.js
@@ -46,15 +46,23 @@ export function observe(model, callback, property = 'layout') {
       affected.forEach(key => {
         c.props[key].state = STATES.VALIDATING;
         const method = OBSERVABLE[key].filter(m => model[m])[0];
-        model[method]().then(value => {
-          if (cache[model.id] && cache[model.id].props[key]) {
-            if (cache[model.id].props[key].state < STATES.CLOSED && cache[model.id].props[key].state !== STATES.VALID) {
-              cache[model.id].props[key].state = STATES.VALID;
-              cache[model.id].props[key].value = value;
-              cache[model.id].props[key].callbacks.forEach(cb => cb(value));
+        model[method]()
+          .then(value => {
+            if (cache[model.id] && cache[model.id].props[key]) {
+              if (
+                cache[model.id].props[key].state < STATES.CLOSED &&
+                cache[model.id].props[key].state !== STATES.VALID
+              ) {
+                cache[model.id].props[key].state = STATES.VALID;
+                cache[model.id].props[key].value = value;
+                cache[model.id].props[key].callbacks.forEach(cb => cb(value));
+              }
             }
-          }
-        });
+          })
+          .catch(() => {
+            // TODO - retry?
+            cache[model.id].props[key].state = STATES.INVALID;
+          });
       });
     };
 

--- a/apis/nucleus/src/selections/object-selections.js
+++ b/apis/nucleus/src/selections/object-selections.js
@@ -55,16 +55,18 @@ export default function(model, app) {
       return appAPI().switchModal(null, null, false, false);
     },
     select(s) {
-      this.begin([s.params[0]]);
+      const b = this.begin([s.params[0]]);
       if (!appAPI().isModal()) {
         return;
       }
       hasSelected = true;
-      model[s.method](...s.params).then(qSuccess => {
-        if (!qSuccess) {
-          this.clear();
-        }
-      });
+      b.then(() =>
+        model[s.method](...s.params).then(qSuccess => {
+          if (!qSuccess) {
+            this.clear();
+          }
+        })
+      );
     },
     canClear() {
       return hasSelected && layout.qSelectionInfo.qMadeSelections;

--- a/commands/create/templates/none/_package.json
+++ b/commands/create/templates/none/_package.json
@@ -18,7 +18,7 @@
     "build": "nebula build",
     "lint": "eslint src",
     "start": "nebula serve",
-    "test:integration": "aw puppet --testExt '*.int.js' --glob 'test/integration/**/*.int.js' --chrome.headless true --mocha.timeout 15000"
+    "test:integration": "aw puppet --testExt '*.int.js' --glob 'test/integration/**/*.int.js'"
   },
   "devDependencies": {
     "@after-work.js/aw": "^6.0.3",

--- a/commands/create/templates/none/test/integration/setup.int.js
+++ b/commands/create/templates/none/test/integration/setup.int.js
@@ -2,7 +2,8 @@ const serve = require('@nebula.js/cli-serve'); // eslint-disable-line
 
 let s;
 
-before(async () => {
+before(async function setup() {
+  this.timeout(15000);
   s = await serve({
     open: false,
   });

--- a/commands/create/templates/picasso/barchart/test/integration/interaction.int.js
+++ b/commands/create/templates/picasso/barchart/test/integration/interaction.int.js
@@ -9,7 +9,11 @@ describe('interaction', () => {
 
     await page.click('rect[data-label="K"]');
     await page.click('rect[data-label="S"]');
+
+    await page.waitForSelector('button[title="Confirm selection"]');
     await page.click('button[title="Confirm selection"]');
+
+    await page.waitFor(100); // wait a bit to make sure websocket traffic has gone through
 
     const rects = await page.$$eval('rect[data-label]', sel => sel.map(r => r.getAttribute('data-label')));
     expect(rects).to.eql(['K', 'S']);

--- a/commands/create/templates/picasso/common/_package.json
+++ b/commands/create/templates/picasso/common/_package.json
@@ -18,7 +18,7 @@
     "build": "nebula build",
     "lint": "eslint src",
     "start": "nebula serve",
-    "test:integration": "aw puppet --testExt '*.int.js' --glob 'test/integration/**/*.int.js' --chrome.headless true --chrome.slowMo 10"
+    "test:integration": "aw puppet --testExt '*.int.js' --glob 'test/integration/**/*.int.js'"
   },
   "devDependencies": {
     "@after-work.js/aw": "^6.0.3",

--- a/commands/create/templates/picasso/common/test/integration/setup.int.js
+++ b/commands/create/templates/picasso/common/test/integration/setup.int.js
@@ -2,7 +2,8 @@ const serve = require('@nebula.js/cli-serve'); // eslint-disable-line
 
 let s;
 
-before(async () => {
+before(async function setup() {
+  this.timeout(15000); // to allow time for the server to start
   s = await serve({
     build: false,
   });


### PR DESCRIPTION
Making selections in the app before the creation of the `current-selections` object is complete will cause that object to be aborted. This fixes that by waiting for the creation to be completed before making any selections.

Before:
![interrupted](https://user-images.githubusercontent.com/16324367/65702592-919f8900-e083-11e9-9d61-c0966c4df191.png)

After:
![fixed](https://user-images.githubusercontent.com/16324367/65702636-a5e38600-e083-11e9-8f98-7f0694472677.png)
