### PR TITLE
feat(cli-build): support config

### DIFF
--- a/commands/build/command.js
+++ b/commands/build/command.js
@@ -1,14 +1,12 @@
-const { build } = require('./build');
+const build = require('./lib/build');
+
+const init = require('./lib/init-config');
 
 module.exports = {
   command: 'build',
   desc: 'Build supernova',
   builder(yargs) {
-    yargs.option('watch', {
-      type: 'boolean',
-      alias: 'w',
-      default: false,
-    });
+    init(yargs).argv;
   },
   handler(argv) {
     build(argv);

--- a/commands/build/lib/init-config.js
+++ b/commands/build/lib/init-config.js
@@ -1,0 +1,35 @@
+/* eslint global-require: 0 */
+const fs = require('fs');
+
+const defaultFilename = 'nebula.config.js';
+const RX = new RegExp(`${defaultFilename.replace(/\./g, '\\.')}$`);
+
+const options = {
+  config: {
+    type: 'string',
+    description: 'Path to config file',
+    default: defaultFilename,
+    alias: 'c',
+  },
+  watch: {
+    description: 'Watch source files',
+    type: 'boolean',
+    alias: 'w',
+    default: false,
+  },
+};
+
+module.exports = yargs =>
+  yargs.options(options).config('config', configPath => {
+    if (configPath === null) {
+      return {};
+    }
+    if (!fs.existsSync(configPath)) {
+      if (RX.test(configPath)) {
+        // do nothing if default filename doesn't exist
+        return {};
+      }
+      throw new Error(`Config ${configPath} not found`);
+    }
+    return require(configPath).build;
+  });

--- a/commands/build/package.json
+++ b/commands/build/package.json
@@ -12,8 +12,9 @@
     "type": "git",
     "url": "https://github.com/qlik-oss/nebula.js.git"
   },
-  "main": "build.js",
+  "main": "lib/build.js",
   "files": [
+    "lib",
     "command.js"
   ],
   "scripts": {
@@ -24,8 +25,10 @@
     "@babel/core": "7.6.4",
     "@babel/preset-env": "7.6.3",
     "chalk": "2.4.2",
+    "extend": "^3.0.2",
     "rollup": "1.26.0",
     "rollup-plugin-babel": "4.3.3",
+    "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-postcss": "2.0.3",
     "rollup-plugin-replace": "2.2.0",

--- a/commands/serve/lib/serve.js
+++ b/commands/serve/lib/serve.js
@@ -4,7 +4,7 @@ const chalk = require('chalk');
 const portfinder = require('portfinder');
 const extend = require('extend');
 const yargs = require('yargs');
-const { watch } = require('@nebula.js/cli-build');
+const build = require('@nebula.js/cli-build');
 
 const initConfig = require('./init-config');
 
@@ -16,7 +16,7 @@ module.exports = async argv => {
   let defaultServeConfig = {};
 
   if (!argv.$0) {
-    defaultServeConfig = initConfig(yargs).parse([]);
+    defaultServeConfig = initConfig(yargs([])).argv;
   }
 
   const serveConfig = extend(true, {}, defaultServeConfig, argv);
@@ -38,7 +38,10 @@ module.exports = async argv => {
     snName = parsed.name;
   } else {
     if (serveConfig.build !== false) {
-      watcher = await watch();
+      watcher = await build({
+        watch: true,
+        config: serveConfig.config,
+      });
     }
     try {
       const externalPkg = require(path.resolve(context, 'package.json')); // eslint-disable-line global-require

--- a/test/integration/setup.int.js
+++ b/test/integration/setup.int.js
@@ -1,4 +1,3 @@
-// const build = require('../__serve__/build');
 const path = require('path');
 const serve = require('@nebula.js/cli-serve'); // eslint-disable-line
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5545,7 +5545,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@3.0.2, extend@^3.0.1, extend@~3.0.2:
+extend@3.0.2, extend@^3.0.1, extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
@@ -10699,7 +10699,7 @@ rollup-plugin-babel@4.3.3:
     "@babel/helper-module-imports" "^7.0.0"
     rollup-pluginutils "^2.8.1"
 
-rollup-plugin-commonjs@10.1.0:
+rollup-plugin-commonjs@10.1.0, rollup-plugin-commonjs@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz#417af3b54503878e084d127adf4d1caf8beb86fb"
   integrity sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==


### PR DESCRIPTION
- Inject default options for build config
- Remove `resolveOptions` from rollup-plugin-node-resolve to allow the default node-resolve algorithm to do its magic
- Add rollup-plugin-commonjs to enable resolution of cjs modules
