### PR TITLE
fix: do not return undefined build config

### DIFF
--- a/commands/build/lib/init-config.js
+++ b/commands/build/lib/init-config.js
@@ -46,6 +46,6 @@ module.exports = (yargs) => {
       }
       throw new Error(`Config ${configPath} not found`);
     }
-    return require(configPath).build;
+    return require(configPath).build || {};
   });
 };


### PR DESCRIPTION
Solves an issue causing a crash with the message _"Invalid JSON config file: nebula.config.js"_ when running `nebula serve` with a `nebula.config.js` file without a `build` section.
The issue was introduced with #625 and the lines:
```
const yargsArgs = argv.config ? ['--config', argv.config] : [];
defaultBuildConfig = initConfig(yargs(yargsArgs)).argv;
```
(The problem could probably occur in other scenarios as well, but this fix should take care of the problem)