### PR TITLE
fix(nucleus): disable enforce focus on actions toolbar

### DIFF
--- a/apis/nucleus/src/components/ActionsToolbar.jsx
+++ b/apis/nucleus/src/components/ActionsToolbar.jsx
@@ -155,6 +155,7 @@ const ActionsToolbar = ({
 
   return popover.show ? (
     <Popover
+      disableEnforceFocus
       open={popover.show}
       anchorEl={popover.anchorEl}
       anchorOrigin={popoverAnchorOrigin}


### PR DESCRIPTION
## Motivation

As it is not a menu that you open use and close but it open a longer time it should not block focus.
A specific problem it that without this fix it prevent editing values in range select bubbles 