### PR TITLE
fix: remove spacing in `Error.jsx`

### DIFF
--- a/apis/nucleus/src/components/Error.jsx
+++ b/apis/nucleus/src/components/Error.jsx
@@ -81,7 +81,6 @@ export default function Error({ title = 'Error', message = '', data = [] }) {
       alignItems="center"
       justify="center"
       style={{ position: 'relative', height: '100%', width: '100%' }}
-      spacing={1}
     >
       <Grid item>
         <WarningTriangle style={{ fontSize: '38px' }} />


### PR DESCRIPTION
## Motivation

Remove the spacing attribute on the Grid in `Error.jsx` which caused misalignment.
