### PR TITLE
fix: add `disabled` in incomplete list

### DIFF
--- a/apis/nucleus/src/components/Error.jsx
+++ b/apis/nucleus/src/components/Error.jsx
@@ -17,7 +17,9 @@ const DescriptionRow = ({ d }) => {
   }
   const style = { color: styleColor };
   const Icon = (
-    <IconButton>{d.missing || d.error ? <WarningTriangle style={style} /> : <Tick style={style} />}</IconButton>
+    <IconButton disabled>
+      {d.missing || d.error ? <WarningTriangle style={style} /> : <Tick style={style} />}
+    </IconButton>
   );
   return (
     <Grid item container alignItems="center" wrap="nowrap">


### PR DESCRIPTION
## Motivation

Add `disabled` state on `IconButton` since you can't interact with it.
