### PR TITLE
chore(cli-serve): preload regenerator-runtime

### DIFF
--- a/commands/serve/lib/sn.js
+++ b/commands/serve/lib/sn.js
@@ -1,3 +1,8 @@
+// Polyfill for using async/await
+// the polyfill is injected here to make sure it exists
+// before the snDefinition is loaded
+import 'regenerator-runtime';
+
 import def from 'snDefinition'; // eslint-disable-line
 
 window.snDefinition = def;

--- a/commands/serve/package.json
+++ b/commands/serve/package.json
@@ -33,6 +33,7 @@
     "html-webpack-plugin": "^3.2.0",
     "portfinder": "^1.0.24",
     "puppeteer": "^1.20.0",
+    "regenerator-runtime": "^0.13.3",
     "source-map-loader": "^0.2.4",
     "webpack": "^4.41.1",
     "webpack-dev-server": "^3.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10483,6 +10483,11 @@ regenerator-runtime@^0.13.2:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
 
+regenerator-runtime@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
 regenerator-transform@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.0.tgz#2ca9aaf7a2c239dd32e4761218425b8c7a86ecaf"


### PR DESCRIPTION
Preload `regenerator-runtime` to make sure it exists in serve environment before `snDefinition` is loaded
