### PR TITLE
feat(nucleus): show action in selection toolbar

### DIFF
--- a/apis/nucleus/__tests__/unit/selectiontoolbar.spec.jsx
+++ b/apis/nucleus/__tests__/unit/selectiontoolbar.spec.jsx
@@ -56,7 +56,6 @@ describe('<SelectionToolbar />', () => {
         key: 'confirm',
         type: 'icon-button',
         label: 'localized confirm',
-        icon: 'tick',
       });
 
       expect(item.enabled()).to.equal('confirmable');
@@ -70,7 +69,6 @@ describe('<SelectionToolbar />', () => {
         key: 'cancel',
         type: 'icon-button',
         label: 'localized cancel',
-        icon: 'close',
       });
       expect(item.enabled()).to.equal('cancelable');
       item.action();
@@ -83,7 +81,6 @@ describe('<SelectionToolbar />', () => {
         key: 'clear',
         type: 'icon-button',
         label: 'localized clear',
-        icon: 'clear-selections',
       });
       expect(item.enabled()).to.equal('clearable');
       item.action();

--- a/apis/nucleus/src/components/Header.jsx
+++ b/apis/nucleus/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { Grid, Typography } from '@material-ui/core';
 
@@ -8,6 +8,16 @@ const Header = ({ layout, sn }) => {
   const showTitle = layout && layout.showTitles && !!layout.title;
   const showSubtitle = layout && layout.showTitles && !!layout.subtitle;
   const showInSelectionActions = sn && layout && layout.qSelectionInfo && layout.qSelectionInfo.qInSelections;
+
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    if (!sn || !sn.component || !sn.component.isHooked) {
+      return;
+    }
+    sn.component.observeActions(actions => setItems(actions));
+  }, [sn]);
+
   return (
     <Grid item container wrap="nowrap" style={{ flexGrow: 0 }}>
       <Grid item zeroMinWidth xs>
@@ -30,7 +40,7 @@ const Header = ({ layout, sn }) => {
             inline
             layout={layout}
             api={sn.component.selections}
-            xItems={sn.selectionToolbar.items}
+            xItems={[...items, ...(sn.selectionToolbar.items || [])]}
           />
         )}
       </Grid>

--- a/apis/nucleus/src/components/SelectionToolbar.jsx
+++ b/apis/nucleus/src/components/SelectionToolbar.jsx
@@ -25,7 +25,6 @@ const SelectionToolbarWithDefault = ({ layout, api, xItems = [], onCancel = () =
       key: 'clear',
       type: 'icon-button',
       label: translator.get('Selection.Clear'),
-      icon: 'clear-selections',
       enabled: () => api.canClear(),
       action: () => api.clear(),
       getSvgIconShape: clearSelections,
@@ -34,7 +33,6 @@ const SelectionToolbarWithDefault = ({ layout, api, xItems = [], onCancel = () =
       key: 'cancel',
       type: 'icon-button',
       label: translator.get('Selection.Cancel'),
-      icon: 'close',
       enabled: () => api.canCancel(),
       action: () => {
         api.cancel();
@@ -46,7 +44,6 @@ const SelectionToolbarWithDefault = ({ layout, api, xItems = [], onCancel = () =
       key: 'confirm',
       type: 'icon-button',
       label: translator.get('Selection.Confirm'),
-      icon: 'tick',
       enabled: () => api.canConfirm(),
       action: () => {
         api.confirm();

--- a/apis/nucleus/src/components/SelectionToolbarItem.jsx
+++ b/apis/nucleus/src/components/SelectionToolbarItem.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 
 import { IconButton, Button, MenuItem, ListItemIcon, Typography } from '@material-ui/core';
 
@@ -12,28 +12,8 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const Item = ({ layout, item }) => {
-  const getDisabled = () => (typeof item.enabled === 'function' ? !item.enabled() : false);
-  const [disabled, setDisabled] = useState(false);
-
-  const onChanged = () => {
-    setDisabled(getDisabled());
-  };
-  // Handle changed from action-hero
-  useEffect(() => {
-    if (item && item.action && item.on) {
-      item.on('changed', onChanged);
-      return () => {
-        item.removeListener('changed', onChanged);
-      };
-    }
-    return undefined;
-  }, []);
-
-  // Handle layout changed
-  useEffect(() => {
-    onChanged();
-  }, [layout]);
+const Item = ({ item }) => {
+  const disabled = typeof item.enabled === 'function' ? !item.enabled() : !!item.disabled;
 
   const { icon } = useStyles();
   const hasSvgIconShape = typeof item.getSvgIconShape === 'function';
@@ -46,6 +26,8 @@ const Item = ({ layout, item }) => {
       </MenuItem>
     );
   }
+
+  // TODO - handle active/toggled state
 
   return item.type === 'button' ? (
     <Button

--- a/apis/nucleus/src/components/__tests__/selectiontoolbaritem.spec.jsx
+++ b/apis/nucleus/src/components/__tests__/selectiontoolbaritem.spec.jsx
@@ -36,20 +36,6 @@ describe('<SelectionToolbarItem />', () => {
     types[0].props.onClick();
     expect(action.callCount).to.equal(1);
   });
-  it('should listen on changed', async () => {
-    const action = sandbox.spy();
-    const getSvgIconShape = sandbox.spy();
-    const on = sandbox.spy();
-    const removeListener = sandbox.spy();
-    const enabled = sandbox.stub().returns(true);
-    await render({ on, removeListener, action, enabled, getSvgIconShape });
-    const types = renderer.root.findAllByType(IconButton);
-    expect(types).to.have.length(1);
-    expect(types[0].props.disabled).to.equal(false);
-    enabled.returns(false);
-    on.callArg(1);
-    expect(types[0].props.disabled).to.equal(true);
-  });
   it('should render button', async () => {
     const action = sandbox.spy();
     await render({ type: 'button', label: 'foo', color: 'purple', action });

--- a/apis/supernova/src/__tests__/hooks.spec.js
+++ b/apis/supernova/src/__tests__/hooks.spec.js
@@ -418,8 +418,9 @@ describe('hooks', () => {
       stub.returns({
         action: 'action',
         icon: 'ic',
+        label: 'meh',
         active: true,
-        enabled: true,
+        disabled: true,
       });
       c.fn = () => {
         useAction(stub, []);
@@ -431,7 +432,8 @@ describe('hooks', () => {
 
       expect(ref.active).to.eql(true);
       expect(ref.getSvgIconShape()).to.eql('ic');
-      expect(ref.enabled).to.eql(true);
+      expect(ref.disabled).to.eql(true);
+      expect(ref.label).to.eql('meh');
     });
 
     it('should dispatch actions', async () => {

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -436,8 +436,8 @@ export function useAction(fn, deps) {
     ref._config = a;
 
     ref.active = a.active || false;
-    ref.enabled = !a.disabled;
-    // TODO - use disabled since enabled is true by default
+    ref.disabled = a.disabled || false;
+    ref.label = a.label || '';
     ref.getSvgIconShape = a.icon ? () => a.icon : undefined;
 
     ref.key = a.key || ref.component.__hooks.actions.length;


### PR DESCRIPTION
Show custom actions in Object selection toolbar:

![actions](https://user-images.githubusercontent.com/16324367/73725185-25b5e700-472d-11ea-9808-863885720875.gif)

