### PR TITLE
chore: skip api-gov job on forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,9 @@ workflows:
                 - /v.*/
       - api-governance:
           filters:
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+              ignore: /pull\/[0-9]+/
             tags:
               only:
                 - /v.*/


### PR DESCRIPTION
Disable API-gov check for forked PRs
