### PR TITLE
feat(cli-serve): serve custom themes

### DIFF
--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { Grid } from '@nebula.js/ui/components';
+import { Grid, Paper } from '@nebula.js/ui/components';
 import { useTheme } from '@nebula.js/ui/theme';
 
 import Requirements from './Requirements';
@@ -62,33 +62,30 @@ export default function Cell({ api, onInitial }) {
   const Comp = !objectProps.sn ? Placeholder : SN;
   const err = objectProps.error || false;
   return (
-    <Grid
-      container
-      direction="column"
-      spacing={0}
-      style={{ height: '100%', padding: '8px', boxSixing: 'border-box', background: theme.palette.background.paper }}
-    >
-      <Grid item style={{ maxWidth: '100%' }}>
-        <Header layout={objectProps.layout} sn={objectProps.sn}>
-          &nbsp;
-        </Header>
+    <Paper style={{ height: '100%', position: 'relative' }} elevation={0} square>
+      <Grid container direction="column" spacing={0} style={{ height: '100%', padding: theme.spacing(1) }}>
+        <Grid item style={{ maxWidth: '100%' }}>
+          <Header layout={objectProps.layout} sn={objectProps.sn}>
+            &nbsp;
+          </Header>
+        </Grid>
+        <Grid item xs>
+          <Content>
+            {err ? (
+              <CError message={err.message} />
+            ) : (
+              <Comp
+                key={objectProps.layout.visualization}
+                sn={objectProps.sn}
+                snContext={userProps.context}
+                snOptions={userProps.options}
+                layout={objectProps.layout}
+              />
+            )}
+          </Content>
+        </Grid>
+        <Footer layout={objectProps.layout} />
       </Grid>
-      <Grid item xs>
-        <Content>
-          {err ? (
-            <CError message={err.message} />
-          ) : (
-            <Comp
-              key={objectProps.layout.visualization}
-              sn={objectProps.sn}
-              snContext={userProps.context}
-              snOptions={userProps.options}
-              layout={objectProps.layout}
-            />
-          )}
-        </Content>
-      </Grid>
-      <Footer layout={objectProps.layout} />
-    </Grid>
+    </Paper>
   );
 }

--- a/commands/serve/command.js
+++ b/commands/serve/command.js
@@ -1,43 +1,11 @@
 const serve = require('./lib/serve');
+const init = require('./init-config');
 
 module.exports = {
   command: 'serve',
   desc: 'Dev server',
   builder(yargs) {
-    yargs
-      .option('entry', {
-        type: 'string',
-        description: 'File entrypoint',
-      })
-      .option('type', {
-        type: 'string',
-        description: 'Generic object type',
-      })
-      .option('build', {
-        type: 'boolean',
-        default: true,
-      })
-      .option('host', {
-        type: 'string',
-      })
-      .option('port', {
-        type: 'number',
-      })
-      .option('enigma.host', {
-        type: 'string',
-      })
-      .option('enigma.port', {
-        type: 'port',
-        default: 9076,
-      })
-      .option('webIntegrationId', {
-        type: 'string',
-      })
-      .option('ACCEPT_EULA', {
-        type: 'boolean',
-        alias: 'a',
-        default: false,
-      }).argv;
+    init(yargs).argv;
   },
   handler(argv) {
     serve(argv);

--- a/commands/serve/init-config.js
+++ b/commands/serve/init-config.js
@@ -1,0 +1,64 @@
+/* eslint global-require: 0 */
+
+const fs = require('fs');
+
+const defaultFilename = 'nebula.config.js';
+const RX = new RegExp(`${defaultFilename.replace(/\./g, '\\.')}$`);
+
+const options = {
+  config: {
+    type: 'string',
+    description: 'Path to config file',
+    default: defaultFilename,
+    alias: 'c',
+  },
+  entry: {
+    type: 'string',
+    description: 'File entrypoint',
+  },
+  type: {
+    type: 'string',
+    description: 'Generic object type',
+  },
+  build: {
+    type: 'boolean',
+    default: true,
+  },
+  host: {
+    type: 'string',
+    default: 'localhost',
+  },
+  port: {
+    type: 'number',
+  },
+  'enigma.host': {
+    type: 'string',
+    default: 'localhost',
+  },
+  'enigma.port': {
+    type: 'number',
+    default: 9076,
+  },
+  webIntegrationId: {
+    type: 'string',
+  },
+  ACCEPT_EULA: {
+    type: 'boolean',
+    default: false,
+  },
+};
+
+module.exports = yargs =>
+  yargs.options(options).config('config', configPath => {
+    if (configPath === null) {
+      return {};
+    }
+    if (!fs.existsSync(configPath)) {
+      if (RX.test(configPath)) {
+        // do nothing if default filename doesn't exist
+        return {};
+      }
+      throw new Error(`Config ${configPath} not found`);
+    }
+    return require(configPath).serve;
+  });

--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -17,6 +17,7 @@ module.exports = async ({
   dev = false,
   open = true,
   watcher,
+  serveConfig,
 }) => {
   let config;
   let contentBase;
@@ -25,6 +26,8 @@ module.exports = async ({
     host,
     port,
   });
+
+  const themes = serveConfig.themes || [];
 
   if (dev) {
     const webpackConfig = require('./webpack.build.js');
@@ -65,6 +68,20 @@ module.exports = async ({
     before(app) {
       snapper.addRoutes(app);
 
+      app.get('/themes', (req, res) => {
+        const arr = themes.map(theme => theme.key);
+        res.json(arr);
+      });
+
+      app.get('/theme/:id', (req, res) => {
+        const t = themes.filter(theme => theme.key === req.params.id)[0];
+        if (!t) {
+          res.sendStatus('404');
+        } else {
+          res.json(t.theme);
+        }
+      });
+
       app.get('/info', (req, res) => {
         res.json({
           enigma: enigmaConfig,
@@ -72,6 +89,7 @@ module.exports = async ({
           supernova: {
             name: snName,
           },
+          themes: themes.map(theme => theme.key),
         });
       });
     },

--- a/commands/serve/package.json
+++ b/commands/serve/package.json
@@ -30,6 +30,7 @@
     "body-parser": "^1.19.0",
     "chalk": "^2.4.2",
     "cross-env": "^6.0.3",
+    "extend": "^3.0.2",
     "html-webpack-plugin": "^3.2.0",
     "portfinder": "^1.0.25",
     "puppeteer": "^1.20.0",

--- a/commands/serve/web/eRender.html
+++ b/commands/serve/web/eRender.html
@@ -29,7 +29,6 @@
       bottom: 8px;
       right: 8px;
       top: 64px;
-      background: #fff;
     }
 
     #chart-container.full {

--- a/commands/serve/web/eRender.js
+++ b/commands/serve/web/eRender.js
@@ -17,6 +17,10 @@ function renderWithEngine() {
     let objType;
 
     const nebbie = nucleus.configured({
+      themes: info.themes ? info.themes.map((t) => ({
+        key: t,
+        load: () => fetch(`/theme/${t}`).then((response) => response.json()),
+      })) : undefined,
       theme: params.theme,
       types: [{
         name: info.supernova.name,
@@ -100,6 +104,10 @@ function renderSnapshot() {
       };
 
       const nebbie = nucleus.configured({
+        themes: info.themes ? info.themes.map((t) => ({
+          key: t,
+          load: () => fetch(`/theme/${t}`).then((response) => response.json()),
+        })) : undefined,
         theme: snapshot.meta.theme,
         types: [{
           name: info.supernova.name,

--- a/nebula.config.js
+++ b/nebula.config.js
@@ -1,18 +1,7 @@
 const config = {
-  serve: {
-    host: '',
-    port: '',
-    enigma: {
-      schema: '',
-      host: '',
-      port: 9076,
-      secure: false,
-      authenticate: {
-        jwt: {},
-        cert: {},
-      },
-    },
-  },
+  build: {},
+  create: {},
+  serve: {},
 };
 
 module.exports = config;

--- a/packages/ui/components/index.js
+++ b/packages/ui/components/index.js
@@ -43,6 +43,7 @@ import Switch from '@material-ui/core/Switch';
 
 import TextField from '@material-ui/core/TextField';
 import AppBar from '@material-ui/core/AppBar';
+import Paper from '@material-ui/core/Paper';
 import { makeStyles } from '@material-ui/styles';
 
 export {
@@ -89,4 +90,5 @@ export {
   AppBar,
   Tab,
   Tabs,
+  Paper,
 };

--- a/packages/ui/icons/index.js
+++ b/packages/ui/icons/index.js
@@ -3,5 +3,6 @@ import ChevronLeft from '@material-ui/icons/ChevronLeft';
 import Brightness3 from '@material-ui/icons/Brightness3';
 import WbSunny from '@material-ui/icons/WbSunny';
 import ExpandMore from '@material-ui/icons/ExpandMore';
+import ColorLens from '@material-ui/icons/ColorLens';
 
-export { ChevronRight, ChevronLeft, Brightness3, WbSunny, ExpandMore };
+export { ChevronRight, ChevronLeft, Brightness3, WbSunny, ExpandMore, ColorLens };


### PR DESCRIPTION
Provide custom themes to the dev-server through a `nebula.config.js` file: 

```js
//nebula.config.js
module.exports = {
  serve: {
    themes: [ // provide custom themes to the dev-server
      {
        key: "pinkish",
        theme: {
          color: "deeppink",
          type: "dark",
          fontFamily: "Georgia"
        }
      }
    ]
  }
};
```

The custom themes will then be available from a menu in the dev-server:

![themes](https://user-images.githubusercontent.com/16324367/67300617-8870d300-f4ee-11e9-89cd-7ead04efee22.gif)

closes #142 
