### PR TITLE
feat: make dims and measures optional in qae

### DIFF
--- a/apis/supernova/__tests__/unit/qae.spec.js
+++ b/apis/supernova/__tests__/unit/qae.spec.js
@@ -35,6 +35,8 @@ describe('qae', () => {
     expect(t.measures.min()).to.eql(0);
     expect(t.measures.max()).to.eql(1000);
     expect(t.measures.added()).to.equal(undefined);
+    expect(t.dimensions.isDefined()).to.equal(false);
+    expect(t.measures.isDefined()).to.equal(false);
   });
 
   it('should map provided data', () => {
@@ -74,6 +76,8 @@ describe('qae', () => {
     expect(t.measures.added()).to.equal('b');
     expect(t.measures.description()).to.equal('Angle');
     expect(t.measures.removed()).to.equal('e');
+    expect(t.dimensions.isDefined()).to.equal(true);
+    expect(t.measures.isDefined()).to.equal(true);
   });
   it('should resolve layout', () => {
     const t = qae({

--- a/apis/supernova/src/qae.js
+++ b/apis/supernova/src/qae.js
@@ -7,7 +7,8 @@ function fallback(x, value) {
   return () => x;
 }
 
-function defFn(def = {}) {
+function defFn(input) {
+  const def = input || {};
   return {
     min: typeof def.min === 'function' ? def.min : fallback(def.min, 0),
     max: typeof def.max === 'function' ? def.max : fallback(def.max, 1000),
@@ -16,6 +17,7 @@ function defFn(def = {}) {
     moved: def.moved || def.move || noop,
     removed: def.removed || def.remove || noop,
     replaced: def.replaced || def.replace || noop,
+    isDefined: () => !!input,
   };
 }
 


### PR DESCRIPTION
## Motivation
Building a chart that doesn't use either dimensions or measures will still get these injected into the qae definition. For example it defaults to allowing any number of dimensions.

Discussion: Should we instead check for "max: 0" and exclude them then?
