### PR TITLE
feat(nucleus): add flags api

### DIFF
--- a/apis/nucleus/src/__tests__/nucleus.spec.js
+++ b/apis/nucleus/src/__tests__/nucleus.spec.js
@@ -6,6 +6,7 @@ describe('nucleus', () => {
   let sandbox;
   let rootApp;
   let translator;
+  let typesFn;
 
   before(() => {
     sandbox = sinon.createSandbox({ useFakeTimers: true });
@@ -14,6 +15,7 @@ describe('nucleus', () => {
     appThemeFn = sandbox.stub();
     rootApp = sandbox.stub();
     translator = { add: sandbox.stub(), language: sandbox.stub() };
+    typesFn = sandbox.stub();
     [{ default: create }] = aw.mock(
       [
         [require.resolve('../locale/app-locale.js'), () => () => ({ translator })],
@@ -21,7 +23,8 @@ describe('nucleus', () => {
         [require.resolve('../components/selections/AppSelections.jsx'), () => () => ({})],
         [require.resolve('../object/create-session-object.js'), () => createObject],
         [require.resolve('../object/get-object.js'), () => getObject],
-        [require.resolve('../sn/types.js'), () => ({ create: () => ({}) })],
+        [require.resolve('../sn/types.js'), () => ({ create: typesFn })],
+        [require.resolve('../flags/flags.js'), () => () => 'flags'],
         [require.resolve('../app-theme.js'), () => appThemeFn],
       ],
       ['../index.js']
@@ -32,12 +35,28 @@ describe('nucleus', () => {
     createObject.returns('created object');
     getObject.returns('got object');
     appThemeFn.returns({ externalAPI: 'internal', setTheme: sandbox.stub() });
+    typesFn.returns({});
     rootApp.returns([{}]);
   });
 
   afterEach(() => {
     sandbox.reset();
     sandbox.restore();
+  });
+
+  it('should initiate types with a public galaxy interface', () => {
+    create('app', {
+      anything: {
+        some: 'thing',
+      },
+    });
+    expect(typesFn.getCall(0).args[0].corona.public.galaxy).to.eql({
+      anything: {
+        some: 'thing',
+      },
+      flags: 'flags',
+      translator,
+    });
   });
 
   it('should wait for theme before rendering object', async () => {

--- a/apis/nucleus/src/flags/flags.js
+++ b/apis/nucleus/src/flags/flags.js
@@ -1,0 +1,14 @@
+export default function(flags = {}) {
+  /**
+   * @interface Flags
+   */
+
+  return /** @lends Flags */ {
+    /**
+     * Checks whether the specified flag is enabled.
+     * @param {string} flag - The value flag to check.
+     * @returns {boolean} True if the specified flag is enabled, false otherwise.
+     */
+    isEnabled: f => flags[f] === true,
+  };
+}

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -7,6 +7,7 @@ import AppSelectionsPortal from './components/selections/AppSelections';
 
 import create from './object/create-session-object';
 import get from './object/get-object';
+import flagsFn from './flags/flags';
 import { create as typesFn } from './sn/types';
 
 /**
@@ -69,8 +70,9 @@ const DEFAULT_CONFIG = /** @lends Configuration */ {
    * @type {(ThemeInfo[])=}
    */
   themes: [],
+
   /** @type {object=} */
-  env: {},
+  anything: {},
 
   /**
    * @type {SnapshotConfiguration=}
@@ -98,7 +100,8 @@ const mergeConfigs = (base, c) => ({
   },
   types: mergeArray(base.types, c.types),
   themes: mergeArray(base.themes, c.themes),
-  env: mergeObj(base.env, c.env),
+  flags: mergeObj(base.flags, c.flags),
+  anything: mergeObj(base.anything, c.anything),
 });
 
 function nuked(configuration = {}) {
@@ -137,9 +140,14 @@ function nuked(configuration = {}) {
     });
 
     const publicAPIs = {
-      env: {
+      galaxy: /** @lends Galaxy */ {
+        /** @type {Translator} */
         translator: locale.translator,
-        nucleus,
+        // TODO - validate flags input
+        /** @type {Flags} */
+        flags: flagsFn(configuration.flags),
+        /** @type {object} */
+        anything: configuration.anything,
       },
       theme: appTheme.externalAPI,
       translator: locale.translator,

--- a/apis/nucleus/src/sn/__tests__/load.spec.js
+++ b/apis/nucleus/src/sn/__tests__/load.spec.js
@@ -4,9 +4,6 @@ describe('load', () => {
   let corona = {};
   beforeEach(() => {
     corona = {
-      public: {
-        env: 'env',
-      },
       config: {
         load: sinon.stub(),
       },
@@ -29,7 +26,7 @@ describe('load', () => {
   it('should call load() with name and version', async () => {
     const loader = sinon.stub();
     load('pie', '1.0.0', corona, loader);
-    expect(loader).to.have.been.calledWithExactly({ name: 'pie', version: '1.0.0' }, 'env');
+    expect(loader).to.have.been.calledWithExactly({ name: 'pie', version: '1.0.0' });
   });
 
   it('should load valid sn', async () => {

--- a/apis/nucleus/src/sn/load.js
+++ b/apis/nucleus/src/sn/load.js
@@ -5,21 +5,17 @@ const LOADED = {};
  * @param {object} type
  * @param {string} type.name
  * @param {string} type.version
- * @param {object} env
  * @returns {Promise<Supernova>}
  */
 
-export async function load(name, version, { config, public: { env } }, loader) {
+export async function load(name, version, { config }, loader) {
   const key = `${name}__${version}`;
   if (!LOADED[key]) {
     const sKey = `${name}${(version && ` v${version}`) || ''}`;
-    const p = (loader || config.load)(
-      {
-        name,
-        version,
-      },
-      env
-    );
+    const p = (loader || config.load)({
+      name,
+      version,
+    });
     const prom = Promise.resolve(p);
     LOADED[key] = prom
       .then(sn => {

--- a/apis/nucleus/src/sn/type.js
+++ b/apis/nucleus/src/sn/type.js
@@ -25,7 +25,7 @@ export default function create(info, corona, opts = {}) {
     },
     supernova: () =>
       load(type.name, type.version, corona, opts.load).then(SNDefinition => {
-        sn = sn || SNFactory(SNDefinition, corona.public.env);
+        sn = sn || SNFactory(SNDefinition, corona.public.galaxy);
         stringified = JSON.stringify(sn.qae.properties.initial);
         return sn;
       }),

--- a/apis/supernova/__tests__/unit/creator.spec.js
+++ b/apis/supernova/__tests__/unit/creator.spec.js
@@ -36,13 +36,13 @@ describe('creator', () => {
           properties: {},
         },
       };
-      const env = {};
+      const galaxy = {};
       const params = {
         model: {},
         app: {},
       };
 
-      const c = create(generator, params, env).component;
+      const c = create(generator, params, galaxy).component;
 
       ['created', 'mounted', 'render', 'resize', 'willUnmount', 'destroy'].forEach(key => {
         c[key]('a');
@@ -56,7 +56,7 @@ describe('creator', () => {
     let fnComponent;
     let generator;
     let opts;
-    let env;
+    let galaxy;
     let hooked;
     beforeEach(() => {
       hooked = {
@@ -78,7 +78,7 @@ describe('creator', () => {
           properties: {},
         },
       };
-      env = {
+      galaxy = {
         translator: { language: () => 'en' },
       };
       opts = {
@@ -90,13 +90,13 @@ describe('creator', () => {
     });
 
     it('should hook into hook API', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       expect(hook).to.have.been.calledWithExactly(fnComponent);
       expect(c.isHooked).to.equal(true);
     });
 
     it('should initiate context', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       expect(c.context).to.eql({
         model: 'model',
         app: 'app',
@@ -104,7 +104,7 @@ describe('creator', () => {
         selections: 'selections',
         element: undefined,
         theme: undefined,
-        translator: env.translator,
+        translator: galaxy.translator,
         layout: {},
         appLayout: {},
         constraints: {
@@ -115,48 +115,48 @@ describe('creator', () => {
     });
 
     it('should initiate hook on mount', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       c.mounted('element');
       expect(hooked.initiate).to.have.been.calledWithExactly(c, { explicitResize: false });
       expect(c.context.element).to.equal('element');
     });
 
     it('should initiate with explicitResize on mount', () => {
-      const c = create(generator, { explicitResize: true, ...opts }, env).component;
+      const c = create(generator, { explicitResize: true, ...opts }, galaxy).component;
       c.mounted('element');
       expect(hooked.initiate).to.have.been.calledWithExactly(c, { explicitResize: true });
       expect(c.context.element).to.equal('element');
     });
 
     it('should teardown on unmount', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       c.willUnmount();
       expect(hooked.teardown).to.have.been.calledWithExactly(c);
     });
 
     it('should schedule update on rect and run on resize', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       c.resize();
       expect(hooked.updateRectOnNextRun).to.have.been.calledWithExactly(c);
       expect(hooked.run).to.have.been.calledWithExactly(c);
     });
 
     it('should setSnapshotData', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       const layout = 'l';
       c.setSnapshotData(layout);
       expect(hooked.runSnaps).to.have.been.calledWithExactly(c, layout);
     });
 
     it('should observeActions', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       const fn = () => {};
       c.observeActions(fn);
       expect(hooked.observeActions).to.have.been.calledWithExactly(c, fn);
     });
 
     it('should get imperative handle', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       hooked.getImperativeHandle.returns('handle');
       const v = c.getImperativeHandle();
       expect(hooked.getImperativeHandle).to.have.been.calledWithExactly(c);
@@ -164,13 +164,13 @@ describe('creator', () => {
     });
 
     it('should run hook on render when params are not provided', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       c.render();
       expect(hooked.run).to.have.been.calledWithExactly(c);
     });
 
     it('should not run hook when observed values have not changed', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       const layout = 'layout';
       c.render({
         layout,
@@ -213,7 +213,7 @@ describe('creator', () => {
     });
 
     it('should run when layout has changed', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       const layout = {};
       c.render({ layout }); // initial should always run
 
@@ -225,7 +225,7 @@ describe('creator', () => {
     });
 
     it('should run when appLayout has changed', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       c.render({}); // initial should always run
 
       c.render({
@@ -239,7 +239,7 @@ describe('creator', () => {
     });
 
     it('should run when constraints have changed', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       c.render({}); // initial should always run
 
       c.render({
@@ -260,7 +260,7 @@ describe('creator', () => {
     });
 
     it('should run when options have changed', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       c.render({}); // initial should always run
 
       const foo = new (class Foo {})();
@@ -295,7 +295,7 @@ describe('creator', () => {
     });
 
     it('should run when theme name has changed', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       c.render({}); // initial should always run
 
       c.render({
@@ -307,24 +307,24 @@ describe('creator', () => {
     });
 
     it('should run when language has changed', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       c.render({}); // initial should always run
 
-      env.translator.language = () => 'sv';
+      galaxy.translator.language = () => 'sv';
 
       c.render({});
       expect(hooked.run.callCount).to.equal(2);
     });
 
     it('should return value from run', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       hooked.run.returns('fast');
       const r = c.render({});
       expect(r).to.equal('fast');
     });
 
     it('should return previous return value when nothing has changed', () => {
-      const c = create(generator, opts, env).component;
+      const c = create(generator, opts, galaxy).component;
       // inital run
       hooked.run.returns('fast');
       const run1 = c.render({});
@@ -345,13 +345,13 @@ describe('creator', () => {
         properties: {},
       },
     };
-    const env = {};
+    const galaxy = {};
     const params = {
       model: {},
       app: {},
     };
 
-    const c = create(generator, params, env).component;
+    const c = create(generator, params, galaxy).component;
 
     ['created', 'mounted', 'render', 'resize', 'willUnmount', 'destroy'].forEach(key =>
       expect(c[key]).to.be.a('function')
@@ -371,7 +371,7 @@ describe('creator', () => {
         },
       },
     };
-    const env = {};
+    const galaxy = {};
     const properties = { dummyPatched: false };
     const params = {
       model: {
@@ -382,7 +382,7 @@ describe('creator', () => {
       app: {},
     };
 
-    create(generator, params, env).component;
+    create(generator, params, galaxy).component;
 
     await params.model.setProperties(properties);
 

--- a/apis/supernova/src/creator.js
+++ b/apis/supernova/src/creator.js
@@ -37,7 +37,7 @@ const mixin = obj => {
   return obj;
 };
 
-function createWithHooks(generator, opts, env) {
+function createWithHooks(generator, opts, galaxy) {
   if (__NEBULA_DEV__) {
     if (generator.component.run !== run) {
       // eslint-disable-next-line no-console
@@ -69,14 +69,13 @@ function createWithHooks(generator, opts, env) {
       element: undefined, // set on mount
       // ---- singletons ----
       theme: undefined,
-      translator: env.translator,
+      translator: galaxy.translator,
       // --- dynamic values ---
       layout: {},
       appLayout: {},
       constraints: forcedConstraints,
       options: {},
     },
-    env,
     fn: generator.component.fn,
     created() {},
     mounted(element) {
@@ -248,13 +247,13 @@ function createClassical(generator, opts) {
   return [componentInstance, hero];
 }
 
-export default function create(generator, opts, env) {
+export default function create(generator, opts, galaxy) {
   if (typeof generator.component === 'function') {
     generator.component = hook(generator.component);
   }
   const [componentInstance, hero] =
     generator.component && generator.component.__hooked
-      ? createWithHooks(generator, opts, env)
+      ? createWithHooks(generator, opts, galaxy)
       : createClassical(generator, opts);
 
   const teardowns = [];

--- a/apis/supernova/src/generator.js
+++ b/apis/supernova/src/generator.js
@@ -1,11 +1,11 @@
 import create from './creator';
-import translator from './translator';
+// import translator from './translator';
 import qae from './qae';
 
 /**
  * The entry point for defining a supernova.
  * @interface Supernova
- * @param {object=} env
+ * @param {Galaxy} galaxy
  * @returns {SupernovaDefinition}
  * @example
  * import { useElement, useLayout } from '@nebula.js/supernova';
@@ -35,20 +35,17 @@ import qae from './qae';
 /**
  * @interface snGenerator
  * @param {Supernova} Sn
- * @param {env} env
+ * @param {Galaxy} galaxy
  * @returns {generator}
  * @private
  */
-export default function generatorFn(UserSN, env) {
+export default function generatorFn(UserSN, galaxy) {
   let sn;
 
-  const localEnv = {
-    translator,
-    ...env,
-  };
+  // TODO validate galaxy API
 
   if (typeof UserSN === 'function') {
-    sn = UserSN(localEnv);
+    sn = UserSN(galaxy);
   } else {
     sn = UserSN;
   }
@@ -73,7 +70,7 @@ export default function generatorFn(UserSN, env) {
      * @param {ObjectSelections} p.selections
      */
     create(params) {
-      const ss = create(generator, params, localEnv);
+      const ss = create(generator, params, galaxy);
       return ss;
     },
     definition: {},

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -210,12 +210,6 @@ function useInternalContext(name) {
   return ctx[name];
 }
 
-// function useInternalEnv(name) {
-//   getHook(++currentIndex);
-//   const { env } = currentComponent;
-//   return env[name];
-// }
-
 export function updateRectOnNextRun(component) {
   if (component.__hooks) {
     component.__hooks.updateRect = true;

--- a/test/component/hooks/hooked.fix.js
+++ b/test/component/hooks/hooked.fix.js
@@ -14,7 +14,7 @@ import {
   useOptions,
 } from '@nebula.js/supernova';
 
-function sn() {
+function sn({ flags }) {
   return {
     component: () => {
       const [count, setCount] = useState(0);
@@ -73,6 +73,7 @@ function sn() {
         <div class="action">${acted}</div>
         <div class="constraints">${!!passive}:${!!active}:${!!select}</div>
         <div class="options">${options.myOption}</div>
+        <div class="flags">${flags.isEnabled('MAGIC_FLAG')}:${flags.isEnabled('_UNKNOWN_')}</div>
       </div>
       `;
     },
@@ -83,6 +84,11 @@ export default function fixture() {
   return {
     type: 'sn-mounted',
     sn,
+    instanceConfig: {
+      flags: {
+        MAGIC_FLAG: true,
+      },
+    },
     snConfig: {
       options: {
         myOption: 'opts',

--- a/test/component/hooks/sn.comp.js
+++ b/test/component/hooks/sn.comp.js
@@ -73,4 +73,9 @@ describe('hooks', () => {
     const text = await page.$eval(`${snSelector} .options`, el => el.textContent);
     expect(text).to.equal('opts');
   });
+
+  it('should have true MAGIC_FLAG', async () => {
+    const text = await page.$eval(`${snSelector} .flags`, el => el.textContent);
+    expect(text).to.equal('true:false');
+  });
 });


### PR DESCRIPTION
Add possibility for feature toggling:

```js
// in nucleus config
nucleus(app, {
  flags: {
    MONKEY_DANCE: true
  }
});
```

```js
// consume in supernova
export function function s({ flags }) {
  if (flags.isEnabled('MONKEY_DANCE')) {
    return dancingMonkey();
  }
  return boringMonkey();
}
```

resolves #380 
