### PR TITLE
feat(cli-serve): log build result on watch

### DIFF
--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -150,9 +150,14 @@ module.exports = async ({
   });
 
   if (watcher) {
+    let inError = false;
     watcher.on('event', event => {
       if (event.code === 'ERROR') {
+        inError = true;
         server.sockWrite(server.sockets, 'errors', [event.error.stack]);
+      } else if (event.code === 'BUNDLE_END' && inError) {
+        inError = false;
+        server.sockWrite(server.sockets, 'ok');
       }
     });
   }


### PR DESCRIPTION
- log status when using watch with `build`
- reset error overlay when build is successful again

![log-watch](https://user-images.githubusercontent.com/16324367/74449733-4690e180-4e7d-11ea-8398-40aaf4cb1871.gif)


fixes #36 