### PR TITLE
feat(supernova): attach model when calling onChange

### DIFF
--- a/apis/supernova/__tests__/unit/creator.spec.js
+++ b/apis/supernova/__tests__/unit/creator.spec.js
@@ -55,4 +55,51 @@ describe('creator', () => {
     });
     expect(c.custom).to.be.undefined;
   });
+
+  it('should call onChange on setProperties and applyPatches', async () => {
+    const generator = {
+      component: {},
+      definition: {},
+      qae: {
+        properties: {
+          onChange: sinon.spy(),
+        },
+      },
+    };
+    const env = {};
+    const properties = { dummyPatched: false };
+    const params = {
+      model: {
+        setProperties: () => Promise.resolve(),
+        applyPatches: () => Promise.resolve(),
+        getEffectiveProperties: () => Promise.resolve(properties),
+      },
+      app: {},
+    };
+
+    create(generator, params, env).component;
+
+    await params.model.setProperties(properties);
+
+    expect(
+      generator.qae.properties.onChange.thisValues[0],
+      'incorrect params in this context after setProperties call'
+    ).to.eql({ model: params.model });
+
+    expect(
+      generator.qae.properties.onChange,
+      'incorrect input params after setProperties call'
+    ).to.have.been.calledWith(properties);
+
+    await params.model.applyPatches([{ qOp: 'replace', qValue: true, qPath: 'dummyPatched' }], true);
+
+    expect(
+      generator.qae.properties.onChange.thisValues[0],
+      'incorrect params in this context after applyPatches call'
+    ).to.eql({ model: params.model });
+
+    expect(generator.qae.properties.onChange, 'incorrect input params after applyPatches call').to.have.been.calledWith(
+      { dummyPatched: true }
+    );
+  });
 });

--- a/apis/supernova/src/creator.js
+++ b/apis/supernova/src/creator.js
@@ -92,7 +92,7 @@ export default function create(generator, opts) {
     };
 
     opts.model.setProperties = function setProperties(...args) {
-      generator.qae.properties.onChange.call(null, ...args);
+      generator.qae.properties.onChange.call({ model: opts.model }, ...args);
       return opts.model.__snInterceptor.setProperties.call(this, ...args);
     };
 
@@ -104,7 +104,7 @@ export default function create(generator, opts) {
         const patches = qPatches.map(p => ({ op: p.qOp, value: JSON.parse(p.qValue), path: p.qPath }));
         JSONPatch.apply(currentProperties, patches);
 
-        generator.qae.properties.onChange.call({}, currentProperties);
+        generator.qae.properties.onChange.call({ model: opts.model }, currentProperties);
 
         // calculate new patches from after change
         const newPatches = JSONPatch.generate(original, currentProperties).map(p => ({


### PR DESCRIPTION
When calling `onChange` function on `setProperties` or `applyPatches`, it's useful to have the model available (needed for expression modifiers).

This PR attaches the model to the `this` context of the `onChange` call.
