### PR TITLE
fix(extension-wrapper): support paths argument in begin

### DIFF
--- a/commands/sense/src/legacy/__tests__/selections.spec.js
+++ b/commands/sense/src/legacy/__tests__/selections.spec.js
@@ -1,0 +1,44 @@
+import createSelections from '../selections';
+
+describe('supernova-wrapper', () => {
+  describe('selections', () => {
+    let selectionsApi;
+    let backendApi;
+    let selections;
+
+    beforeEach(() => {
+      selectionsApi = {
+        activated: sinon.stub(),
+        deactivated: sinon.stub(),
+      };
+      backendApi = {
+        beginSelections: sinon.stub(),
+        endSelections: sinon.stub(),
+        model: {
+          resetMadeSelections: sinon.stub(),
+          app: {
+            switchModalSelection: sinon.stub(),
+          },
+        },
+      };
+      selections = createSelections({ selectionsApi, backendApi });
+      selections.emit = sinon.stub();
+    });
+
+    it('should `begin`', () => {
+      selections.begin();
+      expect(selectionsApi.activated).to.have.been.calledWithExactly(true);
+      expect(backendApi.beginSelections).to.have.been.calledWithExactly();
+      expect(selections.emit).to.have.been.calledWithExactly('activated');
+    });
+
+    it('should `begin` with paths', () => {
+      const paths = ['hypercubePath', 'otherHypercubePath'];
+      selections.begin(paths);
+      expect(selectionsApi.activated).to.have.been.calledWithExactly(true);
+      expect(backendApi.beginSelections).to.not.been.called;
+      expect(backendApi.model.app.switchModalSelection).to.have.been.calledWithExactly(backendApi.model, paths);
+      expect(selections.emit).to.have.been.calledWithExactly('activated');
+    });
+  });
+});

--- a/commands/sense/src/legacy/selections.js
+++ b/commands/sense/src/legacy/selections.js
@@ -13,9 +13,14 @@ export default (scope) => {
   // TODO one and only one
 
   const selectionAPI = {
-    begin() {
-      scope.selectionsApi.activated();
-      scope.backendApi.beginSelections();
+    begin(paths) {
+      const suppressBeginSelections = true;
+      scope.selectionsApi.activated(suppressBeginSelections);
+      if (paths) {
+        scope.backendApi.model.app.switchModalSelection(scope.backendApi.model, paths);
+      } else {
+        scope.backendApi.beginSelections();
+      }
       selectionAPI.emit('activated');
     },
     clear() {


### PR DESCRIPTION
## Motivation

support selections.begin(paths) when wrapped in an sense extension
(it is already supported when used in nebula.js outside sense. [link](https://github.com/qlik-oss/nebula.js/blob/bd39cb4b4d66ac5153083046f0a511263a7095ba/apis/nucleus/src/hooks/useObjectSelections.js#L37))
