### PR TITLE
feat: use first target property path

### DIFF
--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -92,7 +92,9 @@ const handleModal = ({ sn, layout, model }) => {
   if (selections.id === model.id) {
     selections.setLayout(layout);
     if (layout && layout.qSelectionInfo && layout.qSelectionInfo.qInSelections && !selections.isModal()) {
-      selections.goModal('/qHyperCubeDef'); // TODO - use path from data targets
+      const { targets } = sn.generator.qae.data;
+      const firstPropertyPath = targets[0].propertyPath;
+      selections.goModal(firstPropertyPath);
     }
     if (!layout.qSelectionInfo || !layout.qSelectionInfo.qInSelections) {
       if (selections.isModal()) {

--- a/apis/nucleus/src/components/__tests__/cell.spec.jsx
+++ b/apis/nucleus/src/components/__tests__/cell.spec.jsx
@@ -253,6 +253,7 @@ describe('<Cell />', () => {
             data: {
               targets: [
                 {
+                  propertyPath: '/qFoo',
                   layoutPath: '/foo',
                   resolveLayout: () => layout.foo,
                   dimensions: {
@@ -293,6 +294,7 @@ describe('<Cell />', () => {
       };
       await render({ model, nebbie });
       expect(goModal.callCount).to.equal(1);
+      expect(goModal).to.have.been.calledWithExactly('/qFoo');
     });
 
     it('should no modal (selections)', async () => {


### PR DESCRIPTION
## Motivation

Use first targets property path instead of hard coded `qHyperCubeDef` when going into modal mode.
