### PR TITLE
fix(cli-serve): add regenerator-runtime polyfill

### DIFF
--- a/apis/nucleus/package.json
+++ b/apis/nucleus/package.json
@@ -48,7 +48,6 @@
     "react-test-renderer": "16.12.0",
     "react-window": "1.8.5",
     "react-window-infinite-loader": "1.0.5",
-    "regenerator-runtime": "0.13.3",
     "semver": "7.1.1"
   }
 }

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -1,6 +1,4 @@
 /* eslint no-underscore-dangle:0 */
-import 'regenerator-runtime/runtime'; // Polyfill for using async/await
-
 import appLocaleFn from './locale/app-locale';
 import appThemeFn from './app-theme';
 

--- a/apis/supernova/package.json
+++ b/apis/supernova/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "extend": "3.0.2",
-    "node-event-emitter": "0.0.1"
+    "node-event-emitter": "0.0.1",
+    "regenerator-runtime": "0.13.3"
   }
 }

--- a/apis/supernova/src/index.js
+++ b/apis/supernova/src/index.js
@@ -1,3 +1,4 @@
+import 'regenerator-runtime/runtime'; // Polyfill for using async/await
 import generator from './generator';
 
 export { generator };


### PR DESCRIPTION
Since supernova now is a peer dependency to nucleus it will be the first module imported - polyfills should therefore be registered by supernova instead of nucleus.
