### PR TITLE
feat(cli-build): add sourcemaps option to build

### DIFF
--- a/commands/build/README.md
+++ b/commands/build/README.md
@@ -16,5 +16,6 @@ Build supernova
 Options:
   --version    Show version number                                     [boolean]
   --watch, -w                                         [boolean] [default: false]
+  --sourcemaps, -m                                     [boolean] [default: true]
   -h, --help   Show help                                               [boolean]
 ```

--- a/commands/build/README.md
+++ b/commands/build/README.md
@@ -16,6 +16,6 @@ Build supernova
 Options:
   --version    Show version number                                     [boolean]
   --watch, -w                                         [boolean] [default: false]
-  --sourcemaps, -m                                     [boolean] [default: true]
+  --sourcemap, -m                                      [boolean] [default: true]
   -h, --help   Show help                                               [boolean]
 ```

--- a/commands/build/lib/build.js
+++ b/commands/build/lib/build.js
@@ -17,9 +17,10 @@ const { terser } = require('rollup-plugin-terser');
 
 const initConfig = require('./init-config');
 
-const config = ({ mode = 'production', format = 'umd', cwd = process.cwd() } = {}) => {
+const config = ({ mode = 'production', format = 'umd', cwd = process.cwd(), argv = { sourcemaps: true } } = {}) => {
   const pkg = require(path.resolve(cwd, 'package.json')); // eslint-disable-line
   const { name, version, license, author } = pkg;
+  const { sourcemaps } = argv;
 
   if (format === 'esm' && !pkg.module) {
     return false;
@@ -87,7 +88,7 @@ const config = ({ mode = 'production', format = 'umd', cwd = process.cwd() } = {
       format,
       file: format === 'esm' && pkg.module ? pkg.module : pkg.main,
       name: moduleName,
-      sourcemap: true,
+      sourcemap: sourcemaps,
       globals: {
         '@nebula.js/supernova': 'supernova',
       },

--- a/commands/build/lib/build.js
+++ b/commands/build/lib/build.js
@@ -17,10 +17,10 @@ const { terser } = require('rollup-plugin-terser');
 
 const initConfig = require('./init-config');
 
-const config = ({ mode = 'production', format = 'umd', cwd = process.cwd(), argv = { sourcemaps: true } } = {}) => {
+const config = ({ mode = 'production', format = 'umd', cwd = process.cwd(), argv = { sourcemap: true } } = {}) => {
   const pkg = require(path.resolve(cwd, 'package.json')); // eslint-disable-line
   const { name, version, license, author } = pkg;
-  const { sourcemaps } = argv;
+  const { sourcemap } = argv;
 
   if (format === 'esm' && !pkg.module) {
     return false;
@@ -88,7 +88,7 @@ const config = ({ mode = 'production', format = 'umd', cwd = process.cwd(), argv
       format,
       file: format === 'esm' && pkg.module ? pkg.module : pkg.main,
       name: moduleName,
-      sourcemap: sourcemaps,
+      sourcemap,
       globals: {
         '@nebula.js/supernova': 'supernova',
       },

--- a/commands/build/lib/init-config.js
+++ b/commands/build/lib/init-config.js
@@ -17,8 +17,8 @@ const options = {
     alias: 'w',
     default: false,
   },
-  sourcemaps: {
-    description: 'Generate source maps',
+  sourcemap: {
+    description: 'Generate source map',
     type: 'boolean',
     alias: 'm',
     default: true,

--- a/commands/build/lib/init-config.js
+++ b/commands/build/lib/init-config.js
@@ -17,6 +17,12 @@ const options = {
     alias: 'w',
     default: false,
   },
+  sourcemaps: {
+    description: 'Generate source maps',
+    type: 'boolean',
+    alias: 'm',
+    default: true,
+  },
 };
 
 module.exports = yargs =>


### PR DESCRIPTION
## Motivation

For integrated uses of the built packages we sometimes need to disable sourcemaps, this adds an option to do that via the build command.
