### PR TITLE
fix: remove listener on unmount

### DIFF
--- a/apis/nucleus/src/components/__tests__/glue.spec.jsx
+++ b/apis/nucleus/src/components/__tests__/glue.spec.jsx
@@ -21,7 +21,8 @@ describe('glue', () => {
       },
       element: {},
       model: {
-        once: sandbox.spy(),
+        on: sandbox.spy(),
+        removeListener: sandbox.spy(),
       },
       initialSnContext: {},
       initialSnOptions: {},
@@ -36,5 +37,7 @@ describe('glue', () => {
     dissolve();
     expect(param.halo.root.add.callCount).to.equal(1);
     expect(param.halo.root.remove.callCount).to.equal(1);
+    expect(param.model.on.callCount).to.equal(1);
+    expect(param.model.removeListener.callCount).to.equal(1);
   });
 });

--- a/apis/nucleus/src/components/glue.jsx
+++ b/apis/nucleus/src/components/glue.jsx
@@ -20,9 +20,10 @@ export default function glue({ halo, element, model, initialSnOptions, onMount, 
 
   const unmount = () => {
     root.remove(portal);
+    model.removeListener('closed', unmount);
   };
 
-  model.once('closed', unmount);
+  model.on('closed', unmount);
 
   root.add(portal);
 


### PR DESCRIPTION
previous it was only removed if the unmount was caused by a closed model