### PR TITLE
refactor(nucleus): rename `configured` to `createConfiguration`

### DIFF
--- a/apis/nucleus/spec/spec.json
+++ b/apis/nucleus/spec/spec.json
@@ -27,7 +27,7 @@
       },
       "examples": ["import nucleus from '@nebula.js/nucleus'\nconst nebbie = nucleus(app);"],
       "entries": {
-        "configured": {
+        "createConfiguration": {
           "description": "Creates a new `nucleus` instance using the specified configuration.\n\nThe configuration is merged with all previous instances.",
           "kind": "function",
           "params": [
@@ -40,7 +40,7 @@
             "type": "#/entries/nucleus"
           },
           "examples": [
-            "import nucleus from '@nebula.js/nucleus';\n// create a 'master' config which registers all types\nconst m = nucleus.configured({\n  types: [{\n    name: 'mekko',\n    version: '1.0.0',\n  }],\n});\n\n// create an alternate config with dark theme\n// and inherit the config from the previous\nconst d = m.configured({\n theme: 'dark'\n});\n\nm(app).create({ type: 'mekko' }); // will render the object with default theme\nd(app).create({ type: 'mekko' }); // will render the object with 'dark' theme\nnucleus(app).create({ type: 'mekko' }); // will throw error since 'mekko' is not a register type on the default instance"
+            "import nucleus from '@nebula.js/nucleus';\n// create a 'master' config which registers all types\nconst m = nucleus.createConfiguration({\n  types: [{\n    name: 'mekko',\n    version: '1.0.0',\n  }],\n});\n\n// create an alternate config with dark theme\n// and inherit the config from the previous\nconst d = m.createConfiguration({\n theme: 'dark'\n});\n\nm(app).create({ type: 'mekko' }); // will render the object with default theme\nd(app).create({ type: 'mekko' }); // will render the object with 'dark' theme\nnucleus(app).create({ type: 'mekko' }); // will throw error since 'mekko' is not a register type on the default instance"
           ]
         }
       }

--- a/apis/nucleus/src/__tests__/nucleus.spec.js
+++ b/apis/nucleus/src/__tests__/nucleus.spec.js
@@ -100,7 +100,7 @@ describe('nucleus', () => {
   });
 
   it('should avoid type duplication', () => {
-    const nuked = create.configured({ types: ['foo', 'bar', 'foo', 'foo', 'baz'] });
+    const nuked = create.createConfiguration({ types: ['foo', 'bar', 'foo', 'foo', 'baz'] });
     expect(nuked.config.types).to.eql(['foo', 'bar', 'baz']);
   });
 });

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -107,7 +107,7 @@ function nuked(configuration = {}) {
    */
   function nucleus(app, instanceConfig) {
     if (instanceConfig) {
-      return nucleus.configured(instanceConfig)(app);
+      return nucleus.createConfiguration(instanceConfig)(app);
     }
 
     let currentContext = {
@@ -280,7 +280,7 @@ function nuked(configuration = {}) {
    * @example
    * import nucleus from '@nebula.js/nucleus';
    * // create a 'master' config which registers all types
-   * const m = nucleus.configured({
+   * const m = nucleus.createConfiguration({
    *   types: [{
    *     name: 'mekko',
    *     version: '1.0.0',
@@ -289,7 +289,7 @@ function nuked(configuration = {}) {
    *
    * // create an alternate config with dark theme
    * // and inherit the config from the previous
-   * const d = m.configured({
+   * const d = m.createConfiguration({
    *  theme: 'dark'
    * });
    *
@@ -297,7 +297,7 @@ function nuked(configuration = {}) {
    * d(app).create({ type: 'mekko' }); // will render the object with 'dark' theme
    * nucleus(app).create({ type: 'mekko' }); // will throw error since 'mekko' is not a register type on the default instance
    */
-  nucleus.configured = c => nuked(mergeConfigs(configuration, c));
+  nucleus.createConfiguration = c => nuked(mergeConfigs(configuration, c));
   nucleus.config = configuration;
 
   return nucleus;

--- a/apis/supernova/spec/spec.json
+++ b/apis/supernova/spec/spec.json
@@ -273,11 +273,11 @@
         "action": {
           "type": "function"
         },
-        "disabled": {
+        "hidden": {
           "optional": true,
           "type": "boolean"
         },
-        "hidden": {
+        "disabled": {
           "optional": true,
           "type": "boolean"
         },
@@ -311,7 +311,6 @@
     },
     "ActionFactory": {
       "kind": "interface",
-      "params": [],
       "returns": {
         "type": "#/definitions/ActionDefinition"
       },
@@ -320,11 +319,11 @@
     "Constraints": {
       "kind": "interface",
       "entries": {
-        "active": {
+        "passive": {
           "optional": true,
           "type": "boolean"
         },
-        "passive": {
+        "active": {
           "optional": true,
           "type": "boolean"
         },
@@ -336,23 +335,10 @@
     },
     "EffectCallback": {
       "kind": "interface",
-      "params": [],
       "returns": {
         "optional": true,
         "type": "function"
       },
-      "entries": {}
-    },
-    "EnigmaAppModel": {
-      "kind": "interface",
-      "entries": {}
-    },
-    "EnigmaGlobalModel": {
-      "kind": "interface",
-      "entries": {}
-    },
-    "EnigmaObjectModel": {
-      "kind": "interface",
       "entries": {}
     },
     "env": {
@@ -361,22 +347,14 @@
     },
     "Factory": {
       "kind": "interface",
-      "params": [],
       "returns": {
         "type": "any"
       },
       "entries": {}
     },
-    "GenericObjectLayout": {
-      "kind": "object",
-      "entries": {}
-    },
-    "NxAppLayout": {
-      "kind": "object",
-      "entries": {}
-    },
     "ObjectSelections": {
       "kind": "interface",
+      "params": [],
       "entries": {
         "abortModal": {
           "kind": "function",
@@ -552,7 +530,6 @@
     },
     "PromiseCallback": {
       "kind": "interface",
-      "params": [],
       "returns": {
         "type": "Promise",
         "generics": [
@@ -566,16 +543,16 @@
     "Rect": {
       "kind": "interface",
       "entries": {
-        "height": {
+        "top": {
           "type": "number"
         },
         "left": {
           "type": "number"
         },
-        "top": {
+        "width": {
           "type": "number"
         },
-        "width": {
+        "height": {
           "type": "number"
         }
       }
@@ -633,11 +610,11 @@
     "SnDefinition": {
       "kind": "interface",
       "entries": {
-        "component": {
-          "type": "function"
-        },
         "qae": {
           "type": "object"
+        },
+        "component": {
+          "type": "function"
         }
       }
     },
@@ -668,6 +645,7 @@
     },
     "Theme": {
       "kind": "interface",
+      "params": [],
       "entries": {
         "getColorPickerColor": {
           "description": "Resolve a color object using the color picker palette from the provided JSON theme.",
@@ -677,13 +655,13 @@
               "name": "c",
               "kind": "object",
               "entries": {
-                "color": {
-                  "optional": true,
-                  "type": "string"
-                },
                 "index": {
                   "optional": true,
                   "type": "number"
+                },
+                "color": {
+                  "optional": true,
+                  "type": "string"
                 }
               }
             }
@@ -778,14 +756,14 @@
         "ColorPickerPalette": {
           "kind": "interface",
           "entries": {
+            "key": {
+              "type": "string"
+            },
             "colors": {
               "kind": "array",
               "items": {
                 "type": "string"
               }
-            },
-            "key": {
-              "type": "string"
             }
           }
         },
@@ -806,6 +784,23 @@
         "DataPalette": {
           "kind": "interface",
           "entries": {
+            "key": {
+              "type": "string"
+            },
+            "type": {
+              "kind": "union",
+              "items": [
+                {
+                  "kind": "literal",
+                  "value": "'pyramid'"
+                },
+                {
+                  "kind": "literal",
+                  "value": "'row'"
+                }
+              ],
+              "type": "string"
+            },
             "colors": {
               "kind": "union",
               "items": [
@@ -826,35 +821,12 @@
                 }
               ],
               "type": "any"
-            },
-            "key": {
-              "type": "string"
-            },
-            "type": {
-              "kind": "union",
-              "items": [
-                {
-                  "kind": "literal",
-                  "value": "'pyramid'"
-                },
-                {
-                  "kind": "literal",
-                  "value": "'row'"
-                }
-              ],
-              "type": "string"
             }
           }
         },
         "ScalePalette": {
           "kind": "interface",
           "entries": {
-            "colors": {
-              "kind": "array",
-              "items": {
-                "type": "string"
-              }
-            },
             "key": {
               "type": "string"
             },
@@ -871,6 +843,12 @@
                 }
               ],
               "type": "string"
+            },
+            "colors": {
+              "kind": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }

--- a/commands/serve/web/eRender.js
+++ b/commands/serve/web/eRender.js
@@ -6,7 +6,7 @@ import runFixture from './run-fixture';
 import initiateWatch from './hot';
 
 const nuke = async ({ app, supernova: { name }, themes, theme, language }) => {
-  const nuked = nucleus.configured({
+  const nuked = nucleus.createConfiguration({
     themes: themes
       ? themes.map(t => ({
           key: t,
@@ -71,7 +71,7 @@ async function renderSnapshot() {
   const element = document.querySelector('#chart-container');
   element.classList.toggle('full', true);
 
-  const n = nucleus.configured({
+  const n = nucleus.createConfiguration({
     themes: themes
       ? themes.map(t => ({
           key: t,

--- a/test/mashup/snaps/configured.js
+++ b/test/mashup/snaps/configured.js
@@ -23,7 +23,7 @@ const bar = function(env) {
 };
 
 // eslint-disable-next-line
-const configured = nucleus.configured({
+const configured = nucleus.createConfiguration({
   context: {
     theme: 'dark',
     language: 'sv-SE',


### PR DESCRIPTION
## Motivation

API polishing 💅 

BREAKING CHANGE: Use `nucleus.createConfiguration` instead of `nucleus.configured`

<!-- Write your motivation here -->
