### PR TITLE
fix(supernova): fix incorrectly thrown error

### DIFF
--- a/apis/supernova/src/__tests__/hooks.spec.js
+++ b/apis/supernova/src/__tests__/hooks.spec.js
@@ -41,6 +41,15 @@ describe('hooks', () => {
     sandbox = sinon.createSandbox();
     DEV = global.__NEBULA_DEV__;
     global.__NEBULA_DEV__ = true;
+
+    // thrown errors are caught in hooks.js and logged instead using console.error,
+    // so if an error occurs we won't know it.
+    // we therefore stub the console.error method and throw the error
+    // so that a test fails properly
+    const err = e => {
+      throw e;
+    };
+    sandbox.stub(console, 'error').callsFake(err);
     if (!global.requestAnimationFrame) {
       global.requestAnimationFrame = cb => setTimeout(cb, 20);
       global.cancelAnimationFrame = clearTimeout;
@@ -422,6 +431,7 @@ describe('hooks', () => {
         useImperativeHandle(stub, []);
       };
 
+      await run(c);
       await run(c);
       expect(c.__hooks.list[0].value[1]).to.eql(ret);
       expect(c.__hooks.imperativeHandle).to.eql(ret);

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -340,18 +340,19 @@ export function useMemo(fn, deps) {
  */
 export function useImperativeHandle(fn, deps) {
   const h = getHook(++currentIndex);
-  if (__NEBULA_DEV__) {
-    if (currentComponent.__hooks.imperativeHandle) {
-      throw new Error('useImperativeHandle already used.');
+  if (!h.imperative) {
+    if (__NEBULA_DEV__) {
+      if (currentComponent.__hooks.imperativeHandle) {
+        throw new Error('useImperativeHandle already used.');
+      }
     }
+    h.imperative = true;
   }
-  if (!h.component) {
-    h.component = currentComponent;
-  }
+
   if (depsChanged(h.value ? h.value[0] : undefined, deps)) {
     const v = fn();
     h.value = [deps, v];
-    h.component.__hooks.imperativeHandle = v;
+    currentComponent.__hooks.imperativeHandle = v;
   }
 }
 


### PR DESCRIPTION
Fixes incorrect check for multiple `useImperativeHandle`.