### PR TITLE
refactor(supernova): change return value for useAction and useRect

### DIFF
--- a/apis/supernova/src/__tests__/hooks.spec.js
+++ b/apis/supernova/src/__tests__/hooks.spec.js
@@ -484,7 +484,7 @@ describe('hooks', () => {
         action: spy,
       });
       c.fn = () => {
-        [act] = useAction(stub, []);
+        act = useAction(stub, []);
       };
 
       run(c);
@@ -578,7 +578,7 @@ describe('hooks', () => {
         let r;
         element.getBoundingClientRect.returns({ left: 1, top: 2, width: 3, height: 4 });
         c.fn = () => {
-          [r] = useRect();
+          r = useRect();
         };
 
         run(c);
@@ -602,7 +602,7 @@ describe('hooks', () => {
         let r;
         element.getBoundingClientRect.returns({ left: 1, top: 2, width: 3, height: 4 });
         c.fn = () => {
-          [r] = useRect();
+          r = useRect();
         };
 
         run(c);

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -449,7 +449,7 @@ export function usePromise(p, deps) {
 /**
  * @param {module:supernova~ActionFactory} fn
  * @param {Array<any>=} deps
- * @returns {Array<function>}
+ * @returns {function}
  */
 export function useAction(fn, deps) {
   const [ref] = useState({
@@ -475,8 +475,7 @@ export function useAction(fn, deps) {
     dispatchActions(ref.component);
   }, deps);
 
-  // TODO - return array of just action?
-  return [ref.action];
+  return ref.action;
 }
 
 /**
@@ -487,7 +486,7 @@ export function useAction(fn, deps) {
  * @property {number} height
  */
 /**
- * @returns {Array<module:supernova~Rect>}
+ * @returns {module:supernova~Rect}
  */
 export function useRect() {
   const element = useElement();
@@ -524,8 +523,7 @@ export function useRect() {
     };
   }, [element]);
 
-  // TODO - return array or just rect?
-  return [rect];
+  return rect;
 }
 
 /**

--- a/test/component/hooks/hooked.fix.js
+++ b/test/component/hooks/hooked.fix.js
@@ -29,7 +29,7 @@ function sn() {
 
       const { passive, active, select } = useConstraints();
 
-      const [act] = useAction(
+      const act = useAction(
         () => ({
           action() {
             setActed(true);


### PR DESCRIPTION
BREAKING CHANGE: returned value from useAction and useRect now return a single value instead of an array

