### PR TITLE
feat: add checking master item for object conversion

### DIFF
--- a/apis/conversion/src/__tests__/library-utils.spec.js
+++ b/apis/conversion/src/__tests__/library-utils.spec.js
@@ -1,0 +1,21 @@
+import libraryUtils from '../library-utils';
+
+describe('Library utils', () => {
+  describe('findLibraryMeasure', () => {
+    it('should return null if there is no measureList', () => {
+      expect(libraryUtils.findLibraryItem()).to.equal(null);
+      expect(libraryUtils.findLibraryItem('')).to.equal(null);
+      expect(libraryUtils.findLibraryItem('id')).to.equal(null);
+    });
+
+    it('should return null if there is no match', () => {
+      const libraryList = [{ qInfo: { qId: 'id1' } }, { qInfo: { qId: 'id2' } }];
+      expect(libraryUtils.findLibraryItem('someId', libraryList)).to.equal(null);
+    });
+
+    it('should return measure if there is a match', () => {
+      const libraryList = [{ qInfo: { qId: 'id1' } }, { qInfo: { qId: 'id2' } }];
+      expect(libraryUtils.findLibraryItem('id1', libraryList)).to.deep.equal({ qInfo: { qId: 'id1' } });
+    });
+  });
+});

--- a/apis/conversion/src/helpers/__tests__/index.spec.js
+++ b/apis/conversion/src/helpers/__tests__/index.spec.js
@@ -1261,3 +1261,90 @@ describe('shouldInitLayoutExclude', () => {
     });
   });
 });
+
+describe('checkLibraryObjects', () => {
+  let exportFormat;
+  let dimensionList;
+  let measureList;
+
+  beforeEach(() => {
+    exportFormat = {
+      data: [
+        {
+          dimensions: [
+            {
+              title: 'title0',
+            },
+            {
+              qLibraryId: 'id1',
+            },
+            {
+              qLibraryId: 'id2',
+            },
+          ],
+          measures: [
+            {
+              title: 'title10',
+            },
+            {
+              qLibraryId: 'id11',
+            },
+            {
+              qLibraryId: 'id12',
+            },
+          ],
+          excludedDimensions: [],
+          excludedMeasures: [],
+        },
+      ],
+    };
+    dimensionList = [
+      {
+        qInfo: { qId: 'id1' },
+        qData: { title: 'title1' },
+      },
+    ];
+    measureList = [
+      {
+        qInfo: { qId: 'id11' },
+        qData: { title: 'title11' },
+      },
+    ];
+  });
+
+  it('should return false if measures.length + excludedMeasures.length < minMeasures', () => {
+    helpers.checkLibraryObjects({ exportFormat, dimensionList, measureList });
+    expect(exportFormat).to.deep.equal({
+      data: [
+        {
+          dimensions: [
+            {
+              title: 'title0',
+            },
+            {
+              qLibraryId: 'id1',
+              title: 'title1',
+            },
+            {
+              qLibraryId: 'id2',
+            },
+          ],
+          measures: [
+            {
+              title: 'title10',
+            },
+            {
+              qLibraryId: 'id11',
+              title: 'title11',
+            },
+            {
+              qLibraryId: 'id12',
+            },
+          ],
+          excludedDimensions: [],
+          excludedMeasures: [],
+        },
+      ],
+    });
+  });
+});

--- a/apis/conversion/src/helpers/index.js
+++ b/apis/conversion/src/helpers/index.js
@@ -3,6 +3,7 @@
 import extend from 'extend';
 import utils from '../utils';
 import arrayUtils from '../array-util';
+import libraryUtils from '../library-utils';
 
 const MAX_SAFE_INTEGER = 2 ** 53 - 1;
 
@@ -313,6 +314,23 @@ function addDefaultMeasures({ exportFormat, maxMeasures, minMeasures, newHyperCu
   }
 }
 
+function updateTitle(item, libraryItemList) {
+  if (item.qLibraryId) {
+    const libItem = libraryUtils.findLibraryItem(item.qLibraryId, libraryItemList);
+    if (libItem) {
+      item.title = libItem.qData.title;
+    }
+  }
+}
+
+function checkLibraryObjects({ exportFormat, dimensionList, measureList }) {
+  for (let i = 0; i < exportFormat.data.length; ++i) {
+    const { dimensions, measures, excludedDimensions, excludedMeasures } = exportFormat.data[i];
+    [...dimensions, ...excludedDimensions].forEach((item) => updateTitle(item, dimensionList));
+    [...measures, ...excludedMeasures].forEach((item) => updateTitle(item, measureList));
+  }
+}
+
 export default {
   restoreChangedProperties,
   isMasterItemPropperty,
@@ -332,4 +350,5 @@ export default {
   initLayoutExclude,
   addDefaultDimensions,
   addDefaultMeasures,
+  checkLibraryObjects,
 };

--- a/apis/conversion/src/index.js
+++ b/apis/conversion/src/index.js
@@ -50,16 +50,21 @@ const getImportPropertiesFnc = (qae) => {
 };
 
 export const convertTo = async ({ halo, model, cellRef, newType }) => {
-  const propertyTree = await model.getFullPropertyTree();
+  const [propertyTree, targetSnType] = await Promise.all([
+    model.getFullPropertyTree(),
+    getType({ halo, name: newType }),
+  ]);
   const sourceQae = cellRef.current.getQae();
   const exportProperties = getExportPropertiesFnc(sourceQae);
-  const targetSnType = await getType({ halo, name: newType });
   const targetQae = targetSnType.qae;
   const importProperties = getImportPropertiesFnc(targetQae);
   const exportFormat = exportProperties({
     propertyTree,
     hypercubePath: helpers.getHypercubePath(sourceQae),
   });
+  const dimensionList = cellRef.current.getLibraryList('dimension');
+  const measureList = cellRef.current.getLibraryList('measure');
+  helpers.checkLibraryObjects({ exportFormat, dimensionList, measureList });
   const initial = utils.getValue(targetQae, 'properties.initial', {});
   const initialProperties = {
     qInfo: {

--- a/apis/conversion/src/library-utils.js
+++ b/apis/conversion/src/library-utils.js
@@ -1,0 +1,17 @@
+function findLibraryItem(id, libraryItemList) {
+  let i;
+  let item;
+  if (libraryItemList) {
+    for (i = 0; i < libraryItemList.length; i++) {
+      item = libraryItemList[i];
+      if (item.qInfo.qId === id) {
+        return item;
+      }
+    }
+  }
+  return null;
+}
+
+export default {
+  findLibraryItem,
+};

--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -15,6 +15,7 @@ import useRect from '../hooks/useRect';
 import useLayout, { useAppLayout } from '../hooks/useLayout';
 import InstanceContext from '../contexts/InstanceContext';
 import useObjectSelections from '../hooks/useObjectSelections';
+import useLibraryList from '../hooks/useLibraryList';
 
 /**
  * @interface
@@ -284,6 +285,8 @@ const Cell = forwardRef(({ halo, model, initialSnOptions, initialError, onMount 
   const [selections] = useObjectSelections(app, model);
   const [hovering, setHover] = useState(false);
   const hoveringDebouncer = useRef({ enter: null, leave: null });
+  const [dimensionList] = useLibraryList(app, 'dimension');
+  const [measureList] = useLibraryList(app, 'measure');
 
   const handleOnMouseEnter = () => {
     if (hoveringDebouncer.current.leave) {
@@ -372,6 +375,9 @@ const Cell = forwardRef(({ halo, model, initialSnOptions, initialError, onMount 
   useImperativeHandle(
     ref,
     () => ({
+      getLibraryList(type = 'dimension') {
+        return type === 'dimension' ? dimensionList : measureList;
+      },
       getQae() {
         return state.sn.generator.qae;
       },

--- a/apis/nucleus/src/hooks/useLibraryList.js
+++ b/apis/nucleus/src/hooks/useLibraryList.js
@@ -1,5 +1,5 @@
-import useSessionModel from '@nebula.js/nucleus/src/hooks/useSessionModel';
-import useLayout from '@nebula.js/nucleus/src/hooks/useLayout';
+import useSessionModel from './useSessionModel';
+import useLayout from './useLayout';
 
 const D = {
   qInfo: {

--- a/commands/serve/web/components/FieldsPopover.jsx
+++ b/commands/serve/web/components/FieldsPopover.jsx
@@ -10,7 +10,7 @@ import { useTheme } from '@nebula.js/ui/theme';
 
 import useSessionModel from '@nebula.js/nucleus/src/hooks/useSessionModel';
 import useLayout from '@nebula.js/nucleus/src/hooks/useLayout';
-import useLibraryList from '../hooks/useLibraryList';
+import useLibraryList from '@nebula.js/nucleus/src/hooks/useLibraryList';
 
 import AppContext from '../contexts/AppContext';
 

--- a/commands/serve/web/components/property-panel/Fields.jsx
+++ b/commands/serve/web/components/property-panel/Fields.jsx
@@ -13,7 +13,7 @@ import {
 
 import Remove from '@nebula.js/ui/icons/remove';
 
-import useLibraryList from '../../hooks/useLibraryList';
+import useLibraryList from '@nebula.js/nucleus/src/hooks/useLibraryList';
 
 import AppContext from '../../contexts/AppContext';
 import FieldsPopover from '../FieldsPopover';


### PR DESCRIPTION
This PR is to:
1. Move useLibraryList from commands/serve/web to nucleus so it can be reused
2. use useLibraryList in Cell.jsx to get library items
3. expose library items through cellRef to be used in conversion
4. use library items to update master dimensions/measures during conversion