### PR TITLE
fix(cli-serve): mock getConfiguration

### DIFF
--- a/commands/serve/web/connect.js
+++ b/commands/serve/web/connect.js
@@ -139,6 +139,7 @@ const connect = () => {
               qTitle: d.name,
             }));
           },
+          getConfiguration: async () => ({}),
         };
       }
       const url = SenseUtilities.buildUrl({


### PR DESCRIPTION
fix `.getConfiguration is not a function` error when a SaaS endpoint is being used.