### PR TITLE
fix: skip scrollToItem in selections mode

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -99,6 +99,10 @@ export default function ListBox({ model, selections, direction }) {
     local.current.validPages = false;
     if (loaderRef.current) {
       loaderRef.current.resetloadMoreItemsCache(true);
+      // Skip scrollToItem if we are in selections
+      if (layout && layout.qSelectionInfo.qInSelections) {
+        return;
+      }
       loaderRef.current._listRef.scrollToItem(0);
     }
   }, [layout]);


### PR DESCRIPTION
## Motivation

For better UX let's skip `scrollToItem` when doing selections in the listbox
