### PR TITLE
feat(cli-serve): add option to inject script and stylesheet

### DIFF
--- a/commands/serve/lib/head-injector.js
+++ b/commands/serve/lib/head-injector.js
@@ -1,0 +1,33 @@
+class Inject {
+  constructor(options = {}) {
+    this.options = options;
+    this.stylesheets = options.stylesheets || [];
+    this.scripts = options.scripts || [];
+  }
+
+  apply(compiler) {
+    if (!this.scripts.length || !this.stylesheets.length) {
+      return;
+    }
+    compiler.hooks.compilation.tap('Inject', compilation => {
+      compilation.hooks.htmlWebpackPluginAlterAssetTags.tap('Inject', htmlPluginData => {
+        this.scripts.forEach(s => {
+          htmlPluginData.head.unshift({
+            tagName: 'script',
+            closeTag: true,
+            attributes: { type: 'text/javascript', src: s },
+          });
+        });
+        this.stylesheets.forEach(s => {
+          htmlPluginData.head.unshift({
+            tagName: 'link',
+            closeTag: true,
+            attributes: { rel: 'stylesheet', type: 'text/css', href: s },
+          });
+        });
+      });
+    });
+  }
+}
+
+module.exports = Inject;

--- a/commands/serve/lib/init-config.js
+++ b/commands/serve/lib/init-config.js
@@ -35,6 +35,14 @@ const options = {
     type: 'string',
     description: 'Path to a folder that will be served as static files under /assets',
   },
+  scripts: {
+    type: 'array',
+    description: 'Array of scripts to inject',
+  },
+  stylesheets: {
+    type: 'array',
+    description: 'Array of stylesheets to inject',
+  },
   'enigma.host': {
     type: 'string',
     default: 'localhost',

--- a/commands/serve/lib/webpack.build.js
+++ b/commands/serve/lib/webpack.build.js
@@ -7,9 +7,11 @@ const babelPresetReactPath = require.resolve('@babel/preset-react');
 const sourceMapLoaderPath = require.resolve('source-map-loader');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
+const Inject = require('./head-injector');
+
 const favicon = path.resolve(__dirname, '../../../docs/assets/njs.png');
 
-const cfg = ({ srcDir, distDir, dev = false }) => {
+const cfg = ({ srcDir, distDir, dev = false, serveConfig = {} }) => {
   const config = {
     mode: dev ? 'development' : 'production',
     entry: {
@@ -94,6 +96,7 @@ const cfg = ({ srcDir, distDir, dev = false }) => {
         chunks: ['eHub'],
         favicon,
       }),
+      new Inject(serveConfig),
     ],
   };
 

--- a/commands/serve/lib/webpack.prod.js
+++ b/commands/serve/lib/webpack.prod.js
@@ -1,12 +1,14 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
+const Inject = require('./head-injector');
+
 const isSrc = /^([.]{2}\/)/;
 const namespace = /^webpack:\/\/([^/]+)\//;
 const NM = /node_modules/;
 const WP = /\/\(?webpack\)?/;
 
-const cfg = ({ srcDir = path.resolve(__dirname, '../dist') }) => {
+const cfg = ({ srcDir = path.resolve(__dirname, '../dist'), serveConfig = {} }) => {
   const folderName = process
     .cwd()
     .split('/')
@@ -15,7 +17,7 @@ const cfg = ({ srcDir = path.resolve(__dirname, '../dist') }) => {
   const config = {
     mode: 'development',
     entry: path.resolve(__dirname, './sn.js'),
-    devtool: 'source-map',
+    devtool: false,
     output: {
       path: path.resolve(srcDir, 'temp'),
       filename: '[name].js',
@@ -52,6 +54,7 @@ const cfg = ({ srcDir = path.resolve(__dirname, '../dist') }) => {
         filename: 'eDev.html',
         inject: 'head',
       }),
+      new Inject(serveConfig),
     ],
   };
 

--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -40,6 +40,7 @@ module.exports = async ({
       srcDir,
       distDir,
       dev: true,
+      serveConfig,
     });
   } else {
     const webpackConfig = require('./webpack.prod.js');
@@ -47,6 +48,7 @@ module.exports = async ({
     contentBase = srcDir;
     config = webpackConfig({
       srcDir,
+      serveConfig,
     });
   }
   const options = {


### PR DESCRIPTION
Makes it possible to inject scripts and stylesheets into the head of cli-serve. Useful in case there are external css dependencies like fonts that need to be loaded, or if some script needs to run before the rest of the page.

```sh
nebula serve --assets static --stylesheets /assets/fonts.css --scripts /assets/foo.js
```
