### PR TITLE
refactor: move internal APIs into a __DO_NOT_USE__ variable

### DIFF
--- a/.codesandbox/mekko/src/init.js
+++ b/.codesandbox/mekko/src/init.js
@@ -25,7 +25,6 @@ export default function init({ appId, fields, objectId }) {
       load: () => Promise.resolve(mekko),
     });
     nebbie.selections().then((s) => s.mount(document.getElementById('selections')));
-    nebbie.types.clearFromCache('dummy');
 
     nebbie.render(
       objectid

--- a/apis/nucleus/src/__tests__/viz.spec.js
+++ b/apis/nucleus/src/__tests__/viz.spec.js
@@ -1,3 +1,4 @@
+/* eslint no-underscore-dangle:0 */
 const doMock = ({ glue = () => {}, getPatches = () => {} } = {}) =>
   aw.mock(
     [
@@ -45,6 +46,7 @@ describe('viz', () => {
       on: sandbox.spy(),
       once: sandbox.spy(),
       emit: sandbox.spy(),
+      id: 'uid',
     };
     api = create({
       model,
@@ -54,36 +56,41 @@ describe('viz', () => {
   after(() => {
     sandbox.restore();
   });
-  describe('api', () => {
-    it('should have a mount method', () => {
-      expect(api.mount).to.be.a('function');
+  describe('public api', () => {
+    it('should have an id', () => {
+      expect(api.id).to.be.a('string');
     });
 
+    it('should have a destroy method', () => {
+      expect(api.destroy).to.be.a('function');
+    });
+  });
+  describe('internal api', () => {
     it('should have an applyProperties method', () => {
-      expect(api.applyProperties).to.be.a('function');
+      expect(api.__DO_NOT_USE__.applyProperties).to.be.a('function');
     });
 
     it('should have an exportImage method', () => {
-      expect(api.exportImage).to.be.a('function');
+      expect(api.__DO_NOT_USE__.exportImage).to.be.a('function');
     });
   });
 
   describe('mounting', () => {
     it('should mount', async () => {
-      mounted = api.mount('element');
+      mounted = api.__DO_NOT_USE__.mount('element');
       const { onMount } = glue.getCall(0).args[0];
       onMount();
       await mounted;
       expect(glue.callCount).to.equal(1);
     });
     it('should throw if already mounted', async () => {
-      expect(api.mount.bind('element2')).to.throw();
+      expect(api.__DO_NOT_USE__.mount.bind('element2')).to.throw();
     });
   });
 
-  describe('setTemporaryProperties', () => {
+  describe('applyProperties', () => {
     it('should apply patches when there are some', async () => {
-      await api.applyProperties('new');
+      await api.__DO_NOT_USE__.applyProperties('new');
       expect(model.getEffectiveProperties.callCount).to.equal(1);
       expect(getPatches).to.have.been.calledWithExactly('/', 'new', 'old');
       expect(model.applyPatches).to.have.been.calledWithExactly(['patch'], true);
@@ -91,7 +98,7 @@ describe('viz', () => {
 
     it('should not apply patches when there is no diff', async () => {
       model.getEffectiveProperties.resetHistory();
-      await api.applyProperties('new');
+      await api.__DO_NOT_USE__.applyProperties('new');
       getPatches.returns([]);
       model.applyPatches.resetHistory();
       expect(model.getEffectiveProperties.callCount).to.equal(1);
@@ -110,7 +117,7 @@ describe('viz', () => {
   describe('options', () => {
     it('should set sn options', async () => {
       const opts = {};
-      api.options(opts);
+      api.__DO_NOT_USE__.options(opts);
       await mounted;
       expect(cellRef.current.setSnOptions).to.have.been.calledWithExactly(opts);
     });
@@ -118,14 +125,14 @@ describe('viz', () => {
 
   describe('snapshot', () => {
     it('should take a snapshot', async () => {
-      api.takeSnapshot();
+      api.__DO_NOT_USE__.takeSnapshot();
       expect(cellRef.current.takeSnapshot).to.have.been.calledWithExactly();
     });
   });
 
   describe('export', () => {
     it('should export image', async () => {
-      api.exportImage();
+      api.__DO_NOT_USE__.exportImage();
       expect(cellRef.current.exportImage).to.have.been.calledWithExactly();
     });
   });

--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -159,12 +159,7 @@ const loadType = async ({ dispatch, types, name, version, layout, model, app, se
 };
 
 const Cell = forwardRef(({ halo, model, initialSnOptions, initialError, onMount }, ref) => {
-  const {
-    app,
-    public: {
-      nebbie: { types },
-    },
-  } = halo;
+  const { app, types } = halo;
 
   const { translator, language } = useContext(InstanceContext);
   const theme = useTheme();

--- a/apis/nucleus/src/components/__tests__/cell.spec.jsx
+++ b/apis/nucleus/src/components/__tests__/cell.spec.jsx
@@ -72,23 +72,23 @@ describe('<Cell />', () => {
         })
       ),
     };
-    const defaultCorona = {
+    const defaultHalo = {
       app: {
         id: 'app-id',
         getAppLayout: () => Promise.resolve(appLayout),
       },
       public: {
-        nebbie: {
-          types: {
-            getSupportedVersion: sandbox.stub(),
-          },
-        },
+        nebbie: {},
+      },
+      types: {
+        getSupportedVersion: sandbox.stub(),
       },
     };
     render = async ({
       model = {},
       app = {},
       nebbie = {},
+      types = defaultHalo.types,
       initialSnOptions = {},
       onMount = sandbox.spy(),
       theme = createTheme('dark'),
@@ -101,14 +101,15 @@ describe('<Cell />', () => {
         ...model,
       };
       const halo = {
-        ...defaultCorona,
+        ...defaultHalo,
         ...app,
         public: {
-          nebbie: nebbie.types ? nebbie : { ...defaultCorona.public.nebbie },
+          nebbie,
         },
         config: {
           ...config,
         },
+        types,
       };
 
       await act(async () => {
@@ -138,18 +139,16 @@ describe('<Cell />', () => {
   describe('sn', () => {
     it('should render loading', async () => {
       sandbox.useFakeTimers();
-      const nebbie = {
-        types: {
-          get: sandbox.stub().returns({
-            supernova: () => new Promise(() => {}),
-          }),
-          getSupportedVersion: sandbox.stub().returns('1.0.0'),
-        },
+      const types = {
+        get: sandbox.stub().returns({
+          supernova: () => new Promise(() => {}),
+        }),
+        getSupportedVersion: sandbox.stub().returns('1.0.0'),
       };
-      await render({ nebbie });
+      await render({ types });
       sandbox.clock.tick(800);
-      const types = renderer.root.findAllByType(Loading);
-      expect(types).to.have.length(1);
+      const ftypes = renderer.root.findAllByType(Loading);
+      expect(ftypes).to.have.length(1);
       expect(() => renderer.root.findByType(LongRunningQuery)).to.throw();
     });
 
@@ -165,18 +164,16 @@ describe('<Cell />', () => {
           },
         },
       };
-      const nebbie = {
-        types: {
-          get: sandbox.stub().returns({
-            supernova: async () => ({ create: () => sn }),
-          }),
-          getSupportedVersion: sandbox.stub().returns('1.0.0'),
-        },
+      const types = {
+        get: sandbox.stub().returns({
+          supernova: async () => ({ create: () => sn }),
+        }),
+        getSupportedVersion: sandbox.stub().returns('1.0.0'),
       };
-      await render({ nebbie });
+      await render({ types });
       sandbox.clock.tick(2100);
-      const types = renderer.root.findAllByType(LongRunningQuery);
-      expect(types).to.have.length(0);
+      const ftypes = renderer.root.findAllByType(LongRunningQuery);
+      expect(ftypes).to.have.length(0);
     });
 
     it('should render long running', async () => {
@@ -191,18 +188,16 @@ describe('<Cell />', () => {
           },
         },
       };
-      const nebbie = {
-        types: {
-          get: sandbox.stub().returns({
-            supernova: async () => ({ create: () => sn }),
-          }),
-          getSupportedVersion: sandbox.stub().returns('1.0.0'),
-        },
+      const types = {
+        get: sandbox.stub().returns({
+          supernova: async () => ({ create: () => sn }),
+        }),
+        getSupportedVersion: sandbox.stub().returns('1.0.0'),
       };
-      await render({ nebbie });
+      await render({ types });
       sandbox.clock.tick(2100);
-      const types = renderer.root.findAllByType(LongRunningQuery);
-      expect(types).to.have.length(1);
+      const ftypes = renderer.root.findAllByType(LongRunningQuery);
+      expect(ftypes).to.have.length(1);
       expect(() => renderer.root.findByType(Loading)).to.throw();
     });
 
@@ -216,18 +211,16 @@ describe('<Cell />', () => {
           },
         },
       };
-      const nebbie = {
-        types: {
-          get: sandbox.stub().returns({
-            supernova: async () => ({ create: () => sn }),
-          }),
-          getSupportedVersion: sandbox.stub().returns('1.0.0'),
-        },
+      const types = {
+        get: sandbox.stub().returns({
+          supernova: async () => ({ create: () => sn }),
+        }),
+        getSupportedVersion: sandbox.stub().returns('1.0.0'),
       };
-      await render({ nebbie });
+      await render({ types });
 
-      const types = renderer.root.findAllByType(Supernova);
-      expect(types).to.have.length(1);
+      const ftypes = renderer.root.findAllByType(Supernova);
+      expect(ftypes).to.have.length(1);
     });
 
     it('should render requirements', async () => {
@@ -252,19 +245,17 @@ describe('<Cell />', () => {
           },
         },
       };
-      const nebbie = {
-        types: {
-          get: sandbox.stub().returns({
-            supernova: async () => ({ create: () => sn }),
-          }),
-          getSupportedVersion: sandbox.stub().returns('1.0.0'),
-        },
+      const types = {
+        get: sandbox.stub().returns({
+          supernova: async () => ({ create: () => sn }),
+        }),
+        getSupportedVersion: sandbox.stub().returns('1.0.0'),
       };
-      await render({ nebbie });
+      await render({ types });
 
-      const types = renderer.root.findAllByType(CError);
-      expect(types).to.have.length(1);
-      expect(types[0].props.title).to.equal('Supernova.Incomplete');
+      const ftypes = renderer.root.findAllByType(CError);
+      expect(ftypes).to.have.length(1);
+      expect(ftypes[0].props.title).to.equal('Supernova.Incomplete');
     });
 
     it('should render hypercube error', async () => {
@@ -291,21 +282,19 @@ describe('<Cell />', () => {
           },
         },
       };
-      const nebbie = {
-        types: {
-          get: sandbox.stub().returns({
-            supernova: async () => ({ create: () => sn }),
-          }),
-          getSupportedVersion: sandbox.stub().returns('1.0.0'),
-        },
+      const types = {
+        get: sandbox.stub().returns({
+          supernova: async () => ({ create: () => sn }),
+        }),
+        getSupportedVersion: sandbox.stub().returns('1.0.0'),
       };
-      await render({ nebbie });
+      await render({ types });
 
-      const types = renderer.root.findAllByType(CError);
-      expect(types).to.have.length(1);
-      expect(types[0].props.title).to.equal('Error');
-      expect(types[0].props.data[0].path).to.equal('/foo');
-      expect(types[0].props.data[0].error).to.deep.equal({ qErrorCode: 1337 });
+      const ftypes = renderer.root.findAllByType(CError);
+      expect(ftypes).to.have.length(1);
+      expect(ftypes[0].props.title).to.equal('Error');
+      expect(ftypes[0].props.data[0].path).to.equal('/foo');
+      expect(ftypes[0].props.data[0].error).to.deep.equal({ qErrorCode: 1337 });
     });
 
     it('should go modal (selections)', async () => {
@@ -351,15 +340,13 @@ describe('<Cell />', () => {
           items: [],
         },
       };
-      const nebbie = {
-        types: {
-          get: sandbox.stub().returns({
-            supernova: async () => ({ create: () => sn }),
-          }),
-          getSupportedVersion: sandbox.stub().returns('1.0.0'),
-        },
+      const types = {
+        get: sandbox.stub().returns({
+          supernova: async () => ({ create: () => sn }),
+        }),
+        getSupportedVersion: sandbox.stub().returns('1.0.0'),
       };
-      await render({ model, nebbie });
+      await render({ model, types });
       expect(goModal.callCount).to.equal(1);
       expect(goModal).to.have.been.calledWithExactly('/qFoo');
     });
@@ -406,15 +393,13 @@ describe('<Cell />', () => {
           items: [],
         },
       };
-      const nebbie = {
-        types: {
-          get: sandbox.stub().returns({
-            supernova: async () => ({ create: () => sn }),
-          }),
-          getSupportedVersion: sandbox.stub().returns('1.0.0'),
-        },
+      const types = {
+        get: sandbox.stub().returns({
+          supernova: async () => ({ create: () => sn }),
+        }),
+        getSupportedVersion: sandbox.stub().returns('1.0.0'),
       };
-      await render({ model, nebbie });
+      await render({ model, types });
       expect(noModal.callCount).to.equal(1);
     });
   });
@@ -432,15 +417,13 @@ describe('<Cell />', () => {
           },
         },
       };
-      const nebbie = {
-        types: {
-          get: sandbox.stub().returns({
-            supernova: async () => ({ create: () => sn }),
-          }),
-          getSupportedVersion: sandbox.stub().returns('1.0.0'),
-        },
+      const types = {
+        get: sandbox.stub().returns({
+          supernova: async () => ({ create: () => sn }),
+        }),
+        getSupportedVersion: sandbox.stub().returns('1.0.0'),
       };
-      await render({ model, nebbie, cellRef });
+      await render({ model, types, cellRef });
 
       expect(cellRef.current.setSnOptions).to.be.a('function');
       expect(cellRef.current.exportImage).to.be.a('function');
@@ -459,16 +442,14 @@ describe('<Cell />', () => {
         },
         component: {},
       };
-      const nebbie = {
-        types: {
-          get: sandbox.stub().returns({
-            supernova: async () => ({ create: () => sn }),
-          }),
-          getSupportedVersion: sandbox.stub().returns('1.0.0'),
-        },
+      const types = {
+        get: sandbox.stub().returns({
+          supernova: async () => ({ create: () => sn }),
+        }),
+        getSupportedVersion: sandbox.stub().returns('1.0.0'),
       };
       await render({
-        nebbie,
+        types,
         cellRef,
         rendererOptions: {
           createNodeMock: (/* e */) => {
@@ -515,16 +496,14 @@ describe('<Cell />', () => {
           }),
         },
       };
-      const nebbie = {
-        types: {
-          get: sandbox.stub().returns({
-            supernova: async () => ({ create: () => sn }),
-          }),
-          getSupportedVersion: sandbox.stub().returns('1.0.0'),
-        },
+      const types = {
+        get: sandbox.stub().returns({
+          supernova: async () => ({ create: () => sn }),
+        }),
+        getSupportedVersion: sandbox.stub().returns('1.0.0'),
       };
       await render({
-        nebbie,
+        types,
         cellRef,
         rendererOptions: {
           createNodeMock: (/* e */) => {
@@ -560,16 +539,14 @@ describe('<Cell />', () => {
         },
         component: {},
       };
-      const nebbie = {
-        types: {
-          get: sandbox.stub().returns({
-            supernova: async () => ({ create: () => sn }),
-          }),
-          getSupportedVersion: sandbox.stub().returns('1.0.0'),
-        },
+      const types = {
+        get: sandbox.stub().returns({
+          supernova: async () => ({ create: () => sn }),
+        }),
+        getSupportedVersion: sandbox.stub().returns('1.0.0'),
       };
       await render({
-        nebbie,
+        types,
         cellRef,
         config,
       });
@@ -596,16 +573,14 @@ describe('<Cell />', () => {
         },
         component: {},
       };
-      const nebbie = {
-        types: {
-          get: sandbox.stub().returns({
-            supernova: async () => ({ create: () => sn }),
-          }),
-          getSupportedVersion: sandbox.stub().returns('1.0.0'),
-        },
+      const types = {
+        get: sandbox.stub().returns({
+          supernova: async () => ({ create: () => sn }),
+        }),
+        getSupportedVersion: sandbox.stub().returns('1.0.0'),
       };
       await render({
-        nebbie,
+        types,
         cellRef,
         config,
       });

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -112,7 +112,7 @@ function nuked(configuration = {}) {
   const locale = appLocaleFn(configuration.context.language);
 
   /**
-   * Initiates a new embed instance using the specified `app`.
+   * Initiates a new `Embed` instance using the specified enigma `app`.
    * @entry
    * @function embed
    * @param {enigma.Doc} app
@@ -165,6 +165,7 @@ function nuked(configuration = {}) {
       public: publicAPIs,
       context: currentContext,
       nebbie: null,
+      types: null,
     };
 
     const types = typesFn({ halo });
@@ -275,7 +276,7 @@ function nuked(configuration = {}) {
           // const appSelections = await root.getAppSelections(); // Don't expose this for now
           selectionsApi = /** @lends AppSelections# */ {
             /**
-             * Mounts the app selection UI into the provided HTMLElement
+             * Mounts the app selection UI into the provided HTMLElement.
              * @param {HTMLElement} element
              * @example
              * selections.mount(element);
@@ -294,7 +295,7 @@ function nuked(configuration = {}) {
               root.add(selectionsComponentReference);
             },
             /**
-             * Unmounts the app selection UI from the DOM
+             * Unmounts the app selection UI from the DOM.
              * @example
              * selections.unmount();
              */
@@ -308,10 +309,13 @@ function nuked(configuration = {}) {
         }
         return selectionsApi;
       },
-      types,
+      __DO_NOT_USE__: {
+        types,
+      },
     };
 
     halo.public.nebbie = api;
+    halo.types = types;
 
     return api;
   }
@@ -322,7 +326,7 @@ function nuked(configuration = {}) {
    * The configuration is merged with all previous scopes.
    * @memberof embed
    * @param {Configuration} configuration - The configuration object
-   * @returns {Embed}
+   * @returns {embed}
    * @example
    * import { embed } from '@nebula.js/stardust';
    * // create a 'master' config which registers all types

--- a/apis/nucleus/src/object/__tests__/create-session-object.spec.js
+++ b/apis/nucleus/src/object/__tests__/create-session-object.spec.js
@@ -30,11 +30,7 @@ describe('create-session-object', () => {
       app: {
         createSessionObject: sandbox.stub().returns(Promise.resolve(objectModel)),
       },
-      public: {
-        nebbie: {
-          types,
-        },
-      },
+      types,
     };
 
     init.returns('api');

--- a/apis/nucleus/src/object/__tests__/initiate.spec.js
+++ b/apis/nucleus/src/object/__tests__/initiate.spec.js
@@ -1,3 +1,4 @@
+/* eslint no-underscore-dangle:0 */
 describe('initiate api', () => {
   const optional = 'optional';
   const halo = 'halo';
@@ -14,9 +15,10 @@ describe('initiate api', () => {
 
   beforeEach(() => {
     api = {
-      mount: sandbox.stub(),
-      options: sandbox.stub(),
-      context: sandbox.stub(),
+      __DO_NOT_USE__: {
+        mount: sandbox.stub(),
+        options: sandbox.stub(),
+      },
     };
     viz.returns(api);
   });
@@ -35,11 +37,11 @@ describe('initiate api', () => {
 
   it('should call mount when element is provided ', async () => {
     await create(model, { element: 'el' }, halo);
-    expect(api.mount).to.have.been.calledWithExactly('el');
+    expect(api.__DO_NOT_USE__.mount).to.have.been.calledWithExactly('el');
   });
 
   it('should call options when provided ', async () => {
     await create(model, { options: 'opts' }, halo);
-    expect(api.options).to.have.been.calledWithExactly('opts');
+    expect(api.__DO_NOT_USE__.options).to.have.been.calledWithExactly('opts');
   });
 });

--- a/apis/nucleus/src/object/create-session-object.js
+++ b/apis/nucleus/src/object/create-session-object.js
@@ -14,7 +14,7 @@ export default async function createSessionObject({ type, version, fields, prope
   let mergedProps = {};
   let error;
   try {
-    const t = halo.public.nebbie.types.get({ name: type, version });
+    const t = halo.types.get({ name: type, version });
     mergedProps = await t.initialProperties(properties);
     const sn = await t.supernova();
     if (fields) {

--- a/apis/nucleus/src/object/initiate.js
+++ b/apis/nucleus/src/object/initiate.js
@@ -1,6 +1,7 @@
+/* eslint no-underscore-dangle:0 */
 import vizualizationAPI from '../viz';
 
-export default async function (model, optional, halo, initialError, onDestroy = async () => {}) {
+export default async function init(model, optional, halo, initialError, onDestroy = async () => {}) {
   const api = vizualizationAPI({
     model,
     halo,
@@ -8,10 +9,10 @@ export default async function (model, optional, halo, initialError, onDestroy = 
     onDestroy,
   });
   if (optional.options) {
-    api.options(optional.options);
+    api.__DO_NOT_USE__.options(optional.options);
   }
   if (optional.element) {
-    await api.mount(optional.element);
+    await api.__DO_NOT_USE__.mount(optional.element);
   }
 
   return api;

--- a/apis/nucleus/src/viz.js
+++ b/apis/nucleus/src/viz.js
@@ -66,37 +66,39 @@ export default function viz({ model, halo, initialError, onDestroy = async () =>
       unmountCell = noopi;
     },
     // ===== unexposed experimental API - use at own risk ======
-    mount(element) {
-      if (mountedReference) {
-        throw new Error('Already mounted');
-      }
-      mountedReference = element;
-      [unmountCell, cellRef] = glueCell({
-        halo,
-        element,
-        model,
-        initialSnOptions,
-        initialError,
-        onMount,
-      });
-      return mounted;
-    },
-    async applyProperties(props) {
-      const current = await model.getEffectiveProperties();
-      const patches = getPatches('/', props, current);
-      if (patches.length) {
-        return model.applyPatches(patches, true);
-      }
-      return undefined;
-    },
-    options(opts) {
-      setSnOptions(opts);
-    },
-    exportImage() {
-      return cellRef.current.exportImage();
-    },
-    takeSnapshot() {
-      return cellRef.current.takeSnapshot();
+    __DO_NOT_USE__: {
+      mount(element) {
+        if (mountedReference) {
+          throw new Error('Already mounted');
+        }
+        mountedReference = element;
+        [unmountCell, cellRef] = glueCell({
+          halo,
+          element,
+          model,
+          initialSnOptions,
+          initialError,
+          onMount,
+        });
+        return mounted;
+      },
+      async applyProperties(props) {
+        const current = await model.getEffectiveProperties();
+        const patches = getPatches('/', props, current);
+        if (patches.length) {
+          return model.applyPatches(patches, true);
+        }
+        return undefined;
+      },
+      options(opts) {
+        setSnOptions(opts);
+      },
+      exportImage() {
+        return cellRef.current.exportImage();
+      },
+      takeSnapshot() {
+        return cellRef.current.takeSnapshot();
+      },
     },
 
     // old QVisualization API

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -9,7 +9,7 @@
   },
   "entries": {
     "embed": {
-      "description": "Initiates a new embed instance using the specified `app`.",
+      "description": "Initiates a new `Embed` instance using the specified enigma `app`.",
       "kind": "function",
       "params": [
         {
@@ -38,7 +38,7 @@
             }
           ],
           "returns": {
-            "type": "#/definitions/Embed"
+            "type": "#/entries/embed"
           },
           "examples": [
             "import { embed } from '@nebula.js/stardust';\n// create a 'master' config which registers all types\nconst m = embed.createConfiguration({\n  types: [{\n    name: 'mekko',\n    version: '1.0.0',\n    load: () => Promise.resolve(mekko)\n  }],\n});\n\n// create an alternate config with dark theme\n// and inherit the config from the previous\nconst d = m.createConfiguration({\n theme: 'dark'\n});\n\nm(app).render({ type: 'mekko' }); // will render the object with default theme\nd(app).render({ type: 'mekko' }); // will render the object with 'dark' theme\nembed(app).render({ type: 'mekko' }); // will throw error since 'mekko' is not a register type on the default instance"
@@ -654,7 +654,7 @@
       "kind": "class",
       "entries": {
         "mount": {
-          "description": "Mounts the app selection UI into the provided HTMLElement",
+          "description": "Mounts the app selection UI into the provided HTMLElement.",
           "kind": "function",
           "params": [
             {
@@ -665,7 +665,7 @@
           "examples": ["selections.mount(element);"]
         },
         "unmount": {
-          "description": "Unmounts the app selection UI from the DOM",
+          "description": "Unmounts the app selection UI from the DOM.",
           "kind": "function",
           "params": [],
           "examples": ["selections.unmount();"]

--- a/commands/serve/web/components/App.jsx
+++ b/commands/serve/web/components/App.jsx
@@ -1,3 +1,4 @@
+/* eslint no-underscore-dangle:0 */
 import React, { useEffect, useLayoutEffect, useState, useRef, useMemo } from 'react';
 
 import { embed } from '@nebula.js/stardust';
@@ -98,7 +99,7 @@ export default function App({ app, info }) {
           }))
         : null,
     });
-    n.types.register(info.supernova);
+    n.__DO_NOT_USE__.types.register(info.supernova);
     setNebbie(n);
   }, [app]);
 
@@ -121,15 +122,15 @@ export default function App({ app, info }) {
 
     nebbie.selections().then((s) => s.mount(currentSelectionsRef.current));
     window.onHotChange(info.supernova.name, () => {
-      nebbie.types.clearFromCache(info.supernova.name);
-      nebbie.types.register(info.supernova);
+      nebbie.__DO_NOT_USE__.types.clearFromCache(info.supernova.name);
+      nebbie.__DO_NOT_USE__.types.register(info.supernova);
       if (uid.current) {
         app.destroySessionObject(uid.current).then(create);
       } else {
         create();
       }
 
-      nebbie.types
+      nebbie.__DO_NOT_USE__.types
         .get({
           name: info.supernova.name,
         })

--- a/commands/serve/web/components/Cell.jsx
+++ b/commands/serve/web/components/Cell.jsx
@@ -1,3 +1,4 @@
+/* eslint no-underscore-dangle:0 */
 import React, { useContext, useEffect, useState, useCallback, useRef } from 'react';
 
 import { Grid, Toolbar, IconButton, CircularProgress } from '@material-ui/core';
@@ -79,7 +80,7 @@ export default function ({ id, expandable, minHeight }) {
       }
       if (doExport) {
         setExporting(true);
-        vizRef.current.viz.exportImage().then((res) => {
+        vizRef.current.viz.__DO_NOT_USE__.exportImage().then((res) => {
           if (res && res.url) {
             window.open(res.url);
           }
@@ -87,7 +88,7 @@ export default function ({ id, expandable, minHeight }) {
         });
       } else {
         const containerSize = vizRef.current.el.getBoundingClientRect();
-        vizRef.current.viz.takeSnapshot().then((snapshot) => {
+        vizRef.current.viz.__DO_NOT_USE__.takeSnapshot().then((snapshot) => {
           fetch('/njs/snapshot', {
             method: 'POST',
             headers: {

--- a/commands/serve/web/eRender.js
+++ b/commands/serve/web/eRender.js
@@ -1,3 +1,4 @@
+/* eslint no-underscore-dangle:0 */
 import { embed } from '@nebula.js/stardust';
 import snapshooter from '@nebula.js/snapshooter/client';
 
@@ -70,8 +71,8 @@ async function renderWithEngine() {
   window.onHotChange(info.supernova.name, async () => {
     if (viz) {
       viz.close();
-      nebbie.types.clearFromCache(info.supernova.name);
-      nebbie.types.register(info.supernova);
+      nebbie.__DO_NOT_USE__.types.clearFromCache(info.supernova.name);
+      nebbie.__DO_NOT_USE__.types.register(info.supernova);
     }
     viz = await render();
   });

--- a/test/mashup/snaps/snapper.js
+++ b/test/mashup/snaps/snapper.js
@@ -1,6 +1,7 @@
 /* global configured */
+/* eslint no-underscore-dangle: 0 */
 (() => {
-  document.querySelectorAll('.object').forEach(element => {
+  document.querySelectorAll('.object').forEach((element) => {
     const type = element.getAttribute('data-type');
     const obj = {
       id: `${type}-${+new Date()}`,
@@ -26,9 +27,9 @@
     n.render({
       type,
       element,
-    }).then(viz => {
+    }).then((viz) => {
       element.addEventListener('click', () => {
-        viz.exportImage().then(res => {
+        viz.__DO_NOT_USE__.exportImage().then((res) => {
           element.setAttribute('data-captured', res.url);
         });
       });


### PR DESCRIPTION
Move internal APIs into a `__DO_NOT_USE__` variable to make it clear it's internal and should not be used.