### PR TITLE
feat: add test-utils package

### DIFF
--- a/apis/test-utils/index.js
+++ b/apis/test-utils/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/test-utils.js');

--- a/apis/test-utils/package.json
+++ b/apis/test-utils/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@nebula.js/test-utils",
+  "version": "0.1.0-alpha.27",
+  "description": "",
+  "license": "MIT",
+  "author": "QlikTech International AB",
+  "keywords": [],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/qlik-oss/nebula.js.git",
+    "directory": "apis/test-utils"
+  },
+  "main": "index.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "cross-env NODE_ENV=production rollup --config ../../rollup.config.js",
+    "build:dev": "rollup --config ../../rollup.config.js",
+    "build:watch": "rollup --config ../../rollup.config.js -w",
+    "prepublishOnly": "rm -rf dist && yarn run build"
+  },
+  "peerDependencies": {
+    "@nebula.js/supernova": "0.1.0-alpha.27"
+  },
+  "devDependencies": {
+    "regenerator-runtime": "0.13.3"
+  }
+}

--- a/apis/test-utils/src/index.js
+++ b/apis/test-utils/src/index.js
@@ -1,0 +1,46 @@
+/* eslint import/prefer-default-export:0 */
+
+import 'regenerator-runtime/runtime'; // temporary polyfill for transpiled async/await in supernova
+import { hook } from '@nebula.js/supernova';
+
+if (!global.requestAnimationFrame) {
+  global.requestAnimationFrame = cb => setTimeout(cb, 10);
+  global.cancelAnimationFrame = id => clearTimeout(id);
+}
+export function create(definition, context = {}) {
+  const hooked = hook(definition);
+
+  const component = {
+    context: {
+      ...context,
+    },
+    env: {
+      translator: context.translator,
+    },
+    fn: hooked.fn,
+  };
+
+  hooked.initiate(component);
+
+  return {
+    update(ctx) {
+      if (ctx) {
+        Object.assign(component.context, ctx);
+      }
+      if (ctx && ctx.translator) {
+        component.env.translator = ctx.translator;
+      }
+      return hooked.run(component);
+    },
+    unmount() {
+      return hooked.teardown(component);
+    },
+    takeSnapshot() {
+      return hooked.runSnaps(component, component.context.layout);
+    },
+    actions() {
+      // TODO
+      return [];
+    },
+  };
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -115,7 +115,7 @@ const config = (isEsm, dev = false) => {
     output: {
       file: path.resolve(targetDir, getFileName(isEsm ? 'esm' : '', dev)),
       format: isEsm ? 'esm' : 'umd',
-      exports: targetName === 'supernova' ? 'named' : 'default',
+      exports: ['supernova', 'test-utils'].indexOf(targetName) !== -1 ? 'named' : 'default',
       name: umdName,
       sourcemap: false,
       banner,
@@ -197,7 +197,7 @@ const config = (isEsm, dev = false) => {
   return cfg;
 };
 
-const dist = [
+let dist = [
   // production
   watch ? false : config(),
   // dev
@@ -208,5 +208,9 @@ const dist = [
   // esm dev
   pkg.module ? config(true, true) : false,
 ];
+
+if (targetName === 'test-utils') {
+  dist = [config(false)];
+}
 
 module.exports = dist.filter(Boolean);


### PR DESCRIPTION
With hooks and the functional approach it is a bit trickier to test a component since there is no instance to verify properties on, adding test-utils makes it possible to unit test a functional component:

```js
import { useElement, useState } from '@nebula.js/supernova';

function component() {
  const element = useElement();
  element.innerHTML = 'foo';
}
```

```js
import { create } from '@nebula.js/test-utils';
import component from './component';

describe(() => {
  it('should add foo',  async () => {
    const mockedThings = {
      layout: 'meh',
      element: {},
    };
    const c = create(component, mockedThings);
    await c.update();

    expect(mockedThings.element.innerHTML).to.equal('foo');
  });
});
```