### PR TITLE
chore: support running browserless locally

### DIFF
--- a/commands/serve/lib/init-config.js
+++ b/commands/serve/lib/init-config.js
@@ -31,6 +31,10 @@ const options = {
   port: {
     type: 'number',
   },
+  disableHostCheck: {
+    type: 'boolean',
+    default: false,
+  },
   resources: {
     type: 'string',
     description: 'Path to a folder that will be served as static files under /resources',

--- a/commands/serve/lib/serve.js
+++ b/commands/serve/lib/serve.js
@@ -143,6 +143,7 @@ module.exports = async argv => {
   const server = await webpackServe({
     host,
     port,
+    disableHostCheck: serveConfig.disableHostCheck,
     enigmaConfig,
     webIntegrationId: serveConfig.webIntegrationId,
     snName: serveConfig.type || snName,

--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -12,6 +12,7 @@ const snapshotRouter = require('./snapshot-router');
 module.exports = async ({
   host,
   port,
+  disableHostCheck,
   enigmaConfig,
   webIntegrationId,
   snName,
@@ -66,6 +67,7 @@ module.exports = async ({
     hot: dev,
     host,
     port,
+    disableHostCheck,
     overlay: {
       warnings: false,
       errors: true,


### PR DESCRIPTION
## Motivation

To be able to use the browserless docker (on mac, win) run:
nebula serve --host "0.0.0.0" --disable-host-check --enigma.host "host.docker.internal"

Run browserless:

```sh
docker run -d -p 3000:3000 --rm --name chrome browserless/chrome:1.28.0-puppeteer-1.20.0
```

Running integration tests with:
APP_ID="the-app-id" BASE_URL="http://host.docker.internal:8000" yarn test:integration --chrome.browserWSEndpoint "ws://localhost:3000" --no-launch

