### PR TITLE
refactor: change `theme.key` to `theme.id`

### DIFF
--- a/apis/nucleus/src/__tests__/app-theme.spec.js
+++ b/apis/nucleus/src/__tests__/app-theme.spec.js
@@ -31,7 +31,7 @@ describe('app-theme', () => {
         root,
         themes: [
           {
-            key: 'darkish',
+            id: 'darkish',
             load: () =>
               Promise.resolve({
                 type: 'dark',
@@ -57,7 +57,7 @@ describe('app-theme', () => {
         root,
         themes: [
           {
-            key: 'darkish',
+            id: 'darkish',
             load: () => new Promise(resolve => setTimeout(resolve, 6000)),
           },
         ],

--- a/apis/nucleus/src/app-theme.js
+++ b/apis/nucleus/src/app-theme.js
@@ -6,21 +6,21 @@ const timed = (t, v) => new Promise(resolve => setTimeout(() => resolve(v), t));
 const LOAD_THEME_TIMEOUT = 5000;
 
 export default function appTheme({ themes = [], root } = {}) {
-  const theme = themeFn();
+  const wrappedTheme = themeFn();
 
-  const setTheme = async themeName => {
-    const found = themes.filter(t => t.key === themeName)[0];
-    let muiTheme = themeName === 'dark' ? 'dark' : 'light';
+  const setTheme = async themeId => {
+    const found = themes.filter(t => t.id === themeId)[0];
+    let muiTheme = themeId === 'dark' ? 'dark' : 'light';
     if (found && found.load) {
       try {
         const raw = await Promise.race([found.load(), timed(LOAD_THEME_TIMEOUT, { __timedOut: true })]);
         if (raw.__timedOut) {
           if (__NEBULA_DEV__) {
-            console.warn(`Timeout when loading theme '${themeName}'`); // eslint-disable-line no-console
+            console.warn(`Timeout when loading theme '${themeId}'`); // eslint-disable-line no-console
           }
         } else {
           muiTheme = raw.type === 'dark' ? 'dark' : 'light';
-          theme.internalAPI.setTheme(raw, themeName);
+          wrappedTheme.internalAPI.setTheme(raw, themeId);
           root.setMuiThemeName(muiTheme);
         }
       } catch (e) {
@@ -29,11 +29,11 @@ export default function appTheme({ themes = [], root } = {}) {
         }
       }
     } else {
-      theme.internalAPI.setTheme(
+      wrappedTheme.internalAPI.setTheme(
         {
           type: muiTheme,
         },
-        themeName
+        themeId
       );
       root.setMuiThemeName(muiTheme);
     }
@@ -41,6 +41,6 @@ export default function appTheme({ themes = [], root } = {}) {
 
   return {
     setTheme,
-    externalAPI: theme.externalAPI,
+    externalAPI: wrappedTheme.externalAPI,
   };
 }

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -11,7 +11,7 @@ import { create as typesFn } from './sn/types';
 
 /**
  * @interface ThemeInfo
- * @property {string} key Theme identifier
+ * @property {string} id Theme identifier
  * @property {function} load A function that should return a Promise that resolve to a raw JSON theme
  */
 

--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -86,12 +86,12 @@ module.exports = async ({
       }
 
       app.get('/themes', (req, res) => {
-        const arr = themes.map(theme => theme.key);
+        const arr = themes.map(theme => theme.id);
         res.json(arr);
       });
 
       app.get('/theme/:id', (req, res) => {
-        const t = themes.filter(theme => theme.key === req.params.id)[0];
+        const t = themes.filter(theme => theme.id === req.params.id)[0];
         if (!t) {
           res.sendStatus('404');
         } else {
@@ -110,7 +110,7 @@ module.exports = async ({
           sock: {
             port: entryWatcher && entryWatcher.port,
           },
-          themes: themes.map(theme => theme.key),
+          themes: themes.map(theme => theme.id),
         });
       });
 


### PR DESCRIPTION
## Motivation

Use `id` instead of `key` when working with themes.

BREAKING CHANGE: use id instead of key
