### PR TITLE
feat(cli-serve): render existing objects

### DIFF
--- a/commands/serve/web/components/Cell.jsx
+++ b/commands/serve/web/components/Cell.jsx
@@ -1,27 +1,62 @@
-import React from 'react';
+import React, {
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+} from 'react';
 
 import {
+  Button,
   Grid,
   Card,
+  Toolbar,
+  Divider,
 } from '@nebula.js/ui/components';
+
+import PropsDialog from './PropertiesDialog';
+
+import AppContext from '../contexts/AppContext';
 
 import Chart from './Chart';
 
 export default function ({
-  object,
+  id,
   onSelected,
 }) {
+  const app = useContext(AppContext);
+  const [model, setModel] = useState(null);
+  useEffect(() => {
+    const v = app.getObject(id).then((m) => {
+      setModel(m);
+      return m;
+    });
+
+    return () => {
+      v.then((m) => m.emit('close'));
+    };
+  }, [id]);
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const closeDialog = useCallback(() => { setDialogOpen(false); }, []);
+
   return (
-    <Card style={{ minHeight: 400, position: 'relative', overflow: 'visible' }}>
-      <Grid
-        container
-        style={{
-          position: 'absolute',
-          height: '100%',
-        }}
-      >
-        <Grid item xs={12}>
-          <Chart id={object.qInfo.qId} onSelected={onSelected} />
+    <Card style={{ minHeight: 600, height: '100%' }}>
+      <Grid container direction="column" style={{ height: '100%', position: 'relative' }}>
+        <Grid item>
+          <Toolbar variant="dense">
+            <Button
+              variant="outlined"
+              disabled={!model}
+              onClick={() => setDialogOpen(true)}
+            >
+              Props
+            </Button>
+            <PropsDialog model={model} show={dialogOpen} close={closeDialog} />
+          </Toolbar>
+          <Divider />
+        </Grid>
+        <Grid item xs>
+          <Chart id={id} onSelected={onSelected} />
         </Grid>
       </Grid>
     </Card>

--- a/commands/serve/web/components/Chart.jsx
+++ b/commands/serve/web/components/Chart.jsx
@@ -13,7 +13,6 @@ export default function Chart({
 }) {
   const nebbie = useContext(NebulaContext);
   const el = useRef();
-  // const [viz, setViz] = useState(null);
   useEffect(() => {
     const n = nebbie.get({
       id,
@@ -23,7 +22,6 @@ export default function Chart({
       },
       element: el.current,
     });
-    // n.then(setViz);
     return () => {
       n.then((v) => {
         v.close();

--- a/commands/serve/web/components/Collection.jsx
+++ b/commands/serve/web/components/Collection.jsx
@@ -14,8 +14,9 @@ import AppContext from '../contexts/AppContext';
 import Cell from './Cell';
 
 export default function Collection({
-  type,
+  types,
   onSelectedCell,
+  cache,
 }) {
   const app = useContext(AppContext);
   const [layout] = useLayout(app);
@@ -23,21 +24,21 @@ export default function Collection({
 
   useEffect(() => {
     app.getObjects({
-      qTypes: [type],
-      qIncludeSessionObjects: true,
+      qTypes: types,
+      // qIncludeSessionObjects: true,
       qData: {
         title: '/qMetaDef/title',
       },
     }).then((list) => {
-      setObjects(list);
+      setObjects(list.slice(0, 20)); // don't show too many to avoid slow UI
     });
-  }, [layout, type]);
+  }, [layout, types.join(':')]);
 
   return (
     <Grid container spacing={2} style={{ padding: '12px' }}>
       {objects.map((c) => (
-        <Grid item xs={12} md={6} lg={4} key={c.qInfo.qId}>
-          <Cell object={c} onSelected={onSelectedCell} />
+        <Grid item xs={12} md={6} lg={4} key={`${c.qInfo.qId}::${cache}`}>
+          <Cell id={c.qInfo.qId} onSelected={onSelectedCell} />
         </Grid>
       ))}
     </Grid>


### PR DESCRIPTION
## Motivation

Rendering only one object has the limitation of only seeing a chart in its current temporary state and potentially missing out on a lot of different cases.
By rendering multiple objects of a certain type at the same time, it will hopefully make it easier to see how the charts behaves in various states:

![collection](https://user-images.githubusercontent.com/16324367/65705746-53a56380-e089-11e9-947b-f261a09d6563.png)


