### PR TITLE
test: exclude locale and theme entry point

### DIFF
--- a/aw.config.js
+++ b/aw.config.js
@@ -9,6 +9,8 @@ module.exports = {
       '**/__stories__/**',
       '**/apis/supernova/index.js',
       '**/apis/nucleus/index.js',
+      '**/apis/locale/index.js',
+      '**/apis/theme/index.js',
       '**/apis/test-utils/index.js',
       '**/packages/ui/icons/**/*.js', // Exclude the defined icons but test the `<SvgIcon />`
     ],


### PR DESCRIPTION
## Motivation

Exclude the `locale` and `theme` package entry point since it only required the production or dev entry point.
