### PR TITLE
chore(deps): rollback semver major version

### DIFF
--- a/apis/nucleus/package.json
+++ b/apis/nucleus/package.json
@@ -48,6 +48,6 @@
     "react-test-renderer": "16.12.0",
     "react-window": "1.8.5",
     "react-window-infinite-loader": "1.0.5",
-    "semver": "7.1.1"
+    "semver": "6.3.0"
   }
 }

--- a/apis/nucleus/src/sn/__tests__/type.spec.js
+++ b/apis/nucleus/src/sn/__tests__/type.spec.js
@@ -14,7 +14,7 @@ describe('type', () => {
     [{ default: create }] = aw.mock(
       [
         [require.resolve('@nebula.js/supernova'), () => ({ generator: SNFactory })],
-        ['**/semver/functions/satisfies.js', () => satisfies],
+        ['**/semver.js', () => ({ satisfies })],
         ['**/load.js', () => ({ load })],
       ],
       ['../type']

--- a/apis/nucleus/src/sn/type.js
+++ b/apis/nucleus/src/sn/type.js
@@ -1,5 +1,5 @@
 import { generator as SNFactory } from '@nebula.js/supernova';
-import satisfies from 'semver/functions/satisfies';
+import { satisfies } from 'semver';
 import { load } from './load';
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -16292,11 +16292,6 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.1.tgz#29104598a197d6cbe4733eeecbe968f7b43a9667"
-  integrity sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==
-
 semver@^5.7.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"


### PR DESCRIPTION
Rollback `semver` to `6.x.0` to avoid circular dependencies, which cisandbox doesn't seem to be able to handle
