### PR TITLE
chore: handle --ext edge case

### DIFF
--- a/commands/sense/lib/build.js
+++ b/commands/sense/lib/build.js
@@ -49,7 +49,7 @@ async function build(argv) {
       encoding: 'utf8',
     });
     qextjs = qextjs.replace('{{DIST}}', `./${main.replace(/^[./]*/, '').replace(/\.js$/, '')}`);
-    qextjs = qextjs.replace('{{EXT}}', `./${targetDir}/${targetFile}`);
+    qextjs = qextjs.replace('{{EXT}}', `./${targetFile}`);
 
     fs.writeFileSync(qextFileName, JSON.stringify(contents, null, 2));
     fs.writeFileSync(qextFileNameJs, qextjs);

--- a/commands/sense/src/ext.js
+++ b/commands/sense/src/ext.js
@@ -1,6 +1,12 @@
 define(['{{DIST}}', '{{EXT}}'], (supernova, ext) =>
   function supernovaExtension(env) {
     var v = supernova(env);
-    v.ext = typeof ext === 'function' ? ext(env) : ext;
+    var extDef = ext;
+    /* eslint no-underscore-dangle:0 */
+    if (ext.__esmodule === true) {
+      // Handles es modules with multiple exports
+      extDef = ext.default;
+    }
+    v.ext = typeof extDef === 'function' ? extDef(env) : extDef;
     return v;
   });


### PR DESCRIPTION
The "--partial" build didn't handle the "--ext" command correctly as the resulting package couldn't find the ext file. I corrected the path and added a check for an edge case where the ext file is an es module but contains multiple exports (sn-table has this for example to do unit tests)
