### PR TITLE
feat: useAction hook

### DIFF
--- a/apis/supernova/src/creator.js
+++ b/apis/supernova/src/creator.js
@@ -33,6 +33,7 @@ const defaultComponent = /** @lends SnComponent */ {
   getViewState: () => {},
 
   // temporary
+  observeActions() {},
   setSnapshotData: snapshot => Promise.resolve(snapshot),
 };
 
@@ -54,13 +55,14 @@ function createWithHooks(generator, opts, env) {
       console.warn('Detected multiple supernova modules, this might cause problems.');
     }
   }
+  const qGlobal = opts.app && opts.app.session ? opts.app.session.getObjectApi({ handle: -1 }) : null;
   const c = {
     context: {
       element: undefined,
       layout: {},
       model: opts.model,
       app: opts.app,
-      global: opts.global,
+      global: qGlobal,
       selections: opts.selections,
     },
     env,
@@ -92,7 +94,14 @@ function createWithHooks(generator, opts, env) {
       return generator.component.runSnaps(this, layout);
     },
     destroy() {},
+    observeActions(callback) {
+      generator.component.observeActions(this, callback);
+    },
   };
+
+  Object.assign(c, {
+    selections: opts.selections,
+  });
 
   return [c, null];
 }

--- a/apis/supernova/src/index.js
+++ b/apis/supernova/src/index.js
@@ -11,6 +11,7 @@ export { useMemo } from './hooks';
 export { usePromise } from './hooks';
 
 // composed hooks
+export { useAction } from './hooks';
 export { useRect } from './hooks';
 export { useModel } from './hooks';
 export { useApp } from './hooks';

--- a/test/component/hooks/hooked.fix.js
+++ b/test/component/hooks/hooked.fix.js
@@ -1,6 +1,15 @@
 /* eslint import/no-extraneous-dependencies: 0 */
 
-import { useState, useEffect, useLayout, useElement, useTheme, useTranslator, usePromise } from '@nebula.js/supernova';
+import {
+  useState,
+  useEffect,
+  useLayout,
+  useElement,
+  useTheme,
+  useTranslator,
+  usePromise,
+  useAction,
+} from '@nebula.js/supernova';
 
 function sn() {
   return {
@@ -11,16 +20,31 @@ function sn() {
       const theme = useTheme();
       const layout = useLayout();
 
+      const [acted, setActed] = useState(false);
+
+      const [act] = useAction(
+        () => ({
+          action() {
+            setActed(true);
+          },
+        }),
+        []
+      );
+
       useEffect(() => {
         const listener = () => {
-          setCount(prev => prev + 1);
+          if (count >= 1) {
+            act();
+          } else {
+            setCount(prev => prev + 1);
+          }
         };
         element.addEventListener('click', listener);
 
         return () => {
           element.removeEventListener('click', listener);
         };
-      }, [element]);
+      }, [element, count]);
 
       const [v] = usePromise(
         () =>
@@ -38,6 +62,7 @@ function sn() {
         <div class="translator">${translator.get('Common.Cancel')}</div>
         <div class="theme">${theme.getColorPickerColor({ index: 2 })}</div>
         <div class="promise">${v || 'pending'}</div>
+        <div class="action">${acted}</div>
       </div>
       `;
     },

--- a/test/component/hooks/sn.comp.js
+++ b/test/component/hooks/sn.comp.js
@@ -16,11 +16,13 @@ describe('hooks', () => {
   });
 
   it('should render with initial state', async () => {
-    const text = await page.$eval(`${snSelector} .state`, el => el.textContent);
-    expect(text).to.equal('0');
+    const state = await page.$eval(`${snSelector} .state`, el => el.textContent);
+    expect(state).to.equal('0');
+    const action = await page.$eval(`${snSelector} .action`, el => el.textContent);
+    expect(action).to.equal('false');
   });
 
-  it('should update count state after click', async () => {
+  it('should update count state after first click', async () => {
     await page.click(snSelector);
     await page.waitForFunction(
       selector => document.querySelector(selector).textContent === '1',
@@ -29,6 +31,17 @@ describe('hooks', () => {
     );
     const text = await page.$eval(`${snSelector} .state`, el => el.textContent);
     expect(text).to.equal('1');
+  });
+
+  it('should update action state after second click', async () => {
+    await page.click(snSelector);
+    await page.waitForFunction(
+      selector => document.querySelector(selector).textContent === 'true',
+      {},
+      `${snSelector} .action`
+    );
+    const text = await page.$eval(`${snSelector} .action`, el => el.textContent);
+    expect(text).to.equal('true');
   });
 
   it('useLayout', async () => {


### PR DESCRIPTION
useAction that enables adding custom actions into an object's selection toolbar or a future more generic object toolbar.

```js
const [count, setCount] = useState(0);
const [act] = useAction(() => ({
  action() {
    setCount(c => c + 1)
  },
  enabled: true
}));

```