### PR TITLE
feat(cli-serve): generate basic property panel

### DIFF
--- a/commands/serve/web/components/App.jsx
+++ b/commands/serve/web/components/App.jsx
@@ -253,7 +253,7 @@ export default function App({
                     <Grid item xs>
                       {objectListMode ? <Collection cache={currentId} types={[info.supernova.name]} /> : <Stage info={info} storage={storage} uid={currentId} /> }
                     </Grid>
-                    <Grid item style={{ background: theme.palette.background.paper, overflowY: 'auto' }}>
+                    <Grid item style={{ background: theme.palette.background.paper, overflow: 'hidden auto' }}>
                       {activeViz && <Properties sn={sn} viz={activeViz} />}
                     </Grid>
                   </Grid>

--- a/commands/serve/web/components/AutoComponents.jsx
+++ b/commands/serve/web/components/AutoComponents.jsx
@@ -1,0 +1,200 @@
+/* eslint no-param-reassign:0 */
+/* eslint no-use-before-define:0 */
+
+import React, { useState } from 'react';
+
+import {
+  Typography,
+  Grid,
+  Checkbox,
+  FormControlLabel,
+  TextField,
+  ExpansionPanel,
+  ExpansionPanelSummary,
+  ExpansionPanelDetails,
+} from '@nebula.js/ui/components';
+
+import {
+  ExpandMore,
+} from '@nebula.js/ui/icons';
+
+import { makeStyles } from '@nebula.js/ui/theme';
+
+const useStyles = makeStyles((theme) => ({
+  summary: {
+    padding: theme.spacing(0, 1),
+    backgroundColor: theme.palette.background.lighter,
+    borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+  details: {
+    padding: theme.spacing(1),
+  },
+}));
+
+const usePanelStyles = makeStyles((theme) => ({
+  root: {
+    boxShadow: 'none',
+    marginLeft: -theme.spacing(1),
+    marginRight: -theme.spacing(1),
+    '&$expanded': {
+      marginLeft: -theme.spacing(1),
+      marginRight: -theme.spacing(1),
+    },
+  },
+  expanded: {},
+}));
+
+
+const getType = (value) => {
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+  if (typeof value === 'boolean') {
+    return 'boolean';
+  }
+  if (typeof value === 'string') {
+    return 'string';
+  }
+  if (typeof value === 'number') {
+    return 'number';
+  }
+  if (value && typeof value === 'object') {
+    return 'object';
+  }
+  return 'unknown';
+};
+
+const Bool = ({
+  property,
+  value,
+  target,
+  changed,
+}) => {
+  const handleChange = (e) => {
+    target[property] = e.target.checked;
+    changed();
+  };
+  return (
+    <FormControlLabel
+      control={<Checkbox checked={value} onChange={handleChange} />}
+      label={property}
+      labelPlacement="end"
+    />
+  );
+};
+
+const Str = ({
+  property,
+  value,
+  target,
+  changed,
+}) => {
+  const [s, setS] = useState(value);
+  const handleChange = (e) => {
+    setS(e.target.value);
+  };
+  const onBlur = () => {
+    if (s !== value) {
+      target[property] = s;
+      changed();
+    }
+  };
+
+  return (
+    <TextField
+      fullWidth
+      onChange={handleChange}
+      onBlur={onBlur}
+      label={property}
+      value={s}
+    />
+  );
+};
+
+const Num = ({
+  property,
+  value,
+  target,
+  changed,
+}) => {
+  const [s, setS] = useState(+value);
+  const handleChange = (e) => {
+    setS(e.target.value);
+  };
+  const onBlur = () => {
+    if (s !== value) {
+      target[property] = +s;
+      changed();
+    }
+  };
+
+  return (
+    <TextField
+      fullWidth
+      onChange={handleChange}
+      onBlur={onBlur}
+      label={property}
+      value={s}
+    />
+  );
+};
+
+const Obj = ({ property, value, changed }) => {
+  const classes = useStyles();
+  const panelClasses = usePanelStyles();
+  return (
+    <ExpansionPanel square className={[panelClasses.root, panelClasses.expanded].join(' ')}>
+      <ExpansionPanelSummary expandIcon={<ExpandMore />} className={classes.summary}>
+        <Typography>{property}</Typography>
+      </ExpansionPanelSummary>
+      <ExpansionPanelDetails className={classes.details}>
+        {generateComponents(value, changed)}
+      </ExpansionPanelDetails>
+    </ExpansionPanel>
+  );
+};
+
+const registeredComponents = {
+  boolean: Bool,
+  string: Str,
+  object: Obj,
+  number: Num,
+};
+
+const QRX = /^q[A-Z]/;
+
+function generateComponents(properties, changed) {
+  const components = Object.keys(properties).map((key) => {
+    if (['visualization', 'version'].indexOf(key) !== -1) {
+      return false;
+    }
+    if (QRX.test(key)) { // skip q properties for now
+      return false;
+    }
+    const type = getType(properties[key]);
+    if (!registeredComponents[type]) {
+      return false;
+    }
+    return {
+      Component: registeredComponents[type],
+      property: key,
+      target: properties,
+      value: properties[key],
+      key,
+    };
+  }).filter(Boolean);
+
+  return (
+    <Grid container direction="column" spacing={0} alignItems="stretch">
+      {components.map((c) => (
+        <Grid item xs key={c.key} style={{ width: '100%' }}>
+          <c.Component key={c.key} property={c.property} value={c.value} target={properties} changed={changed} />
+        </Grid>
+      ))}
+    </Grid>
+  );
+}
+
+export {
+  generateComponents as default,
+};

--- a/commands/serve/web/components/Properties.jsx
+++ b/commands/serve/web/components/Properties.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import {
   Typography,
@@ -7,12 +7,17 @@ import {
 import useProperties from '@nebula.js/nucleus/src/hooks/useProperties';
 
 import Data from './property-panel/Data';
+import generateComponents from './AutoComponents';
 
 export default function Properties({
   viz,
   sn,
 }) {
   const [properties] = useProperties(viz ? viz.model : null);
+
+  const changed = useCallback(() => {
+    viz.model.setProperties(properties);
+  }, [viz, sn, properties]);
 
   if (!sn) {
     return null;
@@ -37,6 +42,7 @@ export default function Properties({
     }}
     >
       <Data properties={properties} model={viz.model} sn={sn} />
+      {generateComponents(properties, changed)}
     </div>
   );
 }

--- a/packages/ui/components/index.js
+++ b/packages/ui/components/index.js
@@ -1,6 +1,7 @@
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import ButtonBase from '@material-ui/core/ButtonBase';
+import Checkbox from '@material-ui/core/Checkbox';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import IconButton from '@material-ui/core/IconButton';
 import Grid from '@material-ui/core/Grid';
@@ -8,6 +9,9 @@ import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import Typography from '@material-ui/core/Typography';
 import Popover from '@material-ui/core/Popover';
+import ExpansionPanel from '@material-ui/core/ExpansionPanel';
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 import Toolbar from '@material-ui/core/Toolbar';
@@ -43,7 +47,11 @@ export {
   Box,
   Button,
   ButtonBase,
+  Checkbox,
   CircularProgress,
+  ExpansionPanel,
+  ExpansionPanelSummary,
+  ExpansionPanelDetails,
   IconButton,
   Grid,
   Card,

--- a/packages/ui/icons/index.js
+++ b/packages/ui/icons/index.js
@@ -2,5 +2,6 @@ import ChevronRight from '@material-ui/icons/ChevronRight';
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
 import Brightness3 from '@material-ui/icons/Brightness3';
 import WbSunny from '@material-ui/icons/WbSunny';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 
-export { ChevronRight, ChevronLeft, Brightness3, WbSunny };
+export { ChevronRight, ChevronLeft, Brightness3, WbSunny, ExpandMore };

--- a/packages/ui/theme/definitions/defaults.js
+++ b/packages/ui/theme/definitions/defaults.js
@@ -60,5 +60,10 @@ export default {
         borderRadius: 2,
       },
     },
+    MuiExpansionPanelSummary: {
+      content: {
+        margin: '8px 0',
+      },
+    },
   },
 };


### PR DESCRIPTION
Generate a basic UI for object properties, it's fairly simple and limited at the moment, but it does make it easier to quickly modify property values.

![pp](https://user-images.githubusercontent.com/16324367/66555836-94a07c00-eb4f-11e9-8bd8-7cade9ed1c40.gif)

relates to #34 