### PR TITLE
fix(cli-sense): do not remove target dir

### DIFF
--- a/commands/sense/lib/build-legacy.js
+++ b/commands/sense/lib/build-legacy.js
@@ -105,7 +105,6 @@ async function build(argv) {
     });
   }
 
-  await fs.remove(qextLegacyTargetDir);
   await moveSnBundle();
   await moveResources();
   await wrapIt();


### PR DESCRIPTION
## Motivation

Avoid removing the target directory when building a Sense extension since this could easily cause unwanted removal of directories if the wrong output path is provided.