### PR TITLE
test: remove multiple mock

### DIFF
--- a/apis/nucleus/src/object/__tests__/hc-handler.spec.js
+++ b/apis/nucleus/src/object/__tests__/hc-handler.spec.js
@@ -1,12 +1,10 @@
-const doMock = () => aw.mock([['**/uid.js', () => () => 'uid']], ['../hc-handler.js']);
-
 describe('hc-handler', () => {
   let h;
   let hc;
   let def;
   let handler;
   before(() => {
-    [{ default: handler }] = doMock();
+    [{ default: handler }] = aw.mock([['**/uid.js', () => () => 'uid']], ['../hc-handler.js']);
   });
 
   beforeEach(() => {

--- a/apis/nucleus/src/object/__tests__/populator.spec.js
+++ b/apis/nucleus/src/object/__tests__/populator.spec.js
@@ -1,4 +1,3 @@
-const doMock = ({ handler } = {}) => aw.mock([['**/hc-handler.js', () => handler]], ['../populator.js']);
 describe('populator', () => {
   let handler;
   let context;
@@ -19,7 +18,7 @@ describe('populator', () => {
         warn: sb.stub(),
       },
     };
-    [{ default: populate, fieldType: ft }] = doMock({ handler });
+    [{ default: populate, fieldType: ft }] = aw.mock([['**/hc-handler.js', () => handler]], ['../populator.js']);
   });
   beforeEach(() => {
     sb.reset();

--- a/apis/nucleus/src/sn/__tests__/type.spec.js
+++ b/apis/nucleus/src/sn/__tests__/type.spec.js
@@ -1,13 +1,3 @@
-const mock = ({ SNFactory = () => ({}), satisfies = () => false, load = () => null } = {}) =>
-  aw.mock(
-    [
-      ['**/dist/supernova.js', () => SNFactory],
-      ['**/semver.js', () => ({ satisfies })],
-      ['**/load.js', () => ({ load })],
-    ],
-    ['../type']
-  );
-
 describe('type', () => {
   let c;
   let SNFactory;
@@ -20,7 +10,14 @@ describe('type', () => {
     SNFactory = sb.stub();
     load = sb.stub();
     satisfies = sb.stub();
-    [{ default: create }] = mock({ SNFactory, load, satisfies });
+    [{ default: create }] = aw.mock(
+      [
+        ['**/dist/supernova.js', () => SNFactory],
+        ['**/semver.js', () => ({ satisfies })],
+        ['**/load.js', () => ({ load })],
+      ],
+      ['../type']
+    );
   });
   beforeEach(() => {
     c = create({ name: 'pie', version: '1.1.0' }, 'c', { load: 'customLoader' });

--- a/apis/nucleus/src/sn/__tests__/types.spec.js
+++ b/apis/nucleus/src/sn/__tests__/types.spec.js
@@ -1,17 +1,3 @@
-const mock = ({ createType, clearFromCache = () => {} } = {}) =>
-  aw.mock(
-    [
-      ['**/sn/type.js', () => createType],
-      [
-        '**/sn/load.js',
-        () => ({
-          clearFromCache,
-        }),
-      ],
-    ],
-    ['../types']
-  );
-
 describe('types', () => {
   let sb;
   let create;
@@ -23,7 +9,18 @@ describe('types', () => {
     sb = sinon.createSandbox();
     type = sb.stub();
     clearFromCache = sb.stub();
-    [{ create, semverSort }] = mock({ createType: type, clearFromCache });
+    [{ create, semverSort }] = aw.mock(
+      [
+        ['**/sn/type.js', () => type],
+        [
+          '**/sn/load.js',
+          () => ({
+            clearFromCache,
+          }),
+        ],
+      ],
+      ['../types']
+    );
   });
 
   beforeEach(() => {

--- a/apis/supernova/__tests__/unit/creator.spec.js
+++ b/apis/supernova/__tests__/unit/creator.spec.js
@@ -1,5 +1,8 @@
 describe('creator', () => {
-  const [{ default: create }] = aw.mock([['**/action-hero.js', () => () => ({})]], ['../../src/creator']);
+  let create;
+  before(() => {
+    [{ default: create }] = aw.mock([['**/action-hero.js', () => () => ({})]], ['../../src/creator']);
+  });
 
   it('should return a default component api', () => {
     const generator = {

--- a/apis/supernova/__tests__/unit/generator.spec.js
+++ b/apis/supernova/__tests__/unit/generator.spec.js
@@ -1,13 +1,16 @@
 // import generator from '../../src/generator';
 
 describe('generator', () => {
-  const [{ default: generator }] = aw.mock(
-    [
-      ['**/creator.js', () => (...a) => [...a]],
-      ['**/qae.js', () => qae => qae || 'qae'],
-    ],
-    ['../../src/generator']
-  );
+  let generator;
+  before(() => {
+    [{ default: generator }] = aw.mock(
+      [
+        ['**/creator.js', () => (...a) => [...a]],
+        ['**/qae.js', () => qae => qae || 'qae'],
+      ],
+      ['../../src/generator']
+    );
+  });
 
   it('should have a default qae property', () => {
     expect(generator({}).qae).to.eql('qae');


### PR DESCRIPTION
Multiple mocks in the same file messes up coverage stats, only one mock should be used.