### PR TITLE
test: exclude files

### DIFF
--- a/aw.config.js
+++ b/aw.config.js
@@ -4,7 +4,7 @@ module.exports = {
   },
   mocks: [],
   nyc: {
-    exclude: ['**/commands/**', '**/__stories__/**'],
+    exclude: ['**/commands/**', '**/__stories__/**', '**/apis/supernova/index.js', '**/apis/nucleus/index.js'],
   },
 };
 


### PR DESCRIPTION
## Motivation

This excludes root files which only requires different bundles depending on productions vs development

