### PR TITLE
fix(supernova): inject default property values

### DIFF
--- a/apis/nucleus/src/object/__tests__/hc-handler.spec.js
+++ b/apis/nucleus/src/object/__tests__/hc-handler.spec.js
@@ -31,6 +31,17 @@ describe('hc-handler', () => {
     });
   });
 
+  it('should add default values', () => {
+    expect(hc).to.eql({
+      qDimensions: [],
+      qMeasures: [],
+      qInterColumnSortOrder: [],
+      qInitialDataFetch: [],
+      qColumnOrder: [],
+      qExpansionState: [],
+    });
+  });
+
   describe('add dimension', () => {
     it('from string', () => {
       h.addDimension('A');
@@ -47,6 +58,9 @@ describe('hc-handler', () => {
               },
             ],
           },
+          qAttributeDimensions: [],
+          qAttributeExpressions: [],
+          qOtherTotalSpec: {},
         },
       ]);
     });
@@ -59,8 +73,18 @@ describe('hc-handler', () => {
         {
           qDef: {
             cId: 'uid',
+            qSortCriterias: [
+              {
+                qSortByLoadOrder: 1,
+                qSortByNumeric: 1,
+                qSortByAscii: 1,
+              },
+            ],
           },
           qTotalLabel: 'total',
+          qAttributeDimensions: [],
+          qAttributeExpressions: [],
+          qOtherTotalSpec: {},
         },
       ]);
     });
@@ -77,7 +101,19 @@ describe('hc-handler', () => {
       expect(def.dimensions.added).to.have.been.calledWithExactly(
         {
           a: 'b',
-          qDef: { cId: 'uid' },
+          qDef: {
+            cId: 'uid',
+            qSortCriterias: [
+              {
+                qSortByLoadOrder: 1,
+                qSortByNumeric: 1,
+                qSortByAscii: 1,
+              },
+            ],
+          },
+          qAttributeDimensions: [],
+          qAttributeExpressions: [],
+          qOtherTotalSpec: {},
         },
         'props'
       );
@@ -87,7 +123,24 @@ describe('hc-handler', () => {
       h.addDimension('A');
       h.addDimension('B');
       h.addDimension({ a: '=a' });
-      expect(hc.qLayoutExclude.qHyperCubeDef.qDimensions).to.eql([{ a: '=a', qDef: { cId: 'uid' } }]);
+      expect(hc.qLayoutExclude.qHyperCubeDef.qDimensions).to.eql([
+        {
+          a: '=a',
+          qDef: {
+            cId: 'uid',
+            qSortCriterias: [
+              {
+                qSortByLoadOrder: 1,
+                qSortByNumeric: 1,
+                qSortByAscii: 1,
+              },
+            ],
+          },
+          qAttributeDimensions: [],
+          qAttributeExpressions: [],
+          qOtherTotalSpec: {},
+        },
+      ]);
     });
 
     it('should update qInterColumnSortOrder', () => {
@@ -132,6 +185,8 @@ describe('hc-handler', () => {
             qSortByLoadOrder: 1,
             qSortByNumeric: -1,
           },
+          qAttributeDimensions: [],
+          qAttributeExpressions: [],
         },
       ]);
     });
@@ -146,6 +201,12 @@ describe('hc-handler', () => {
             cId: 'uid',
           },
           bla: 'meh',
+          qSortBy: {
+            qSortByLoadOrder: 1,
+            qSortByNumeric: -1,
+          },
+          qAttributeDimensions: [],
+          qAttributeExpressions: [],
         },
       ]);
     });
@@ -164,6 +225,12 @@ describe('hc-handler', () => {
         {
           a: 'b',
           qDef: { cId: 'uid' },
+          qSortBy: {
+            qSortByLoadOrder: 1,
+            qSortByNumeric: -1,
+          },
+          qAttributeDimensions: [],
+          qAttributeExpressions: [],
         },
         'props'
       );
@@ -174,7 +241,18 @@ describe('hc-handler', () => {
       h.addMeasure('B');
       h.addMeasure('C');
       h.addMeasure({ a: '=a' });
-      expect(hc.qLayoutExclude.qHyperCubeDef.qMeasures).to.eql([{ a: '=a', qDef: { cId: 'uid' } }]);
+      expect(hc.qLayoutExclude.qHyperCubeDef.qMeasures).to.eql([
+        {
+          a: '=a',
+          qDef: { cId: 'uid' },
+          qSortBy: {
+            qSortByLoadOrder: 1,
+            qSortByNumeric: -1,
+          },
+          qAttributeDimensions: [],
+          qAttributeExpressions: [],
+        },
+      ]);
     });
 
     it('should update qInterColumnSortOrder', () => {

--- a/apis/nucleus/src/object/hc-handler.js
+++ b/apis/nucleus/src/object/hc-handler.js
@@ -26,13 +26,6 @@ function removeIndex(array, index) {
 const nxDimension = f => ({
   qDef: {
     qFieldDefs: [f],
-    qSortCriterias: [
-      {
-        qSortByLoadOrder: 1,
-        qSortByNumeric: 1,
-        qSortByAscii: 1,
-      },
-    ],
   },
 });
 
@@ -40,16 +33,15 @@ const nxMeasure = f => ({
   qDef: {
     qDef: f,
   },
-  qSortBy: {
-    qSortByLoadOrder: 1,
-    qSortByNumeric: -1,
-  },
 });
 
 export default function hcHandler({ hc, def, properties }) {
   hc.qDimensions = hc.qDimensions || [];
   hc.qMeasures = hc.qMeasures || [];
   hc.qInterColumnSortOrder = hc.qInterColumnSortOrder || [];
+  hc.qInitialDataFetch = hc.qInitialDataFetch || [];
+  hc.qColumnOrder = hc.qColumnOrder || [];
+  hc.qExpansionState = hc.qExpansionState || [];
 
   const objectProperties = properties;
 
@@ -69,12 +61,24 @@ export default function hcHandler({ hc, def, properties }) {
               qDef: d.qDef || {},
             };
       dimension.qDef.cId = dimension.qDef.cId || uid();
-      if (!dimension.qDef.cId) {
-        dimension.qDef.cId = uid();
-      }
+
+      // ====== add default objects and arrays for NxDimension =====
+
+      // TODO - apply autosort properties based on tags
+      dimension.qDef.qSortCriterias = dimension.qDef.qSortCriterias || [
+        {
+          qSortByLoadOrder: 1,
+          qSortByNumeric: 1,
+          qSortByAscii: 1,
+        },
+      ];
+
+      dimension.qOtherTotalSpec = dimension.qOtherTotalSpec || {};
+      dimension.qAttributeExpressions = dimension.qAttributeExpressions || [];
+      dimension.qAttributeDimensions = dimension.qAttributeDimensions || [];
+      // ========= end defaults =============
 
       if (hc.qDimensions.length < h.maxDimensions()) {
-        // TODO - apply autosort properties based on tags
         hc.qDimensions.push(dimension);
         addIndex(hc.qInterColumnSortOrder, hc.qDimensions.length - 1);
         def.dimensions.added(dimension, objectProperties);
@@ -101,9 +105,15 @@ export default function hcHandler({ hc, def, properties }) {
               qDef: m.qDef || {},
             };
       measure.qDef.cId = measure.qDef.cId || uid();
-      if (!measure.qDef.cId) {
-        measure.qDef.cId = uid();
-      }
+
+      // ====== add default objects and arrays for NxMeasure =====
+      measure.qSortBy = measure.qSortBy || {
+        qSortByLoadOrder: 1,
+        qSortByNumeric: -1,
+      };
+
+      measure.qAttributeDimensions = measure.qAttributeDimensions || [];
+      measure.qAttributeExpressions = measure.qAttributeExpressions || [];
 
       if (hc.qMeasures.length < h.maxMeasures()) {
         hc.qMeasures.push(measure);

--- a/commands/serve/web/components/property-panel/HyperCube.jsx
+++ b/commands/serve/web/components/property-panel/HyperCube.jsx
@@ -31,6 +31,7 @@ export default function HyperCube({ model, target, properties }) {
       hcHandler({
         def: target,
         hc: getValue(properties, target.propertyPath),
+        properties,
       }),
     [properties]
   );


### PR DESCRIPTION
The hypercube/measure/dimension definition should have the default object/array properties injected to make it easier to modify those properties at deeper levels.