### PR TITLE
fix: make sure ActionsTooblar doesn't steal focus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
   build:
     docker:
       - image: circleci/node:12.15.0
-      - image: qlikcore/engine:12.972.0
+      - image: qlikcore/engine:12.961.0
         command: |
           -S AcceptEULA=yes
           -S SSEPlugin=sse,localhost:50051

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
   build:
     docker:
       - image: circleci/node:12.15.0
-      - image: qlikcore/engine:12.925.0
+      - image: qlikcore/engine:12.972.0
         command: |
           -S AcceptEULA=yes
           -S SSEPlugin=sse,localhost:50051

--- a/apis/nucleus/src/components/ActionsToolbar.jsx
+++ b/apis/nucleus/src/components/ActionsToolbar.jsx
@@ -154,6 +154,8 @@ const ActionsToolbar = ({
   return popover.show ? (
     <Popover
       disableEnforceFocus
+      disableAutoFocus
+      disableRestoreFocus
       open={popover.show}
       anchorEl={popover.anchorEl}
       anchorOrigin={popoverAnchorOrigin}

--- a/commands/serve/docker-compose.yml
+++ b/commands/serve/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   engine:
-    image: qlikcore/engine:${ENGINE_VERSION:-12.700.0}
+    image: qlikcore/engine:${ENGINE_VERSION:-12.972.0}
     # restart: always
     command: |
       -S AcceptEULA=${ACCEPT_EULA:-no}

--- a/test/fixtures/docker/docker-compose.yml
+++ b/test/fixtures/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   engine:
-    image: qlikcore/engine:${ENGINE_VERSION:-12.700.0}
+    image: qlikcore/engine:${ENGINE_VERSION:-12.972.0}
     # restart: always
     command: |
       -S AcceptEULA=${ACCEPT_EULA:-no}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation
When starting selections and the ActionsToolbar shows up, it steals focus. It also set focus to where it was before opening when it closes. This is disruptive for the sn-table since you want to stay inside the table, then potentially tab to the toolbar when you want to confirm/cancel selections.