### PR TITLE
fix(cli-serve): show scrollbar in hub

### DIFF
--- a/commands/serve/web/eHub.html
+++ b/commands/serve/web/eHub.html
@@ -10,7 +10,7 @@
         height: 100%;
         margin: 0;
         padding: 0;
-        overflow: hidden;
+        overflow: auto;
       }
 
       body {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

When a lot of apps appeared in the hub, the bottom ones could become unaccessible.
