### PR TITLE
refactor: remove `abortModal`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     docker:
       - image: circleci/node:10.19.0
-      - image: qlikcore/engine:12.612.0
+      - image: qlikcore/engine:12.657.0
         command: -S AcceptEULA=yes
       - image: browserless/chrome:1.28.0-puppeteer-1.20.0
 

--- a/apis/nucleus/src/hooks/__tests__/use-app-selections.spec.jsx
+++ b/apis/nucleus/src/hooks/__tests__/use-app-selections.spec.jsx
@@ -115,7 +115,6 @@ describe('useAppSelections', () => {
     // eslint-disable-next-line prefer-promise-reject-errors
     beginSelections.onFirstCall().returns(Promise.reject({ code: 6003 }));
     beginSelections.onSecondCall().returns(res);
-    sandbox.stub(appSel, 'abortModal').returns(Promise.resolve());
     await appModal.begin(object);
     await res;
 
@@ -149,16 +148,6 @@ describe('useAppSelections', () => {
     expect(ref.current.result[0].isModal(obj)).to.equal(true);
     expect(ref.current.result[0].isModal({})).to.equal(false);
     expect(ref.current.result[0].isModal()).to.equal(true);
-  });
-
-  it('should abort modal', async () => {
-    app.abortModal.reset();
-    await render();
-    await render();
-
-    modalObjectStore.get.returns(true);
-    await ref.current.result[0].abortModal();
-    expect(app.abortModal.callCount).to.equal(1);
   });
 
   it('can go forward', async () => {

--- a/apis/nucleus/src/hooks/__tests__/use-object-selections.spec.jsx
+++ b/apis/nucleus/src/hooks/__tests__/use-object-selections.spec.jsx
@@ -40,7 +40,6 @@ describe('useObjectSelections', () => {
     };
     appSel = {
       isModal: sandbox.stub(),
-      abortModal: sandbox.stub(),
     };
     layout = {};
     modalObjectStore = {
@@ -248,13 +247,5 @@ describe('useObjectSelections', () => {
 
     ref.current.result[0].noModal(true);
     expect(appModal.end).to.have.been.calledWithExactly(true);
-  });
-
-  it('abort modal state', async () => {
-    await render();
-    await render();
-
-    ref.current.result[0].abortModal();
-    expect(appSel.abortModal).to.have.been.calledWithExactly(true);
   });
 });

--- a/apis/nucleus/src/hooks/useAppSelections.js
+++ b/apis/nucleus/src/hooks/useAppSelections.js
@@ -71,13 +71,6 @@ function createAppSelections({ app, currentSelectionsLayout, navState }) {
       // TODO check model state
       return object ? modalObjectStore.get(key) === object : !!modalObjectStore.get(key);
     },
-    async abortModal(accept = true) {
-      if (!modalObjectStore.get(key)) {
-        return;
-      }
-      await app.abortModal(accept);
-      modalObjectStore.set(key, undefined);
-    },
     canGoForward() {
       return navState.canGoForward;
     },

--- a/apis/nucleus/src/hooks/useObjectSelections.js
+++ b/apis/nucleus/src/hooks/useObjectSelections.js
@@ -142,10 +142,6 @@ function createObjectSelections({ appSelections, appModal, model }) {
      * @returns {Promise<undefined>}
      */
     noModal: (accept = false) => appModal.end(accept),
-    /**
-     * @returns {Promise<undefined>}
-     */
-    abortModal: () => appSelections.abortModal(true),
   };
 
   eventmixin(api);


### PR DESCRIPTION
## Motivation

Remove superfluous `abortModal` from `appSelections` and `objectSelections`.


BREAKING CHANGE: `appSelections.abortModal` and `objectSelections.abortModal` removed.