### PR TITLE
fix: trim whitespace before using url -

### DIFF
--- a/commands/serve/web/connect.js
+++ b/commands/serve/web/connect.js
@@ -36,15 +36,16 @@ const parseEngineURL = (url) => {
   }
 
   let appId;
-  let engineUrl = url;
+  const trimmedUrl = url.trim();
+  let engineUrl = trimmedUrl;
   let appUrl;
 
-  const rxApp = /\/app\/([^?&#:]+)/.exec(url);
+  const rxApp = /\/app\/([^?&#:]+)/.exec(trimmedUrl);
 
   if (rxApp) {
     [, appId] = rxApp;
-    engineUrl = url.substring(0, rxApp.index);
-    appUrl = url;
+    engineUrl = trimmedUrl.substring(0, rxApp.index);
+    appUrl = trimmedUrl;
   }
 
   return {


### PR DESCRIPTION
## Motivation

The dev environment is not working which can create some frustration since the solution is not obvious. The issue comes from having spaces in the `engineUrl`. Therefore, we need to trim the URL before using it.
