### PR TITLE
fix(supernova): return value from last run

### DIFF
--- a/apis/supernova/__tests__/unit/creator.spec.js
+++ b/apis/supernova/__tests__/unit/creator.spec.js
@@ -62,7 +62,7 @@ describe('creator', () => {
       hooked = {
         __hooked: true,
         initiate: sinon.spy(),
-        run: sinon.spy(),
+        run: sinon.stub(),
         teardown: sinon.spy(),
         runSnaps: sinon.spy(),
         observeActions: sinon.spy(),
@@ -305,6 +305,26 @@ describe('creator', () => {
 
       c.render({});
       expect(hooked.run.callCount).to.equal(2);
+    });
+
+    it('should return value from run', () => {
+      const c = create(generator, opts, env).component;
+      hooked.run.returns('fast');
+      const r = c.render({});
+      expect(r).to.equal('fast');
+    });
+
+    it('should return previous return value when nothing has changed', () => {
+      const c = create(generator, opts, env).component;
+      // inital run
+      hooked.run.returns('fast');
+      const run1 = c.render({});
+      expect(run1).to.equal('fast');
+
+      const run2 = c.render({});
+      expect(run2).to.equal('fast');
+
+      expect(hooked.run.callCount).to.equal(1);
     });
   });
 

--- a/apis/supernova/src/creator.js
+++ b/apis/supernova/src/creator.js
@@ -155,9 +155,10 @@ function createWithHooks(generator, opts, env) {
 
       if (changed) {
         hasRun = true;
-        return generator.component.run(this);
+        this.currentResult = generator.component.run(this);
+        return this.currentResult;
       }
-      return Promise.resolve();
+      return this.currentResult || Promise.resolve();
     },
     resize() {
       // resize should never really by necesseary since the ResizeObserver


### PR DESCRIPTION
Fix issue where a call to `render` that takes time could be circumvented by calling another `render` with the same parameters. Since the second call does not contain any changes, we would return an already resolved promise even if the previous call was still unresolved.

Fix it by storing the return value from the last changed call and return that when `render` is called without changes.
