### PR TITLE
fix: add `cellRect` to dependencies

### DIFF
--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -298,7 +298,7 @@ const Cell = forwardRef(({ corona, model, initialSnOptions, initialError, onMoun
         return corona.config.snapshot.capture(snapshot);
       },
     }),
-    [state.sn, contentRect, layout, theme.name, appLayout]
+    [state.sn, contentRect, cellRect, layout, theme.name, appLayout]
   );
 
   // console.log('content', state);


### PR DESCRIPTION
## Motivation

This ensures having `cellRect` before exposing `takeSnapshot`
