### PR TITLE
test: support render configs

### DIFF
--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -41,6 +41,7 @@ module.exports = async ({
   });
 
   const themes = serveConfig.themes || [];
+  const renderConfigs = serveConfig.renderConfigs || [];
 
   if (dev) {
     const webpackConfig = require('./webpack.build.js');
@@ -98,6 +99,19 @@ module.exports = async ({
           res.sendStatus('404');
         } else {
           res.json(t.theme);
+        }
+      });
+
+      app.get('/render-configs', (_, res) => {
+        res.json(renderConfigs);
+      });
+
+      app.get('/render-config/:id', (req, res) => {
+        const renderConfig = renderConfigs.filter((r) => r.id === req.params.id)[0];
+        if (!renderConfig) {
+          res.sendStatus('404');
+        } else {
+          res.json(renderConfig.render);
         }
       });
 

--- a/commands/serve/web/eRender.js
+++ b/commands/serve/web/eRender.js
@@ -38,16 +38,29 @@ async function renderWithEngine() {
   const app = await openApp(info.enigma.appId);
   const nebbie = await nuke({ app, ...info, theme: params.theme, language: params.language });
   const element = document.querySelector('#chart-container');
-  const cfg = params.object
-    ? {
-        id: params.object,
-        element,
-      }
-    : {
-        type: info.supernova.name,
-        fields: params.cols || [],
-        element,
-      };
+  let cfg;
+  if (params['render-config']) {
+    const rc = await (await fetch(`/render-config/${params['render-config']}`)).json();
+    cfg = {
+      ...rc,
+      // eslint-disable-next-line no-nested-ternary
+      ...(params.object ? { id: params.object } : rc.id ? { id: rc.id } : {}),
+      type: rc.type ? rc.type : info.supernova.name,
+      fields: params.cols ? params.cols : rc.fields,
+      element,
+    };
+  } else if (params.object) {
+    cfg = {
+      id: params.object,
+      element,
+    };
+  } else {
+    cfg = {
+      type: info.supernova.name,
+      fields: params.cols || [],
+      element,
+    };
+  }
 
   const render = async () => {
     await nebbie.render(cfg);


### PR DESCRIPTION
## Motivation

This enables to pass render configs via `nebula.config.js`

```
serve: {
  renderConfigs: [{
	id: "test123",
	render: {
     fields: ["Month", "=sum(Sales)"],
	}
  }],
}
```

In your integration test you can then use

```
await page.goto(`${process.env.BASE_URL}/render/?app=${app}&render-config=test123`);
```