### PR TITLE
feat(cli-build): add mode option to build

### DIFF
--- a/commands/build/README.md
+++ b/commands/build/README.md
@@ -21,4 +21,6 @@ Options:
                                           [string] [default: "nebula.config.js"]
   --watch, -w      Watch source files                 [boolean] [default: false]
   --sourcemap, -m  Generate source map                 [boolean] [default: true]
+  --mode           Explicitly set mode
+                                 [string] [choices: "production", "development"]
 ```

--- a/commands/build/lib/build.js
+++ b/commands/build/lib/build.js
@@ -115,7 +115,7 @@ const config = ({
 
 const minified = async (argv) => {
   const c = config({
-    mode: 'production',
+    mode: argv.mode || 'production',
     format: 'umd',
     argv,
   });
@@ -125,7 +125,7 @@ const minified = async (argv) => {
 
 const esm = async (argv, core) => {
   const c = config({
-    mode: 'development',
+    mode: argv.mode || 'development',
     format: 'esm',
     argv,
     core,
@@ -152,7 +152,7 @@ function clearScreen(msg) {
 
 const watch = async (argv) => {
   const c = config({
-    mode: 'development',
+    mode: argv.mode || 'development',
     format: 'umd',
     argv,
   });

--- a/commands/build/lib/init-config.js
+++ b/commands/build/lib/init-config.js
@@ -23,6 +23,11 @@ const options = {
     alias: 'm',
     default: true,
   },
+  mode: {
+    description: 'Explicitly set mode ("developer"|"production")',
+    type: 'string',
+    default: undefined,
+  },
 };
 
 module.exports = (yargs) =>


### PR DESCRIPTION
Possibility to explicitly override `mode` option (`development` or `production`) used for the rollup config. This allows user to get everything minified (even the core package).
