### PR TITLE
feat: use constraints

### DIFF
--- a/.codesandbox/mekko/src/init.js
+++ b/.codesandbox/mekko/src/init.js
@@ -28,9 +28,6 @@ export default function init({ appId, fields, objectId }) {
     nebbie.types.clearFromCache('dummy');
 
     const params = {
-      context: {
-        permissions: ['passive', 'interact', 'select', 'fetch'],
-      },
       element: document.getElementById('object'),
     };
 

--- a/apis/nucleus/src/__tests__/app-theme.spec.js
+++ b/apis/nucleus/src/__tests__/app-theme.spec.js
@@ -47,10 +47,13 @@ describe('app-theme', () => {
       });
       await at.setTheme('darkish');
       expect(root.setMuiThemeName).to.have.been.calledWithExactly('dark');
-      expect(internalAPI.setTheme).to.have.been.calledWithExactly({
-        type: 'dark',
-        color: 'red',
-      });
+      expect(internalAPI.setTheme).to.have.been.calledWithExactly(
+        {
+          type: 'dark',
+          color: 'red',
+        },
+        'darkish'
+      );
     });
 
     it('should timeout after 5sec', async () => {
@@ -93,9 +96,12 @@ describe('app-theme', () => {
       const root = { setMuiThemeName: sinon.spy() };
       const at = appThemeFn({ root });
       at.setTheme('light');
-      expect(internalAPI.setTheme).to.have.been.calledWithExactly({
-        type: 'light',
-      });
+      expect(internalAPI.setTheme).to.have.been.calledWithExactly(
+        {
+          type: 'light',
+        },
+        'light'
+      );
     });
   });
 });

--- a/apis/nucleus/src/__tests__/nucleus.spec.js
+++ b/apis/nucleus/src/__tests__/nucleus.spec.js
@@ -89,7 +89,7 @@ describe('nucleus', () => {
       context: {
         language: 'en-US',
         theme: 'light',
-        permissions: ['idle', 'interact', 'select', 'fetch'],
+        constraints: {},
         translator,
       },
     });
@@ -108,7 +108,7 @@ describe('nucleus', () => {
     nuked.context({ foo: 'a' });
     expect(root.context.callCount).to.equal(0);
 
-    nuked.context({ permissions: 'a' });
+    nuked.context({ constraints: 'a' });
     expect(root.context.callCount).to.equal(1);
 
     nuked.context({ language: 'sv-SE' });

--- a/apis/nucleus/src/__tests__/viz.spec.js
+++ b/apis/nucleus/src/__tests__/viz.spec.js
@@ -111,25 +111,9 @@ describe('viz', () => {
   describe('options', () => {
     it('should set sn options', async () => {
       const opts = {};
-      const chaining = api.options(opts);
+      api.options(opts);
       await mounted;
-      expect(chaining).to.equal(api);
       expect(cellRef.current.setSnOptions).to.have.been.calledWithExactly(opts);
-    });
-  });
-
-  describe('context', () => {
-    it('should set sn context', async () => {
-      const ctx = {
-        permissions: [],
-        theme: undefined,
-      };
-      const chaining = api.context(ctx);
-      await mounted;
-      expect(chaining).to.equal(api);
-      expect(cellRef.current.setSnContext).to.have.been.calledWith({
-        ...ctx,
-      });
     });
   });
 

--- a/apis/nucleus/src/app-theme.js
+++ b/apis/nucleus/src/app-theme.js
@@ -18,16 +18,19 @@ export default function appTheme({ themes = [], logger, root } = {}) {
           logger.warn(`Timeout when loading theme '${themeName}'`);
         } else {
           muiTheme = raw.type === 'dark' ? 'dark' : 'light';
-          theme.internalAPI.setTheme(raw);
+          theme.internalAPI.setTheme(raw, themeName);
           root.setMuiThemeName(muiTheme);
         }
       } catch (e) {
         logger.error(e);
       }
     } else {
-      theme.internalAPI.setTheme({
-        type: muiTheme,
-      });
+      theme.internalAPI.setTheme(
+        {
+          type: muiTheme,
+        },
+        themeName
+      );
       root.setMuiThemeName(muiTheme);
     }
   };

--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -158,7 +158,7 @@ const loadType = async ({ dispatch, types, name, version, layout, model, app, se
   return undefined;
 };
 
-const Cell = forwardRef(({ corona, model, initialSnContext, initialSnOptions, initialError, onMount }, ref) => {
+const Cell = forwardRef(({ corona, model, initialSnOptions, initialError, onMount }, ref) => {
   const {
     app,
     public: {
@@ -173,7 +173,6 @@ const Cell = forwardRef(({ corona, model, initialSnContext, initialSnOptions, in
   const [layout, { validating, canCancel, canRetry }, longrunning] = useLayout(model);
   const [appLayout] = useAppLayout(app);
   const [contentRef, contentRect, , contentNode] = useRect();
-  const [snContext, setSnContext] = useState(initialSnContext);
   const [snOptions, setSnOptions] = useState(initialSnOptions);
   const [selections] = useObjectSelections(app, model);
 
@@ -247,7 +246,6 @@ const Cell = forwardRef(({ corona, model, initialSnContext, initialSnOptions, in
   useImperativeHandle(
     ref,
     () => ({
-      setSnContext,
       setSnOptions,
       async takeSnapshot() {
         const { width, height } = cellRef.current.getBoundingClientRect();
@@ -293,7 +291,7 @@ const Cell = forwardRef(({ corona, model, initialSnContext, initialSnOptions, in
       <Supernova
         key={layout.visualization}
         sn={state.sn}
-        snContext={snContext}
+        corona={corona}
         snOptions={snOptions}
         layout={layout}
         appLayout={appLayout}

--- a/apis/nucleus/src/components/__tests__/cell.spec.jsx
+++ b/apis/nucleus/src/components/__tests__/cell.spec.jsx
@@ -63,7 +63,6 @@ describe('<Cell />', () => {
       model = {},
       app = {},
       nebbie = {},
-      initialSnContext = {},
       initialSnOptions = {},
       onMount = sandbox.spy(),
       theme = createTheme('dark'),
@@ -86,14 +85,7 @@ describe('<Cell />', () => {
         renderer = create(
           <ThemeProvider theme={theme}>
             <InstanceContext.Provider value={{ translator: { get: s => s, language: () => 'sv' } }}>
-              <Cell
-                ref={cellRef}
-                corona={corona}
-                model={model}
-                initialSnContext={initialSnContext}
-                initialSnOptions={initialSnOptions}
-                onMount={onMount}
-              />
+              <Cell ref={cellRef} corona={corona} model={model} initialSnOptions={initialSnOptions} onMount={onMount} />
             </InstanceContext.Provider>
           </ThemeProvider>,
           rendererOptions || null
@@ -382,8 +374,8 @@ describe('<Cell />', () => {
       };
       await render({ model, nebbie, cellRef });
 
-      expect(cellRef.current.setSnContext).to.be.a('function');
       expect(cellRef.current.setSnOptions).to.be.a('function');
+      expect(cellRef.current.exportImage).to.be.a('function');
       expect(cellRef.current.takeSnapshot).to.be.a('function');
     });
 

--- a/apis/nucleus/src/components/__tests__/supernova.spec.jsx
+++ b/apis/nucleus/src/components/__tests__/supernova.spec.jsx
@@ -18,14 +18,14 @@ describe('<Supernova />', () => {
     render = async ({
       sn = { component: {} },
       snOptions = {},
-      snContext = {},
       layout = {},
       appLayout = {},
+      corona = {},
       rendererOptions,
     } = {}) => {
       await act(async () => {
         renderer = create(
-          <Supernova sn={sn} snOptions={snOptions} snContext={snContext} layout={layout} appLayout={appLayout} />,
+          <Supernova sn={sn} snOptions={snOptions} layout={layout} appLayout={appLayout} corona={corona} />,
           rendererOptions || null
         );
       });
@@ -43,9 +43,9 @@ describe('<Supernova />', () => {
         component: {},
       },
       snOptions: {},
-      snContext: {},
       layout: {},
       appLayout: {},
+      corona: {},
     });
   });
   it('should mount', async () => {
@@ -61,7 +61,6 @@ describe('<Supernova />', () => {
         logicalSize,
         component,
       },
-      snContext: {},
       rendererOptions: {
         createNodeMock: () => {
           return {
@@ -98,14 +97,9 @@ describe('<Supernova />', () => {
         component,
       },
       snOptions,
-      snContext: {
-        permissions: 'p',
-        theme: 't',
-        rtl: 'rtl',
-        localeInfo: 'loc',
-      },
       layout: 'layout',
-      appLayout: 'app-layout',
+      appLayout: { qLocaleInfo: 'loc' },
+      corona: { public: { theme: 'theme' }, app: { session: {} } },
       rendererOptions: {
         createNodeMock: () => {
           return {
@@ -124,12 +118,12 @@ describe('<Supernova />', () => {
       layout: 'layout',
       options: snOptions,
       context: {
-        permissions: 'p',
-        theme: 't',
-        rtl: 'rtl',
+        constraints: {},
+        appLayout: { qLocaleInfo: 'loc' },
+        theme: 'theme',
+        permissions: ['passive', 'interact', 'select', 'fetch'],
         localeInfo: 'loc',
         logicalSize: 'logical',
-        appLayout: 'app-layout',
       },
     });
   });
@@ -149,8 +143,8 @@ describe('<Supernova />', () => {
         logicalSize,
         component,
       },
-      snContext: {},
       layout: {},
+      corona: { public: {} },
       rendererOptions: {
         createNodeMock: () => {
           return {

--- a/apis/nucleus/src/components/glue.jsx
+++ b/apis/nucleus/src/components/glue.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Cell from './Cell';
 
-export default function glue({ corona, element, initialSnContext, model, initialSnOptions, onMount, initialError }) {
+export default function glue({ corona, element, model, initialSnOptions, onMount, initialError }) {
   const { root } = corona;
   const cellRef = React.createRef();
   const portal = ReactDOM.createPortal(
@@ -10,7 +10,6 @@ export default function glue({ corona, element, initialSnContext, model, initial
       ref={cellRef}
       corona={corona}
       model={model}
-      initialSnContext={initialSnContext}
       initialSnOptions={initialSnOptions}
       initialError={initialError}
       onMount={onMount}

--- a/apis/nucleus/src/contexts/InstanceContext.js
+++ b/apis/nucleus/src/contexts/InstanceContext.js
@@ -4,5 +4,5 @@ export default React.createContext({
   language: null,
   theme: null,
   translator: null,
-  permissions: [],
+  constraints: {},
 });

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -27,7 +27,7 @@ const DEFAULT_CONFIG = {
   context: {
     theme: 'light',
     language: 'en-US',
-    permissions: ['idle', 'interact', 'select', 'fetch'],
+    constraints: {},
   },
   /**
    *
@@ -200,12 +200,12 @@ function nuked(configuration = {}) {
        * @param {object} ctx
        * @param {string} ctx.theme
        * @param {string} ctx.language
-       * @param {string[]} ctx.permissions
+       * @param {string[]} ctx.constraints
        */
       context: async ctx => {
         // filter valid values to avoid triggering unnecessary rerender
         let changes;
-        ['theme', 'language', 'permissions'].forEach(key => {
+        ['theme', 'language', 'constraints'].forEach(key => {
           if (ctx[key] && ctx[key] !== currentContext[key]) {
             if (!changes) {
               changes = {};

--- a/apis/nucleus/src/object/__tests__/initiate.spec.js
+++ b/apis/nucleus/src/object/__tests__/initiate.spec.js
@@ -41,9 +41,4 @@ describe('initiate api', () => {
     await create(model, { options: 'opts' }, corona);
     expect(api.options).to.have.been.calledWithExactly('opts');
   });
-
-  it('should call context when provided ', async () => {
-    await create(model, { context: 'ctx' }, corona);
-    expect(api.context).to.have.been.calledWithExactly('ctx');
-  });
 });

--- a/apis/nucleus/src/object/get-object.js
+++ b/apis/nucleus/src/object/get-object.js
@@ -9,10 +9,9 @@ import { modelStore } from '../stores/modelStore';
 /**
  * @typedef {object} VizConfig
  * @property {HTMLElement=} element
- * @property {object=} options
- * @property {object=} context
- * @property {Array<'passive'|'select'|'interact'|'fetch'>} [context.permissions]
- * @property {object=} properties
+ * @property {object=} optional
+ * @property {object=} optional.options
+ * @property {object=} optional.properties
  */
 export default async function initiate({ id }, optional, corona) {
   const key = `${corona.app.id}/${id}`;

--- a/apis/nucleus/src/object/initiate.js
+++ b/apis/nucleus/src/object/initiate.js
@@ -12,9 +12,6 @@ export default async function(model, optional, corona, initialError) {
   if (optional.options) {
     api.options(optional.options);
   }
-  if (optional.context) {
-    api.context(optional.context);
-  }
 
   return api;
 }

--- a/apis/nucleus/src/viz.js
+++ b/apis/nucleus/src/viz.js
@@ -13,10 +13,6 @@ export default function viz({ model, corona, initialError } = {}) {
     onMount = resolve;
   });
 
-  let initialSnContext = {
-    theme: corona.public.theme,
-    permissions: [],
-  };
   let initialSnOptions = {};
 
   const setSnOptions = async opts => {
@@ -33,25 +29,6 @@ export default function viz({ model, corona, initialError } = {}) {
       initialSnOptions = {
         ...initialSnOptions,
         ...opts,
-      };
-    }
-  };
-
-  const setSnContext = async ctx => {
-    if (mountedReference) {
-      (async () => {
-        await mounted;
-        cellRef.current.setSnContext({
-          ...initialSnContext,
-          ...ctx,
-          theme: corona.public.theme,
-        });
-      })();
-    } else {
-      // Handle setting context before mount
-      initialSnContext = {
-        ...initialSnContext,
-        ...ctx,
       };
     }
   };
@@ -79,7 +56,6 @@ export default function viz({ model, corona, initialError } = {}) {
         corona,
         element,
         model,
-        initialSnContext,
         initialSnOptions,
         initialError,
         onMount,
@@ -105,13 +81,10 @@ export default function viz({ model, corona, initialError } = {}) {
     },
     options(opts) {
       setSnOptions(opts);
-      return api;
-    },
-    context(ctx) {
-      setSnContext(ctx);
-      return api;
+      // return api;
     },
     exportImage() {
+      // TODO - check if exportable
       return cellRef.current.exportImage();
     },
 

--- a/apis/snapshooter/src/__tests__/renderer.spec.js
+++ b/apis/snapshooter/src/__tests__/renderer.spec.js
@@ -62,12 +62,13 @@ describe('snapshooter', () => {
     expect(element.innerHTML).to.eql('<p>meh</p>');
   });
 
-  it('should call nucleus with context theme and language', async () => {
+  it('should call nucleus with context theme, language and constraints', async () => {
     await renderer({ nucleus });
     expect(nucleus.firstCall.args[1]).to.eql({
       context: {
         theme: 'dark',
         language: 'sv',
+        constraints: { passive: true, active: true, select: true },
       },
     });
   });

--- a/apis/snapshooter/src/renderer.js
+++ b/apis/snapshooter/src/renderer.js
@@ -60,6 +60,11 @@ async function renderSnapshot({ nucleus, element }) {
     context: {
       theme,
       language,
+      constraints: {
+        select: true,
+        passive: true,
+        active: true,
+      },
     },
   });
 

--- a/apis/supernova/src/__tests__/hooks.spec.js
+++ b/apis/supernova/src/__tests__/hooks.spec.js
@@ -24,6 +24,7 @@ import {
   useStaleLayout,
   useAppLayout,
   useTranslator,
+  useConstraints,
   onTakeSnapshot,
 } from '../hooks';
 
@@ -580,14 +581,15 @@ describe('hooks', () => {
     beforeEach(() => {
       c = {};
       c.context = {
-        model: 'model',
-        app: 'app',
-        global: 'global',
+        model: { session: 'm' },
+        app: { session: 'a' },
+        global: { session: 'global' },
         element: 'element',
         selections: 'selections',
         theme: 'theme',
         layout: 'layout',
         appLayout: 'appLayout',
+        constraints: 'constraints',
       };
       c.env = {
         translator: 'translator',
@@ -604,7 +606,11 @@ describe('hooks', () => {
         value = useModel();
       };
       run(c);
-      expect(value).to.equal('model');
+      expect(value).to.eql({ session: 'm' });
+
+      c.context.model = {};
+      run(c);
+      expect(value).to.eql(undefined);
     });
 
     it('useApp', () => {
@@ -613,7 +619,11 @@ describe('hooks', () => {
         value = useApp();
       };
       run(c);
-      expect(value).to.equal('app');
+      expect(value).to.eql({ session: 'a' });
+
+      c.context.app = {};
+      run(c);
+      expect(value).to.eql(undefined);
     });
     it('useGlobal', () => {
       let value;
@@ -621,7 +631,11 @@ describe('hooks', () => {
         value = useGlobal();
       };
       run(c);
-      expect(value).to.equal('global');
+      expect(value).to.eql({ session: 'global' });
+
+      c.context.global = {};
+      run(c);
+      expect(value).to.eql(undefined);
     });
     it('useElement', () => {
       let value;
@@ -685,6 +699,14 @@ describe('hooks', () => {
       };
       run(c);
       expect(value).to.equal('translator');
+    });
+    it('useConstraints', () => {
+      let value;
+      c.fn = () => {
+        value = useConstraints();
+      };
+      run(c);
+      expect(value).to.eql('constraints');
     });
     it('onTakeSnapshot', () => {
       const spy = sandbox.spy();

--- a/apis/supernova/src/creator.js
+++ b/apis/supernova/src/creator.js
@@ -64,6 +64,7 @@ function createWithHooks(generator, opts, env) {
       app: opts.app,
       global: qGlobal,
       selections: opts.selections,
+      constraints: {},
     },
     env,
     fn: generator.component.fn,
@@ -81,6 +82,11 @@ function createWithHooks(generator, opts, env) {
         ...r.context,
         layout: r.layout,
       };
+
+      // select should be a constraint when a real model is not available
+      if (!this.context.constraints.select && (!this.context.model || !this.context.model.session)) {
+        this.context.constraints.select = true;
+      }
 
       return generator.component.run(this);
     },
@@ -177,7 +183,7 @@ export default function create(generator, opts, env) {
 
   if (generator.qae.properties.onChange) {
     // TODO - handle multiple sn
-    // TODO - check permissions
+    // TODO - check privileges
     if (opts.model.__snInterceptor) {
       // remove old hook - happens only when proper cleanup hasn't been done
       opts.model.__snInterceptor.teardown();

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -417,15 +417,18 @@ export function useRect() {
 }
 
 export function useModel() {
-  return useInternalContext('model');
+  const model = useInternalContext('model');
+  return model && model.session ? model : undefined;
 }
 
 export function useApp() {
-  return useInternalContext('app');
+  const app = useInternalContext('app');
+  return app && app.session ? app : undefined;
 }
 
 export function useGlobal() {
-  return useInternalContext('global');
+  const global = useInternalContext('global');
+  return global && global.session ? global : undefined;
 }
 
 export function useElement() {
@@ -459,6 +462,15 @@ export function useAppLayout() {
 
 export function useTranslator() {
   return useInternalEnv('translator');
+}
+
+export function useConstraints() {
+  return useInternalContext('constraints');
+  // return {
+  //   passive: true,
+  //   active: true,
+  //   select: true,
+  // };
 }
 
 export function onTakeSnapshot(cb) {

--- a/apis/supernova/src/index.js
+++ b/apis/supernova/src/index.js
@@ -22,5 +22,6 @@ export { useLayout } from './hooks';
 export { useStaleLayout } from './hooks';
 export { useAppLayout } from './hooks';
 export { useTranslator } from './hooks';
+export { useConstraints } from './hooks';
 
 export { onTakeSnapshot } from './hooks';

--- a/apis/theme/src/index.js
+++ b/apis/theme/src/index.js
@@ -99,7 +99,7 @@ export default function theme() {
      * @private
      * @param {object} t Raw JSON theme
      */
-    setTheme(t) {
+    setTheme(t, name) {
       resolvedThemeJSON = setTheme(t, styleResolverFn.resolveRawTheme);
       styleResolverInstanceCache = {};
 
@@ -114,6 +114,7 @@ export default function theme() {
       contraster = contrasterFn([textColor, inverseTextColor]);
 
       externalAPI.emit('changed');
+      externalAPI.name = () => name;
     },
   };
 
@@ -122,7 +123,7 @@ export default function theme() {
   });
   EventEmitter.init(externalAPI);
 
-  internalAPI.setTheme({});
+  internalAPI.setTheme({}, 'light');
 
   return {
     externalAPI,

--- a/commands/create/templates/picasso/barchart/test/integration/interaction.int.js
+++ b/commands/create/templates/picasso/barchart/test/integration/interaction.int.js
@@ -2,9 +2,7 @@ describe('interaction', () => {
   const content = '.nebulajs-sn[data-render-count="1"]';
   it('should select two bars', async () => {
     const app = encodeURIComponent(process.env.APP_ID || '/apps/ctrl00.qvf');
-    await page.goto(
-      `${process.env.BASE_URL}/render/?app=${app}&cols=Alpha,=5+avg(Expression1)&permissions=interact,select`
-    );
+    await page.goto(`${process.env.BASE_URL}/render/?app=${app}&cols=Alpha,=5+avg(Expression1)`);
     await page.waitForSelector(content, { visible: true });
 
     await page.click('rect[data-label="K"]');

--- a/commands/serve/web/components/Cell.jsx
+++ b/commands/serve/web/components/Cell.jsx
@@ -123,9 +123,7 @@ export default function({ id, expandable, minHeight }) {
                 model
                   ? `${document.location.href.replace(/\/dev\//, '/render/')}${
                       window.location.search ? '&' : '?'
-                    }object=${
-                      model.id
-                    }&permissions=passive,interact,select&theme=${currentThemeName}&language=${language}`
+                    }object=${model.id}&theme=${currentThemeName}&language=${language}`
                   : ''
               }
               target="_blank"

--- a/commands/serve/web/components/Chart.jsx
+++ b/commands/serve/web/components/Chart.jsx
@@ -16,9 +16,6 @@ export default function Chart({ id, onLoad }) {
         id,
       },
       {
-        context: {
-          permissions: ['passive', 'interact', 'select', 'fetch'],
-        },
         element: el.current,
       }
     );

--- a/commands/serve/web/components/Stage.jsx
+++ b/commands/serve/web/components/Stage.jsx
@@ -21,9 +21,6 @@ export default function Stage({ info, storage, uid }) {
           type: info.supernova.name,
         },
         {
-          context: {
-            permissions: ['passive', 'interact', 'select', 'fetch'],
-          },
           properties: {
             ...(storage.get('readFromCache') !== false ? storage.props(info.supernova.name) : {}),
             qInfo: {

--- a/commands/serve/web/eRender.js
+++ b/commands/serve/web/eRender.js
@@ -40,9 +40,6 @@ async function renderWithEngine() {
   const element = document.querySelector('#chart-container');
   const vizCfg = {
     element,
-    context: {
-      permissions: params.permissions || [],
-    },
   };
   const getCfg = params.object
     ? {
@@ -88,6 +85,12 @@ async function renderSnapshot() {
         name: supernova.name,
       },
     ],
+    context: {
+      constraints: {
+        passive: true,
+        active: true,
+      },
+    },
   });
 
   window.onHotChange(supernova.name, async () => {
@@ -114,6 +117,7 @@ const renderFixture = async () => {
     context: {
       theme,
       language: params.language,
+      constraints: {},
     },
   };
   const mockedObjects = {};

--- a/test/component/barchart/barchart.fix.js
+++ b/test/component/barchart/barchart.fix.js
@@ -5,11 +5,7 @@ export default function fixture() {
   return {
     type: 'barchart',
     sn,
-    snConfig: {
-      context: {
-        permissions: ['passive', 'interact'],
-      },
-    },
+    snConfig: {},
     object: {
       getLayout: async () => ({
         qHyperCubeDef: null,

--- a/test/component/hooks/hooked.fix.js
+++ b/test/component/hooks/hooked.fix.js
@@ -10,6 +10,7 @@ import {
   useTranslator,
   usePromise,
   useAction,
+  useConstraints,
 } from '@nebula.js/supernova';
 
 function sn() {
@@ -23,6 +24,8 @@ function sn() {
       const appLayout = useAppLayout();
 
       const [acted, setActed] = useState(false);
+
+      const { passive, active, select } = useConstraints();
 
       const [act] = useAction(
         () => ({
@@ -66,6 +69,7 @@ function sn() {
         <div class="theme">${theme.getColorPickerColor({ index: 2 })}</div>
         <div class="promise">${v || 'pending'}</div>
         <div class="action">${acted}</div>
+        <div class="constraints">${!!passive}:${!!active}:${!!select}</div>
       </div>
       `;
     },
@@ -76,10 +80,6 @@ export default function fixture() {
   return {
     type: 'sn-mounted',
     sn,
-    snConfig: {
-      context: {
-        permissions: ['passive', 'interact'],
-      },
-    },
+    snConfig: {},
   };
 }

--- a/test/component/hooks/sn.comp.js
+++ b/test/component/hooks/sn.comp.js
@@ -63,4 +63,9 @@ describe('hooks', () => {
     const text = await page.$eval(`${snSelector} .theme`, el => el.textContent);
     expect(text).to.equal('#a54343');
   });
+
+  it('useConstraints', async () => {
+    const text = await page.$eval(`${snSelector} .constraints`, el => el.textContent);
+    expect(text).to.equal('false:false:true');
+  });
 });

--- a/test/component/object/sn-incomplete.fix.js
+++ b/test/component/object/sn-incomplete.fix.js
@@ -23,10 +23,6 @@ export default function fixture() {
   return {
     type: 'incomplete-sn',
     sn: incompleteSn,
-    snConfig: {
-      context: {
-        permissions: ['passive', 'interact'],
-      },
-    },
+    snConfig: {},
   };
 }

--- a/test/component/object/sn-locale.fix.js
+++ b/test/component/object/sn-locale.fix.js
@@ -18,10 +18,6 @@ export default function fixture() {
   return {
     type: 'sn-locale',
     sn,
-    snConfig: {
-      context: {
-        permissions: ['passive', 'interact'],
-      },
-    },
+    snConfig: {},
   };
 }


### PR DESCRIPTION
- removed snContext API per object instance, context is instead applied from the nucleus instance
- permissions replaced by constraints
- useModel, useApp and useGlobal return undefined if the models are not connected to a real session

BREAKING CHANGE: permissions removed and replaced with constraints
