### PR TITLE
fix(theme): add additional palette fallback

### DIFF
--- a/apis/theme/src/__tests__/set-theme.spec.js
+++ b/apis/theme/src/__tests__/set-theme.spec.js
@@ -74,7 +74,21 @@ describe('set theme', () => {
     });
   });
 
+  it('should add defaults if custom scales and palettes are empty', () => {
+    const root = { color: 'pink', palettes: { data: 'data', ui: 'ui' }, scales: 'scales' };
+    const merged = { palettes: { data: [], ui: [] } };
+    extend.onFirstCall().returns(root);
+    extend.onSecondCall().returns(merged);
+    const custom = { color: 'red' };
+    create(custom, resolve);
+    expect(resolve).to.have.been.calledWithExactly({
+      palettes: { data: 'data', ui: 'ui' },
+      scales: 'scales',
+    });
+  });
+
   it('should return resolved theme', () => {
+    extend.onFirstCall().returns({ palettes: { data: 'data', ui: 'ui' }, scales: [] });
     extend.onSecondCall().returns({ palettes: { data: [], ui: [] }, scales: [] });
     resolve.returns('resolved');
     expect(create({}, resolve)).to.equal('resolved');

--- a/apis/theme/src/__tests__/set-theme.spec.js
+++ b/apis/theme/src/__tests__/set-theme.spec.js
@@ -76,7 +76,7 @@ describe('set theme', () => {
 
   it('should add defaults if custom scales and palettes are empty', () => {
     const root = { color: 'pink', palettes: { data: 'data', ui: 'ui' }, scales: 'scales' };
-    const merged = { palettes: { data: [], ui: [] } };
+    const merged = { palettes: { data: [], ui: [] }, scales: [] };
     extend.onFirstCall().returns(root);
     extend.onSecondCall().returns(merged);
     const custom = { color: 'red' };
@@ -88,7 +88,7 @@ describe('set theme', () => {
   });
 
   it('should return resolved theme', () => {
-    extend.onFirstCall().returns({ palettes: { data: 'data', ui: 'ui' }, scales: [] });
+    extend.onFirstCall().returns({ palettes: { data: [], ui: [] }, scales: [] });
     extend.onSecondCall().returns({ palettes: { data: [], ui: [] }, scales: [] });
     resolve.returns('resolved');
     expect(create({}, resolve)).to.equal('resolved');

--- a/apis/theme/src/set-theme.js
+++ b/apis/theme/src/set-theme.js
@@ -15,7 +15,7 @@ export default function setTheme(t, resolve) {
   if (!rawThemeJSON.palettes.ui || !rawThemeJSON.palettes.ui.length) {
     rawThemeJSON.palettes.ui = root.palettes.ui;
   }
-  if (!rawThemeJSON.scales) {
+  if (!rawThemeJSON.scales || !rawThemeJSON.scales.length) {
     rawThemeJSON.scales = root.scales;
   }
 

--- a/apis/theme/src/set-theme.js
+++ b/apis/theme/src/set-theme.js
@@ -9,10 +9,10 @@ export default function setTheme(t, resolve) {
   const root = extend(true, {}, baseRawJSON, colorRawJSON);
   // avoid merging known array objects as it could cause issues if they are of different types (pyramid vs class) or length
   const rawThemeJSON = extend(true, {}, root, { scales: null, palettes: { data: null, ui: null } }, t);
-  if (!rawThemeJSON.palettes.data) {
+  if (!rawThemeJSON.palettes.data || !rawThemeJSON.palettes.data.length) {
     rawThemeJSON.palettes.data = root.palettes.data;
   }
-  if (!rawThemeJSON.palettes.ui) {
+  if (!rawThemeJSON.palettes.ui || !rawThemeJSON.palettes.ui.length) {
     rawThemeJSON.palettes.ui = root.palettes.ui;
   }
   if (!rawThemeJSON.scales) {


### PR DESCRIPTION
# Motivation

When a sense theme incorrectly includes empty arrays for palettes they end up as empty in the finished theme, even with inheritance enabled.
