### PR TITLE
fix: add focus style on icon buttons

### DIFF
--- a/packages/ui/theme/create.js
+++ b/packages/ui/theme/create.js
@@ -33,6 +33,11 @@ const dark = {
     },
   },
   overrides: {
+    MuiTypography: {
+      root: {
+        color: '#fff',
+      },
+    },
     MuiIconButton: {
       root: {
         ...defaults.overrides.MuiIconButton.root,

--- a/packages/ui/theme/definitions/defaults.js
+++ b/packages/ui/theme/definitions/defaults.js
@@ -1,3 +1,6 @@
+const focusBorder = '#469DCD';
+const focusOutline = 'rgba(70, 157, 205, 0.3)';
+
 export default {
   typography: {
     fontSize: 14,
@@ -46,18 +49,29 @@ export default {
   props: {
     MuiButtonBase: {
       disableRipple: true,
+      disableTouchRipple: true,
+      focusRipple: false,
     },
   },
   overrides: {
-    MuiTypography: {
-      root: {
-        color: '#fff',
-      },
-    },
     MuiIconButton: {
       root: {
-        padding: 8,
+        padding: 7,
         borderRadius: 2,
+        border: '1px solid transparent',
+        // should ideally use $focusVisible, but that messes up focus in all other places where Iconbutton is used (Checkbox, Switch etc)
+        '&:focus': {
+          borderColor: focusBorder,
+          boxShadow: `0 0 0 2px ${focusOutline}`,
+        },
+      },
+    },
+    MuiButton: {
+      outlined: {
+        '&$focusVisible': {
+          borderColor: focusBorder,
+          boxShadow: `0 0 0 2px ${focusOutline}`,
+        },
       },
     },
     MuiExpansionPanelSummary: {


### PR DESCRIPTION

mui uses touchripple to highlight when a component receives focus, since we disable the ripple in this project we need to add custom styling when elements are focused.

Some components can be styled using `$focusVisible` which [should be used when possible](https://github.com/WICG/focus-visible/blob/master/explainer.md), otherwise `:focused` can be used.

![Screenshot 2019-11-29 at 12 47 25](https://user-images.githubusercontent.com/16324367/69867204-7a109680-12a6-11ea-954e-37792622184b.png)
![Screenshot 2019-11-29 at 12 47 36](https://user-images.githubusercontent.com/16324367/69867205-7aa92d00-12a6-11ea-8863-d90e84453474.png)

