### PR TITLE
fix: object-selections

### DIFF
--- a/apis/nucleus/src/hooks/__tests__/use-object-selections.spec.jsx
+++ b/apis/nucleus/src/hooks/__tests__/use-object-selections.spec.jsx
@@ -153,13 +153,42 @@ describe('useObjectSelections', () => {
     expect(res).to.equal(true);
   });
 
-  it('should clear on non successful select', async () => {
+  it('should return false on non successful select', async () => {
     await render();
 
     appSel.isModal.returns(true);
     object.select.returns(false);
     const res = await ref.current.result[0].select({ method: 'select', params: [] });
     expect(res).to.equal(false);
+  });
+
+  it('should not emit cleared on non successful select', async () => {
+    await render();
+    const cleared = sandbox.stub();
+    objectSel.on('cleared', cleared);
+
+    appSel.isModal.returns(true);
+    object.select.returns(false);
+    await objectSel.select({ method: 'select', params: [] });
+    expect(cleared).to.not.be.called;
+  });
+
+  it('should call resetMadeSelections on non successful select', async () => {
+    await render();
+
+    appSel.isModal.returns(true);
+    object.select.returns(false);
+    await objectSel.select({ method: 'select', params: [] });
+    expect(object.resetMadeSelections).to.have.been.calledWithExactly();
+  });
+
+  it('should not be possible to clear after select has be called with resetMadeSelections', async () => {
+    await render();
+    appSel.isModal.returns(true);
+    object.select.returns(true);
+    await objectSel.select({ method: 'resetMadeSelections', params: [] });
+
+    expect(objectSel.canClear()).to.equal(false);
   });
 
   it('can clear', async () => {
@@ -174,12 +203,11 @@ describe('useObjectSelections', () => {
     objectSel.setLayout(layout);
     expect(ref.current.result[0].canClear()).to.equal(true);
 
-    layout = {
-      qSelectionInfo: {
-        qMadeSelections: true,
-      },
-    };
+    layout = {};
     objectSel.setLayout(layout);
+    appSel.isModal.returns(true);
+    object.select.returns(true);
+    await objectSel.select({ method: 'select', params: [] });
     expect(ref.current.result[0].canClear()).to.equal(true);
   });
 
@@ -195,12 +223,11 @@ describe('useObjectSelections', () => {
     objectSel.setLayout(layout);
     expect(ref.current.result[0].canConfirm()).to.equal(true);
 
-    layout = {
-      qSelectionInfo: {
-        qMadeSelections: true,
-      },
-    };
+    layout = {};
     objectSel.setLayout(layout);
+    appSel.isModal.returns(true);
+    object.select.returns(true);
+    await objectSel.select({ method: 'select', params: [] });
     expect(ref.current.result[0].canConfirm()).to.equal(true);
   });
 

--- a/apis/nucleus/src/hooks/useObjectSelections.js
+++ b/apis/nucleus/src/hooks/useObjectSelections.js
@@ -90,11 +90,11 @@ function createObjectSelections({ appSelections, appModal, model }) {
       }
       await b;
       const qSuccess = await model[s.method](...s.params);
+      hasSelected = s.method !== 'resetMadeSelections';
       if (!qSuccess) {
-        this.clear();
+        model.resetMadeSelections();
         return false;
       }
-      hasSelected = true;
       return true;
     },
     /**
@@ -104,7 +104,7 @@ function createObjectSelections({ appSelections, appModal, model }) {
       if (layout && layout.qListObject && layout.qListObject.qDimensionInfo) {
         return !layout.qListObject.qDimensionInfo.qLocked;
       }
-      return hasSelected || (layout && layout.qSelectionInfo.qMadeSelections);
+      return hasSelected;
     },
     /**
      * @returns {boolean}
@@ -113,7 +113,7 @@ function createObjectSelections({ appSelections, appModal, model }) {
       if (layout && layout.qListObject && layout.qListObject.qDimensionInfo) {
         return !layout.qListObject.qDimensionInfo.qLocked;
       }
-      return hasSelected || (layout && layout.qSelectionInfo.qMadeSelections);
+      return hasSelected;
     },
     /**
      * @returns {boolean}


### PR DESCRIPTION
don't clear an empty range select
disable clear and confirm button when the selection is cleared

## Motivation

improved selections experience and match how it works inside qlik-sense