### PR TITLE
chore(deps): avoid lock on peer dependencies

### DIFF
--- a/apis/nucleus/package.json
+++ b/apis/nucleus/package.json
@@ -28,12 +28,12 @@
     "spec": "scriptappy-from-jsdoc -c ./spec/spec.conf.js"
   },
   "peerDependencies": {
-    "@material-ui/core": "4.9.0",
-    "@material-ui/icons": "4.5.1",
-    "@material-ui/styles": "4.9.0",
-    "@nebula.js/supernova": "0.1.0-alpha.27",
-    "react": "16.12.0",
-    "react-dom": "16.12.0"
+    "@material-ui/core": "^4.9.0",
+    "@material-ui/icons": "^4.5.1",
+    "@material-ui/styles": "^4.9.0",
+    "@nebula.js/supernova": "^0.1.0-alpha.27",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   },
   "devDependencies": {
     "@material-ui/core": "4.9.0",

--- a/apis/test-utils/package.json
+++ b/apis/test-utils/package.json
@@ -24,7 +24,7 @@
     "prepublishOnly": "rm -rf dist && yarn run build"
   },
   "peerDependencies": {
-    "@nebula.js/supernova": "0.1.0-alpha.27"
+    "@nebula.js/supernova": "^0.1.0-alpha.27"
   },
   "devDependencies": {
     "regenerator-runtime": "0.13.3"

--- a/examples/sn-hello-react/package.json
+++ b/examples/sn-hello-react/package.json
@@ -21,7 +21,7 @@
     "start": "nebula serve --no-build"
   },
   "peerDependencies": {
-    "@nebula.js/supernova": "0.1.0-alpha.27"
+    "@nebula.js/supernova": "^0.1.0-alpha.27"
   },
   "devDependencies": {
     "@babel/cli": "7.4.4",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,11 +8,11 @@
   "keywords": [],
   "scripts": {},
   "peerDependencies": {
-    "@material-ui/core": "4.9.0",
-    "@material-ui/icons": "4.5.1",
-    "@material-ui/styles": "4.9.0",
-    "react": "16.12.0",
-    "react-dom": "16.12.0"
+    "@material-ui/core": "^4.9.0",
+    "@material-ui/icons": "^4.5.1",
+    "@material-ui/styles": "^4.9.0",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   },
   "devDependencies": {
     "@material-ui/core": "4.9.0",


### PR DESCRIPTION
Very little use in having locked version of peer dependencies, should simply specify the range that is required 
