### PR TITLE
fix(supernova): enable exlicit resize

### DIFF
--- a/apis/supernova/__tests__/unit/creator.spec.js
+++ b/apis/supernova/__tests__/unit/creator.spec.js
@@ -67,6 +67,7 @@ describe('creator', () => {
         runSnaps: sinon.spy(),
         observeActions: sinon.spy(),
         getImperativeHandle: sinon.stub(),
+        updateRectOnNextRun: sinon.spy(),
       };
       hook.returns(hooked);
       fnComponent = sinon.spy();
@@ -116,7 +117,14 @@ describe('creator', () => {
     it('should initiate hook on mount', () => {
       const c = create(generator, opts, env).component;
       c.mounted('element');
-      expect(hooked.initiate).to.have.been.calledWithExactly(c);
+      expect(hooked.initiate).to.have.been.calledWithExactly(c, { explicitResize: false });
+      expect(c.context.element).to.equal('element');
+    });
+
+    it('should initiate with explicitResize on mount', () => {
+      const c = create(generator, { explicitResize: true, ...opts }, env).component;
+      c.mounted('element');
+      expect(hooked.initiate).to.have.been.calledWithExactly(c, { explicitResize: true });
       expect(c.context.element).to.equal('element');
     });
 
@@ -126,9 +134,10 @@ describe('creator', () => {
       expect(hooked.teardown).to.have.been.calledWithExactly(c);
     });
 
-    it('should run on resize', () => {
+    it('should schedule update on rect and run on resize', () => {
       const c = create(generator, opts, env).component;
       c.resize();
+      expect(hooked.updateRectOnNextRun).to.have.been.calledWithExactly(c);
       expect(hooked.run).to.have.been.calledWithExactly(c);
     });
 

--- a/apis/supernova/src/creator.js
+++ b/apis/supernova/src/creator.js
@@ -81,7 +81,9 @@ function createWithHooks(generator, opts, env) {
     created() {},
     mounted(element) {
       this.context.element = element;
-      generator.component.initiate(c);
+      generator.component.initiate(c, {
+        explicitResize: !!opts.explicitResize,
+      });
     },
     render(r) {
       let changed = !hasRun || false;
@@ -164,6 +166,7 @@ function createWithHooks(generator, opts, env) {
       // resize should never really by necesseary since the ResizeObserver
       // in useRect observes changes on the size of the object, the only time it might
       // be necessary is on IE 11 when the object is resized without the window changing size
+      generator.component.updateRectOnNextRun(this);
       return this.render();
     },
     willUnmount() {


### PR DESCRIPTION
## Motivation

Since ResizeObserver isn't available in IE11 and Edge we need a way to explicitly trigger a resize of a component.
