### PR TITLE
fix: load remote supernova

### DIFF
--- a/commands/serve/docker-compose.yml
+++ b/commands/serve/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   engine:
-    image: qlikcore/engine:${ENGINE_VERSION:-12.477.0}
+    image: qlikcore/engine:${ENGINE_VERSION:-12.556.0}
     # restart: always
     command: -S AcceptEULA=${ACCEPT_EULA:-no} -S DocumentDirectory=/apps
     ports:

--- a/commands/serve/lib/serve.js
+++ b/commands/serve/lib/serve.js
@@ -159,7 +159,9 @@ module.exports = async argv => {
     if (watcher) {
       watcher.close();
     }
-    await ww.close();
+    if (ww) {
+      await ww.close();
+    }
     server.close();
   };
 

--- a/commands/serve/web/hot.js
+++ b/commands/serve/web/hot.js
@@ -2,15 +2,16 @@ import * as supernova from '@nebula.js/supernova';
 
 import { requireFrom } from 'd3-require';
 
-const getModule = name => {
-  const r = requireFrom(async n => `/pkg/${encodeURIComponent(n)}`);
+const getModule = (name, url) => {
+  const localResolve = n => `/pkg/${encodeURIComponent(n)}`;
+  const remoteResolve = n => n;
+  const resolve = url ? remoteResolve : localResolve;
+  const r = requireFrom(async n => resolve(n));
   const a = r.alias({
     '@nebula.js/supernova': supernova,
   });
-  return a(name);
+  return a(url || name);
 };
-
-const getRemoteModule = url => requireFrom(() => url)();
 
 const hotListeners = {};
 
@@ -41,7 +42,7 @@ window.onHotChange = onHotChange;
 
 export default function initiateWatch(info) {
   const update = () => {
-    (info.supernova.url ? getRemoteModule(info.supernova.url) : getModule(info.supernova.name)).then(mo => {
+    getModule(info.supernova.name, info.supernova.url).then(mo => {
       window[info.supernova.name] = mo;
       lightItUp(info.supernova.name);
     });


### PR DESCRIPTION
## Motivation

Fix loading remote supernovae e.g

`--entry https://unpkg.com/@nebula.js/sn-mekko-chart`

and bump engine docker version
