### PR TITLE
fix: update styling for listbox popover

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -6,6 +6,7 @@ import Unlock from '@nebula.js/ui/icons/unlock';
 import { IconButton, Popover, Grid, MenuList } from '@material-ui/core';
 
 import { more } from '@nebula.js/ui/icons/more';
+import { useTheme } from '@nebula.js/ui/theme';
 import useModel from '../../hooks/useModel';
 import useLayout from '../../hooks/useLayout';
 
@@ -21,6 +22,7 @@ import DirectionContext from '../../contexts/DirectionContext';
 import ListBoxSearch from './ListBoxSearch';
 
 export default function ListBoxPopover({ alignTo, show, close, app, fieldName, stateName = '$' }) {
+  const theme = useTheme();
   const [model] = useModel(
     {
       qInfo: {
@@ -102,7 +104,7 @@ export default function ListBoxPopover({ alignTo, show, close, app, fieldName, s
     type: 'icon-button',
     label: translator.get('Selection.Menu'),
     getSvgIconShape: more,
-    enabled: () => true,
+    disabled: isLocked,
     action: () => setShowSelectionsMenu(!showSelectionsMenu),
   };
 
@@ -124,27 +126,26 @@ export default function ListBoxPopover({ alignTo, show, close, app, fieldName, s
       }}
     >
       <Grid container direction="column" spacing={0}>
-        <Grid item>
-          <Grid container direction="row" justify="flex-end">
-            <Grid item>
-              {isLocked ? (
-                <IconButton onClick={unlock}>
-                  <Unlock />
-                </IconButton>
-              ) : (
-                <IconButton onClick={lock}>
-                  <Lock />
-                </IconButton>
-              )}
-            </Grid>
-            <Grid item>
-              <SelectionToolbarWithDefault
-                api={sel}
-                xItems={[moreItem]}
-                onConfirm={popoverClose}
-                onCancel={() => popoverClose(null, 'escapeKeyDown')}
-              />
-            </Grid>
+        <Grid item container style={{ padding: theme.spacing(1) }}>
+          <Grid item>
+            {isLocked ? (
+              <IconButton onClick={unlock}>
+                <Lock />
+              </IconButton>
+            ) : (
+              <IconButton onClick={lock}>
+                <Unlock />
+              </IconButton>
+            )}
+          </Grid>
+          <Grid item xs />
+          <Grid item>
+            <SelectionToolbarWithDefault
+              api={sel}
+              xItems={[moreItem]}
+              onConfirm={popoverClose}
+              onCancel={() => popoverClose(null, 'escapeKeyDown')}
+            />
           </Grid>
         </Grid>
         <Grid item xs>
@@ -160,8 +161,11 @@ export default function ListBoxPopover({ alignTo, show, close, app, fieldName, s
               disablePortal
               hideBackdrop
               style={{ pointerEvents: 'none' }}
+              transitionDuration={0}
+              elevation={0}
               PaperProps={{
                 style: {
+                  boxShadow: '0 12px 8px -8px rgba(0, 0, 0, 0.2)',
                   minWidth: '250px',
                   pointerEvents: 'auto',
                 },

--- a/apis/nucleus/src/components/listbox/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxSearch.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { Grid, TextField } from '@material-ui/core';
+import { InputAdornment, OutlinedInput } from '@material-ui/core';
 import Search from '@nebula.js/ui/icons/search';
 
 import { makeStyles } from '@nebula.js/ui/theme';
@@ -7,14 +7,13 @@ import { makeStyles } from '@nebula.js/ui/theme';
 import LocaleContext from '../../contexts/LocaleContext';
 
 const useStyles = makeStyles(theme => ({
-  gridContainer: {
-    padding: theme.spacing(0, 1, 0, 1),
-  },
-  gridItem: {
-    padding: theme.spacing(0, 1, 0, 1),
+  root: {
+    '& fieldset': {
+      borderRadius: 0,
+      borderColor: `${theme.palette.divider} transparent`,
+    },
   },
 }));
-
 const TREE_PATH = '/qListObjectDef';
 
 export default function ListBoxSearch({ model }) {
@@ -38,23 +37,23 @@ export default function ListBoxSearch({ model }) {
     }
   };
 
-  const { gridContainer, gridItem } = useStyles();
+  const classes = useStyles();
 
   return (
-    <Grid className={gridContainer} item container direction="row" alignItems="center">
-      <Grid item>
-        <Search />
-      </Grid>
-      <Grid className={gridItem} item xs>
-        <TextField
-          fullWidth
-          autoFocus
-          placeholder={translator.get('Listbox.Search')}
-          value={value}
-          onChange={onChange}
-          onKeyDown={onKeyDown}
-        />
-      </Grid>
-    </Grid>
+    <OutlinedInput
+      startAdornment={
+        <InputAdornment position="start">
+          <Search />
+        </InputAdornment>
+      }
+      className={[classes.root].join(' ')}
+      autoFocus
+      margin="dense"
+      fullWidth
+      placeholder={translator.get('Listbox.Search')}
+      value={value}
+      onChange={onChange}
+      onKeyDown={onKeyDown}
+    />
   );
 }

--- a/apis/nucleus/src/components/listbox/__tests__/list-box-search.spec.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box-search.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { TextField } from '@material-ui/core';
+import { OutlinedInput } from '@material-ui/core';
 
 const LocaleContext = React.createContext();
 const [{ default: ListBoxSearch }] = aw.mock(
@@ -24,7 +24,7 @@ describe('<ListBoxSearch />', () => {
       </LocaleContext.Provider>
     );
     const testInstance = testRenderer.root;
-    const types = testInstance.findAllByType(TextField);
+    const types = testInstance.findAllByType(OutlinedInput);
     expect(types).to.have.length(1);
     expect(types[0].props.fullWidth).to.equal(true);
     expect(types[0].props.autoFocus).to.equal(true);
@@ -33,7 +33,7 @@ describe('<ListBoxSearch />', () => {
     expect(types[0].props.onChange).to.be.a('function');
     expect(types[0].props.onKeyDown).to.be.a('function');
   });
-  it('should update `TextField` and search `onChange`', () => {
+  it('should update `OutlinedInput` and search `onChange`', () => {
     const model = {
       searchListObjectFor: sinon.spy(),
       acceptListObjectSearch: sinon.spy(),
@@ -45,7 +45,7 @@ describe('<ListBoxSearch />', () => {
       </LocaleContext.Provider>
     );
     const testInstance = testRenderer.root;
-    let type = testInstance.findByType(TextField);
+    let type = testInstance.findByType(OutlinedInput);
     type.props.onChange({ target: { value: 'foo' } });
     testRenderer.update(
       <LocaleContext.Provider value={{ get: () => 'Search' }}>
@@ -53,10 +53,10 @@ describe('<ListBoxSearch />', () => {
       </LocaleContext.Provider>
     );
     expect(model.searchListObjectFor).to.have.been.calledWith('/qListObjectDef', 'foo');
-    type = testInstance.findByType(TextField);
+    type = testInstance.findByType(OutlinedInput);
     expect(type.props.value).to.equal('foo');
   });
-  it('should reset `TextField` and `acceptListObjectSearch` on `Enter`', () => {
+  it('should reset `OutlinedInput` and `acceptListObjectSearch` on `Enter`', () => {
     const model = {
       searchListObjectFor: sinon.spy(),
       acceptListObjectSearch: sinon.spy(),
@@ -68,7 +68,7 @@ describe('<ListBoxSearch />', () => {
       </LocaleContext.Provider>
     );
     const testInstance = testRenderer.root;
-    const type = testInstance.findByType(TextField);
+    const type = testInstance.findByType(OutlinedInput);
     type.props.onChange({ target: { value: 'foo' } });
     expect(type.props.value).to.equal('foo');
     type.props.onKeyDown({ key: 'Enter' });
@@ -87,7 +87,7 @@ describe('<ListBoxSearch />', () => {
       </LocaleContext.Provider>
     );
     const testInstance = testRenderer.root;
-    const type = testInstance.findByType(TextField);
+    const type = testInstance.findByType(OutlinedInput);
     type.props.onChange({ target: { value: 'foo' } });
     expect(type.props.value).to.equal('foo');
     type.props.onKeyDown({ key: 'Escape' });

--- a/apis/nucleus/src/selections/object-selections.js
+++ b/apis/nucleus/src/selections/object-selections.js
@@ -107,6 +107,9 @@ export default function(model, app) {
      * @returns {boolean}
      */
     canCancel() {
+      if (layout && layout.qListObject && layout.qListObject.qDimensionInfo) {
+        return !layout.qListObject.qDimensionInfo.qLocked;
+      }
       return true;
     },
     /**


### PR DESCRIPTION
- switch lock icon to show current state
- disable other actions when locked
- add padding to actions
- update search input styling
- update more dropdown shadow

_|Before|After
---|---|---
Search|![search-before](https://user-images.githubusercontent.com/16324367/69815115-eda69b00-11f5-11ea-9fb8-89e9a482a1d2.png)|![search-after](https://user-images.githubusercontent.com/16324367/69815114-eda69b00-11f5-11ea-9453-ca127c6ce0ab.png)
Dropdown|![more-before](https://user-images.githubusercontent.com/16324367/69815129-f5663f80-11f5-11ea-92ab-68c3a25c3078.png)|![more-after](https://user-images.githubusercontent.com/16324367/69815127-f5663f80-11f5-11ea-8570-3561502b8c60.png)
