### PR TITLE
feat(cli-serve): enable statically served files

### DIFF
--- a/commands/serve/lib/init-config.js
+++ b/commands/serve/lib/init-config.js
@@ -31,6 +31,10 @@ const options = {
   port: {
     type: 'number',
   },
+  assets: {
+    type: 'string',
+    description: 'Path to a folder that will be served as static files under /assets',
+  },
   'enigma.host': {
     type: 'string',
     default: 'localhost',

--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -1,6 +1,7 @@
 /* eslint global-require: 0 */
 const path = require('path');
 const chalk = require('chalk');
+const express = require('express');
 
 const webpack = require('webpack');
 const WebpackDevServer = require('webpack-dev-server');
@@ -25,6 +26,7 @@ module.exports = async ({
   const snapper = snapshotter({
     host,
     port,
+    images: serveConfig.images || [],
   });
 
   const themes = serveConfig.themes || [];
@@ -92,6 +94,10 @@ module.exports = async ({
           themes: themes.map(theme => theme.key),
         });
       });
+
+      if (serveConfig.assets) {
+        app.use('/assets', express.static(serveConfig.assets));
+      }
     },
     proxy: [
       {

--- a/commands/serve/package.json
+++ b/commands/serve/package.json
@@ -30,6 +30,7 @@
     "body-parser": "^1.19.0",
     "chalk": "^2.4.2",
     "cross-env": "^6.0.3",
+    "express": "^4.17.1",
     "extend": "^3.0.2",
     "html-webpack-plugin": "^3.2.0",
     "portfinder": "^1.0.25",


### PR DESCRIPTION
## Motivation

Enable static files to be served from '/assets' and makes it possible to e.g. serve local images.
