### PR TITLE
fix: keep modal state

### DIFF
--- a/apis/nucleus/src/components/selections/SelectedFields.jsx
+++ b/apis/nucleus/src/components/selections/SelectedFields.jsx
@@ -47,7 +47,7 @@ export default function SelectedFields({ api }) {
       setState(currState => {
         const newItems = getItems(api.layout());
         // Maintain modal state in app selections
-        if (api.isInModal() && newItems.length !== currState.items.length) {
+        if (api.isInModal() && newItems.length + 1 === currState.items.length) {
           const lastDeselectedField = currState.items.filter(
             f1 => newItems.some(f2 => f1.name === f2.name) === false
           )[0];

--- a/apis/nucleus/src/components/selections/__tests__/selected-fields.spec.jsx
+++ b/apis/nucleus/src/components/selections/__tests__/selected-fields.spec.jsx
@@ -169,4 +169,40 @@ describe('<SelectedFields />', () => {
     expect(types[1].props.field.name).to.equal('my-field1');
     expect(types[2].props.field.name).to.equal('my-field2');
   });
+  it('should not run keep item in modal state when doing new selection', () => {
+    const data = {
+      qSelectionObject: {
+        qSelections: [],
+      },
+    };
+    const newData = {
+      qSelectionObject: {
+        qSelections: [
+          {
+            qField: 'my-field0',
+          },
+        ],
+      },
+    };
+    const on = sinon.stub();
+    const removeListener = sinon.spy();
+    const isInModal = sinon.stub();
+    const api = {
+      layout: sinon.stub(),
+      on,
+      removeListener,
+      isInModal,
+    };
+    api.layout.onFirstCall().returns(data);
+    api.layout.onSecondCall().returns(data);
+    api.layout.onThirdCall().returns(newData);
+    const testRenderer = renderer.create(<SelectedFields api={api} />);
+    testRenderer.update(<SelectedFields api={api} />);
+    const testInstance = testRenderer.root;
+    isInModal.returns(true);
+    on.firstCall.callArg(1);
+    const types = testInstance.findAllByType(MockedOneField);
+    expect(types).to.have.length(1);
+    expect(types[0].props.field.name).to.equal('my-field0');
+  });
 });


### PR DESCRIPTION
We should only keep modal state in app selections when a selected field is removed by deselecting last value.