### PR TITLE
feat(cli-serve): serve custom snapshots

### DIFF
--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -256,6 +256,7 @@ const Cell = forwardRef(({ corona, model, initialSnOptions, initialError, onMoun
           clonedLayout = (await state.sn.component.setSnapshotData(clonedLayout)) || clonedLayout;
         }
         return {
+          // TODO - this snapshot format needs to be documented and governed
           key: String(+Date.now()),
           meta: {
             language: translator.language(),

--- a/apis/snapshooter/lib/snapshooter.js
+++ b/apis/snapshooter/lib/snapshooter.js
@@ -50,6 +50,9 @@ function snapshooter({ snapshotUrl, chrome = {} } = {}) {
     getStoredSnapshot(id) {
       return snapshots[id];
     },
+    getStoredSnapshots() {
+      return Object.keys(snapshots).map(key => snapshots[key]);
+    },
     storeSnapshot(snapshot) {
       if (!snapshot) {
         throw new Error('Empty snapshot');

--- a/commands/serve/lib/snapshot-router.js
+++ b/commands/serve/lib/snapshot-router.js
@@ -50,5 +50,9 @@ module.exports = function router({ base, snapshotUrl, snapshooter }) {
     }
   });
 
+  r.get('/snapshots', (req, res) => {
+    res.json(snapshooter.getStoredSnapshots());
+  });
+
   return r;
 };

--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -6,7 +6,7 @@ const express = require('express');
 const webpack = require('webpack');
 const WebpackDevServer = require('webpack-dev-server');
 
-const snapshooter = require('@nebula.js/snapshooter');
+const snapshooterFn = require('@nebula.js/snapshooter');
 const snapshotRouter = require('./snapshot-router');
 
 module.exports = async ({
@@ -27,10 +27,16 @@ module.exports = async ({
 
   const snapshotRoute = '/njs';
 
+  const snapshooter = snapshooterFn({ snapshotUrl: `http://${host}:${port}/eRender.html` });
+
+  (serveConfig.snapshots || []).forEach(s => {
+    snapshooter.storeSnapshot(s);
+  });
+
   const snapRouter = snapshotRouter({
     base: `http://${host}:${port}${snapshotRoute}`,
     snapshotUrl: `http://${host}:${port}/eRender.html`,
-    snapshooter: snapshooter({ snapshotUrl: `http://${host}:${port}/eRender.html` }),
+    snapshooter,
   });
 
   const themes = serveConfig.themes || [];


### PR DESCRIPTION
read and serve custom snapshots from `nebula.config.js` to allow simple testing without backend:


```js
// nebula.config.js
module.exports = {
  serve: {
    snapshots: [{
      key: 'basic',
      meta: {
        size: { width: 600, height: 600 },
        language: 'sv-SE',
        theme: 'dark',
        appLayout: { qLocaleInfo: {} },
      },
      layout: {
        showTitles: false,
        qHyperCube: {}
      }
    }]
  }
}
```

A given snapshot can be provided as a query parameter under the /render route in order to render the supernova without a data backend, e.g. `http://localhost:8000/render/?snapshot=basic`