### PR TITLE
fix: wait for container rect

### DIFF
--- a/apis/nucleus/src/components/Supernova.jsx
+++ b/apis/nucleus/src/components/Supernova.jsx
@@ -33,7 +33,7 @@ const Supernova = ({ sn, snOptions: options, layout, appLayout, corona }) => {
 
   // Render
   useEffect(() => {
-    if (!isMounted || !snNode || !containerNode) {
+    if (!isMounted || !snNode || !containerRect) {
       return;
     }
     // TODO remove in-selections guard for old component API


### PR DESCRIPTION
## Motivation

Ensure having a container rect before rendering else we can get an initial render and then directly another one when the container rect changes.

