### PR TITLE
feat: give charts access to the nebula instance

### DIFF
--- a/apis/nucleus/src/__tests__/nucleus.spec.js
+++ b/apis/nucleus/src/__tests__/nucleus.spec.js
@@ -54,7 +54,10 @@ describe('nucleus', () => {
         some: 'thing',
       },
     });
-    expect(typesFn.getCall(0).args[0].halo.public.galaxy).to.eql({
+    const { galaxy } = typesFn.getCall(0).args[0].halo.public;
+    expect(galaxy.nebbie).to.be.ok;
+    delete galaxy.nebbie;
+    expect(galaxy).to.eql({
       anything: {
         some: 'thing',
       },

--- a/apis/nucleus/src/__tests__/nucleus.spec.js
+++ b/apis/nucleus/src/__tests__/nucleus.spec.js
@@ -55,8 +55,6 @@ describe('nucleus', () => {
       },
     });
     const { galaxy } = typesFn.getCall(0).args[0].halo.public;
-    expect(galaxy.nebbie).to.be.ok;
-    delete galaxy.nebbie;
     expect(galaxy).to.eql({
       anything: {
         some: 'thing',

--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -254,13 +254,14 @@ const getType = async ({ types, name, version }) => {
   return SN;
 };
 
-const loadType = async ({ dispatch, types, visualization, version, model, app, selections }) => {
+const loadType = async ({ dispatch, types, visualization, version, model, app, selections, nebbie }) => {
   try {
     const snType = await getType({ types, name: visualization, version });
     const sn = snType.create({
       model,
       app,
       selections,
+      nebbie,
     });
     return sn;
   } catch (err) {
@@ -271,6 +272,7 @@ const loadType = async ({ dispatch, types, visualization, version, model, app, s
 
 const Cell = forwardRef(({ halo, model, initialSnOptions, initialSnPlugins, initialError, onMount }, ref) => {
   const { app, types } = halo;
+  const { nebbie } = halo.public;
 
   const { translator, language } = useContext(InstanceContext);
   const theme = useTheme();
@@ -329,6 +331,7 @@ const Cell = forwardRef(({ halo, model, initialSnOptions, initialSnPlugins, init
         model,
         app,
         selections,
+        nebbie,
       });
       if (sn) {
         dispatch({ type: 'LOADED', sn, visualization });

--- a/apis/nucleus/src/components/Error.jsx
+++ b/apis/nucleus/src/components/Error.jsx
@@ -79,7 +79,7 @@ export default function Error({ title = 'Error', message = '', data = [] }) {
       container
       direction="column"
       alignItems="center"
-      justify="center"
+      justifyContent="center"
       style={{ position: 'relative', height: '100%', width: '100%' }}
     >
       <Grid item>

--- a/apis/nucleus/src/components/Loading.jsx
+++ b/apis/nucleus/src/components/Loading.jsx
@@ -10,7 +10,7 @@ export default function Loading() {
       container
       direction="column"
       alignItems="center"
-      justify="center"
+      justifyContent="center"
       style={{
         position: 'absolute',
         width: '100%',

--- a/apis/nucleus/src/components/LongRunningQuery.jsx
+++ b/apis/nucleus/src/components/LongRunningQuery.jsx
@@ -70,7 +70,7 @@ export default function LongRunningQuery({ canCancel, canRetry, api }) {
       container
       direction="column"
       alignItems="center"
-      justify="center"
+      justifyContent="center"
       className={stripes}
       style={{
         position: 'absolute',

--- a/apis/nucleus/src/components/Supernova.jsx
+++ b/apis/nucleus/src/components/Supernova.jsx
@@ -76,6 +76,7 @@ const Supernova = ({ sn, snOptions: options, snPlugins: plugins, layout, appLayo
           layout,
           options,
           plugins,
+          embed: halo.public.galaxy.nebbie,
           context: {
             constraints,
             // halo.public.theme is a singleton so themeName is used as dep to make sure this effect is triggered

--- a/apis/nucleus/src/components/Supernova.jsx
+++ b/apis/nucleus/src/components/Supernova.jsx
@@ -76,7 +76,7 @@ const Supernova = ({ sn, snOptions: options, snPlugins: plugins, layout, appLayo
           layout,
           options,
           plugins,
-          embed: halo.public.galaxy.nebbie,
+          embed: halo.public.nebbie,
           context: {
             constraints,
             // halo.public.theme is a singleton so themeName is used as dep to make sure this effect is triggered

--- a/apis/nucleus/src/components/__tests__/supernova.spec.jsx
+++ b/apis/nucleus/src/components/__tests__/supernova.spec.jsx
@@ -107,7 +107,7 @@ describe('<Supernova />', () => {
       snPlugins: [],
       layout: 'layout',
       appLayout: { qLocaleInfo: 'loc' },
-      halo: { public: { theme: 'theme' }, app: { session: {} } },
+      halo: { public: { theme: 'theme', nebbie: 'embedAPI' }, app: { session: {} } },
       rendererOptions: {
         createNodeMock: () => ({
           style: {},
@@ -126,6 +126,7 @@ describe('<Supernova />', () => {
       layout: 'layout',
       options: snOptions,
       plugins: [],
+      embed: 'embedAPI',
       context: {
         constraints: {},
         appLayout: { qLocaleInfo: 'loc' },

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -90,7 +90,6 @@ export function ListBoxInline({ app, fieldIdentifier, stateName = '$', options =
   useEffect(() => {
     if (selections) {
       if (!selections.isModal(model)) {
-        selections.goModal('/qListObjectDef');
         selections.on('deactivated', () => {
           setShowToolbar(false);
         });

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -386,6 +386,7 @@ function nuked(configuration = {}) {
     };
 
     halo.public.nebbie = api;
+    halo.public.galaxy.nebbie = api;
     halo.types = types;
 
     return api;

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -166,7 +166,6 @@ function nuked(configuration = {}) {
       config: configuration,
       public: publicAPIs,
       context: currentContext,
-      nebbie: null,
       types: null,
     };
 
@@ -382,6 +381,7 @@ function nuked(configuration = {}) {
       },
       /**
        * Gets a list of registered visualization types and versions
+       * @function
        * @returns {Array<Object>} types
        * @example
        * const types = n.getRegisteredTypes();
@@ -400,7 +400,6 @@ function nuked(configuration = {}) {
     };
 
     halo.public.nebbie = api;
-    halo.public.galaxy.nebbie = api;
     halo.types = types;
 
     return api;

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -380,6 +380,20 @@ function nuked(configuration = {}) {
         };
         return fieldSels;
       },
+      /**
+       * Gets a list of registered visualization types and versions
+       * @returns {Array<Object>} types
+       * @example
+       * const types = n.getRegisteredTypes();
+       * // Contains
+       * //[
+       * // {
+       * //   name: "barchart"
+       * //   versions:[undefined, "1.2.0"]
+       * // }
+       * //]
+       */
+      getRegisteredTypes: types.getList,
       __DO_NOT_USE__: {
         types,
       },

--- a/apis/nucleus/src/sn/__tests__/types.spec.js
+++ b/apis/nucleus/src/sn/__tests__/types.spec.js
@@ -52,11 +52,38 @@ describe('types', () => {
       );
     });
 
+    it('should instantiate a type when calling get the first time', () => {
+      type.withArgs({ name: 'pie', version: '1.0.3' }).returns({ name: 'pie', version: '1.0.3' });
+      expect(c.get({ name: 'pie', version: '1.0.3' })).to.eql({ name: 'pie', version: '1.0.3' });
+      expect(type).to.have.been.calledWithExactly(
+        {
+          name: 'pie',
+          version: '1.0.3',
+        },
+        'halo',
+        undefined
+      );
+    });
+
+    it('should only instantiate a type when calling get the first time', () => {
+      type.withArgs({ name: 'pie', version: '1.0.3' }).returns({ name: 'pie', version: '1.0.3' });
+      c.get({ name: 'pie', version: '1.0.3' }, 'opts');
+      expect(c.get({ name: 'pie', version: '1.7.0' })).to.eql({ name: 'pie', version: '1.0.3' });
+    });
+
     it('should throw when registering an already registered version', () => {
       c.register({ name: 'pie', version: '1.0.3' }, 'opts');
       const fn = () => c.register({ name: 'pie', version: '1.0.3' }, 'opts');
 
       expect(fn).to.throw("Supernova 'pie@1.0.3' already registered.");
+    });
+
+    it('should fallback to first registered version when getting unknown version', () => {
+      type.withArgs({ name: 'pie', version: '1.0.3' }).returns({ name: 'pie', version: '1.0.3' });
+      type.withArgs({ name: 'pie', version: '1.0.4' }).returns({ name: 'pie', version: '1.0.4' });
+      c.register({ name: 'pie', version: '1.0.3' }, 'opts');
+      c.register({ name: 'pie', version: '1.0.4' }, 'opts');
+      expect(c.get({ name: 'pie', version: '1.7.0' })).to.eql({ name: 'pie', version: '1.0.3' });
     });
 
     it('should find 1.5.1 as matching version from properties', () => {

--- a/apis/nucleus/src/sn/types.js
+++ b/apis/nucleus/src/sn/types.js
@@ -77,6 +77,11 @@ export function create({ halo, parent }) {
       }
       return tc[name].get(version) || p.get(typeInfo);
     },
+    getList: () =>
+      Object.keys(tc).map((key) => ({
+        name: key,
+        versions: Object.keys(tc[key].versions).map((v) => (v === 'undefined' ? undefined : v)),
+      })),
     clearFromCache: (name) => {
       if (tc[name]) {
         tc[name] = undefined;

--- a/apis/nucleus/src/sn/types.js
+++ b/apis/nucleus/src/sn/types.js
@@ -71,9 +71,21 @@ export function create({ halo, parent }) {
       return tc[name].getMatchingVersionFromProperties(propertyVersion);
     },
     get(typeInfo) {
-      const { name, version } = typeInfo;
-      if (!tc[name] || !tc[name].versions[version]) {
+      const { name } = typeInfo;
+      let { version } = typeInfo;
+      if (!tc[name]) {
+        // Fall back to existing version
+        if (__NEBULA_DEV__) {
+          console.warn(`Visualization ${name} is not registered.`); // eslint-disable-line no-console
+        }
         this.register({ name, version });
+      } else if (!tc[name].versions[version]) {
+        // Fall back to existing version
+        const versionToUse = Object.keys(tc[name].versions)[0];
+        if (__NEBULA_DEV__) {
+          console.warn(`Version ${version} of ${name} is not registered. Falling back to version ${versionToUse}`); // eslint-disable-line no-console
+        }
+        version = versionToUse;
       }
       return tc[name].get(version) || p.get(typeInfo);
     },

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -676,7 +676,15 @@
         },
         "getRegisteredTypes": {
           "description": "Gets a list of registered visualization types and versions",
-          "type": "any",
+          "kind": "function",
+          "params": [],
+          "returns": {
+            "description": "types",
+            "kind": "array",
+            "items": {
+              "type": "Object"
+            }
+          },
           "examples": [
             "const types = n.getRegisteredTypes();\n// Contains\n//[\n// {\n//   name: \"barchart\"\n//   versions:[undefined, \"1.2.0\"]\n// }\n//]"
           ]
@@ -852,141 +860,6 @@
             "description": "True if the specified flag is enabled, false otherwise.",
             "type": "boolean"
           }
-        }
-      }
-    },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
-      "kind": "interface",
-      "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
-              "type": "string"
-            }
-          }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
-        }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
-    },
-    "Field": {
-      "kind": "alias",
-      "items": {
-        "kind": "union",
-        "items": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "qae.NxDimension"
-          },
-          {
-            "type": "qae.NxMeasure"
-          },
-          {
-            "type": "#/definitions/LibraryField"
-          }
-        ]
-      }
-    },
-    "CreateConfig": {
-      "description": "Rendering configuration for creating and rendering a new object",
-      "extends": [
-        {
-          "type": "#/definitions/BaseConfig"
-        }
-      ],
-      "kind": "interface",
-      "entries": {
-        "type": {
-          "type": "string"
-        },
-        "version": {
-          "type": "string"
-        },
-        "fields": {
-          "optional": true,
-          "kind": "union",
-          "items": [
-            {
-              "kind": "array",
-              "items": {
-                "type": "#/definitions/Field"
-              }
-            }
-          ]
-        },
-        "properties": {
-          "optional": true,
-          "type": "qae.GenericObjectProperties"
-        }
-      }
-    },
-    "BaseConfig": {
-      "description": "Basic rendering configuration for rendering an object",
-      "kind": "interface",
-      "entries": {
-        "element": {
-          "type": "HTMLElement"
-        },
-        "options": {
-          "optional": true,
-          "type": "object"
-        },
-        "plugins": {
-          "optional": true,
-          "kind": "array",
-          "items": {
-            "type": "#/definitions/Plugin"
-          }
-        }
-      }
-    },
-    "GetConfig": {
-      "description": "Rendering configuration for rendering an existing object",
-      "extends": [
-        {
-          "type": "#/definitions/BaseConfig"
-        }
-      ],
-      "kind": "interface",
-      "entries": {
-        "id": {
-          "type": "string"
-        }
-      }
-    },
-    "LibraryField": {
-      "kind": "interface",
-      "entries": {
-        "qLibraryId": {
-          "type": "string"
-        },
-        "type": {
-          "kind": "union",
-          "items": [
-            {
-              "kind": "literal",
-              "value": "'dimension'"
-            },
-            {
-              "kind": "literal",
-              "value": "'measure'"
-            }
-          ]
         }
       }
     },
@@ -1182,6 +1055,141 @@
           }
         }
       }
+    },
+    "Field": {
+      "kind": "alias",
+      "items": {
+        "kind": "union",
+        "items": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "qae.NxDimension"
+          },
+          {
+            "type": "qae.NxMeasure"
+          },
+          {
+            "type": "#/definitions/LibraryField"
+          }
+        ]
+      }
+    },
+    "CreateConfig": {
+      "description": "Rendering configuration for creating and rendering a new object",
+      "extends": [
+        {
+          "type": "#/definitions/BaseConfig"
+        }
+      ],
+      "kind": "interface",
+      "entries": {
+        "type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "fields": {
+          "optional": true,
+          "kind": "union",
+          "items": [
+            {
+              "kind": "array",
+              "items": {
+                "type": "#/definitions/Field"
+              }
+            }
+          ]
+        },
+        "properties": {
+          "optional": true,
+          "type": "qae.GenericObjectProperties"
+        }
+      }
+    },
+    "BaseConfig": {
+      "description": "Basic rendering configuration for rendering an object",
+      "kind": "interface",
+      "entries": {
+        "element": {
+          "type": "HTMLElement"
+        },
+        "options": {
+          "optional": true,
+          "type": "object"
+        },
+        "plugins": {
+          "optional": true,
+          "kind": "array",
+          "items": {
+            "type": "#/definitions/Plugin"
+          }
+        }
+      }
+    },
+    "GetConfig": {
+      "description": "Rendering configuration for rendering an existing object",
+      "extends": [
+        {
+          "type": "#/definitions/BaseConfig"
+        }
+      ],
+      "kind": "interface",
+      "entries": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "LibraryField": {
+      "kind": "interface",
+      "entries": {
+        "qLibraryId": {
+          "type": "string"
+        },
+        "type": {
+          "kind": "union",
+          "items": [
+            {
+              "kind": "literal",
+              "value": "'dimension'"
+            },
+            {
+              "kind": "literal",
+              "value": "'measure'"
+            }
+          ]
+        }
+      }
+    },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
     },
     "LoadType": {
       "kind": "interface",

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "@nebula.js/stardust",
     "description": "Product and framework agnostic integration API for Qlik's Associative Engine",
-    "version": "1.4.0",
+    "version": "1.7.0",
     "license": "MIT",
     "stability": "stable"
   },

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -3,7 +3,7 @@
   "info": {
     "name": "@nebula.js/stardust",
     "description": "Product and framework agnostic integration API for Qlik's Associative Engine",
-    "version": "1.2.0",
+    "version": "1.4.0",
     "license": "MIT",
     "stability": "stable"
   },
@@ -341,6 +341,16 @@
         "import { useTheme } from '@nebula.js/stardust';\n\nconst theme = useTheme();\nconsole.log(theme.getContrastinColorTo('#ff0000'));"
       ]
     },
+    "useEmbed": {
+      "description": "Gets the embed instance used.",
+      "kind": "function",
+      "params": [],
+      "returns": {
+        "description": "The embed instance used.",
+        "type": "#/definitions/Embed"
+      },
+      "examples": ["import { useEmbed } from '@nebula.js/stardust';\n\nconst embed = useEmbed();\nembed.render(...)"]
+    },
     "useTranslator": {
       "description": "Gets the translator.",
       "kind": "function",
@@ -661,6 +671,13 @@
           },
           "examples": [
             "const fieldInstance = await n.field(\"MyField\");\nfieldInstance.mount(element, { title: \"Hello Field\"});"
+          ]
+        },
+        "getRegisteredTypes": {
+          "description": "Gets a list of registered visualization types and versions",
+          "type": "any",
+          "examples": [
+            "const types = n.getRegisteredTypes();\n// Contains\n//[\n// {\n//   name: \"barchart\"\n//   versions:[undefined, \"1.2.0\"]\n// }\n//]"
           ]
         }
       }
@@ -1030,33 +1047,6 @@
         }
       }
     },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
-      "kind": "interface",
-      "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
-              "type": "string"
-            }
-          }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
-        }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
-    },
     "Field": {
       "kind": "alias",
       "items": {
@@ -1164,6 +1154,33 @@
           ]
         }
       }
+    },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
     },
     "LoadType": {
       "kind": "interface",

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -343,6 +343,7 @@
     },
     "useEmbed": {
       "description": "Gets the embed instance used.",
+      "stability": "experimental",
       "kind": "function",
       "params": [],
       "returns": {
@@ -854,6 +855,141 @@
         }
       }
     },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
+    },
+    "Field": {
+      "kind": "alias",
+      "items": {
+        "kind": "union",
+        "items": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "qae.NxDimension"
+          },
+          {
+            "type": "qae.NxMeasure"
+          },
+          {
+            "type": "#/definitions/LibraryField"
+          }
+        ]
+      }
+    },
+    "CreateConfig": {
+      "description": "Rendering configuration for creating and rendering a new object",
+      "extends": [
+        {
+          "type": "#/definitions/BaseConfig"
+        }
+      ],
+      "kind": "interface",
+      "entries": {
+        "type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "fields": {
+          "optional": true,
+          "kind": "union",
+          "items": [
+            {
+              "kind": "array",
+              "items": {
+                "type": "#/definitions/Field"
+              }
+            }
+          ]
+        },
+        "properties": {
+          "optional": true,
+          "type": "qae.GenericObjectProperties"
+        }
+      }
+    },
+    "BaseConfig": {
+      "description": "Basic rendering configuration for rendering an object",
+      "kind": "interface",
+      "entries": {
+        "element": {
+          "type": "HTMLElement"
+        },
+        "options": {
+          "optional": true,
+          "type": "object"
+        },
+        "plugins": {
+          "optional": true,
+          "kind": "array",
+          "items": {
+            "type": "#/definitions/Plugin"
+          }
+        }
+      }
+    },
+    "GetConfig": {
+      "description": "Rendering configuration for rendering an existing object",
+      "extends": [
+        {
+          "type": "#/definitions/BaseConfig"
+        }
+      ],
+      "kind": "interface",
+      "entries": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "LibraryField": {
+      "kind": "interface",
+      "entries": {
+        "qLibraryId": {
+          "type": "string"
+        },
+        "type": {
+          "kind": "union",
+          "items": [
+            {
+              "kind": "literal",
+              "value": "'dimension'"
+            },
+            {
+              "kind": "literal",
+              "value": "'measure'"
+            }
+          ]
+        }
+      }
+    },
     "AppSelections": {
       "kind": "class",
       "constructor": {
@@ -1046,141 +1182,6 @@
           }
         }
       }
-    },
-    "Field": {
-      "kind": "alias",
-      "items": {
-        "kind": "union",
-        "items": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "qae.NxDimension"
-          },
-          {
-            "type": "qae.NxMeasure"
-          },
-          {
-            "type": "#/definitions/LibraryField"
-          }
-        ]
-      }
-    },
-    "CreateConfig": {
-      "description": "Rendering configuration for creating and rendering a new object",
-      "extends": [
-        {
-          "type": "#/definitions/BaseConfig"
-        }
-      ],
-      "kind": "interface",
-      "entries": {
-        "type": {
-          "type": "string"
-        },
-        "version": {
-          "type": "string"
-        },
-        "fields": {
-          "optional": true,
-          "kind": "union",
-          "items": [
-            {
-              "kind": "array",
-              "items": {
-                "type": "#/definitions/Field"
-              }
-            }
-          ]
-        },
-        "properties": {
-          "optional": true,
-          "type": "qae.GenericObjectProperties"
-        }
-      }
-    },
-    "BaseConfig": {
-      "description": "Basic rendering configuration for rendering an object",
-      "kind": "interface",
-      "entries": {
-        "element": {
-          "type": "HTMLElement"
-        },
-        "options": {
-          "optional": true,
-          "type": "object"
-        },
-        "plugins": {
-          "optional": true,
-          "kind": "array",
-          "items": {
-            "type": "#/definitions/Plugin"
-          }
-        }
-      }
-    },
-    "GetConfig": {
-      "description": "Rendering configuration for rendering an existing object",
-      "extends": [
-        {
-          "type": "#/definitions/BaseConfig"
-        }
-      ],
-      "kind": "interface",
-      "entries": {
-        "id": {
-          "type": "string"
-        }
-      }
-    },
-    "LibraryField": {
-      "kind": "interface",
-      "entries": {
-        "qLibraryId": {
-          "type": "string"
-        },
-        "type": {
-          "kind": "union",
-          "items": [
-            {
-              "kind": "literal",
-              "value": "'dimension'"
-            },
-            {
-              "kind": "literal",
-              "value": "'measure'"
-            }
-          ]
-        }
-      }
-    },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
-      "kind": "interface",
-      "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
-              "type": "string"
-            }
-          }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
-        }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
     },
     "LoadType": {
       "kind": "interface",

--- a/apis/stardust/src/index.js
+++ b/apis/stardust/src/index.js
@@ -32,6 +32,7 @@ export {
   usePlugins,
   useConstraints,
   useOptions,
+  useEmbed,
   onTakeSnapshot,
 } from '@nebula.js/supernova';
 

--- a/apis/supernova/__tests__/unit/creator.spec.js
+++ b/apis/supernova/__tests__/unit/creator.spec.js
@@ -81,6 +81,7 @@ describe('creator', () => {
       galaxy = {
         deviceType: 'desktop',
         translator: { language: () => 'en' },
+        nebbie: 'embedAPI',
       };
       opts = {
         model: 'model',
@@ -103,6 +104,7 @@ describe('creator', () => {
         app: 'app',
         global: undefined,
         selections: 'selections',
+        nebbie: 'embedAPI',
         element: undefined,
         theme: undefined,
         translator: galaxy.translator,

--- a/apis/supernova/__tests__/unit/creator.spec.js
+++ b/apis/supernova/__tests__/unit/creator.spec.js
@@ -81,9 +81,9 @@ describe('creator', () => {
       galaxy = {
         deviceType: 'desktop',
         translator: { language: () => 'en' },
-        nebbie: 'embedAPI',
       };
       opts = {
+        nebbie: 'embedAPI',
         model: 'model',
         app: 'app',
         selections: 'selections',

--- a/apis/supernova/src/__tests__/hooks.spec.js
+++ b/apis/supernova/src/__tests__/hooks.spec.js
@@ -31,6 +31,7 @@ import {
   useConstraints,
   useOptions,
   onTakeSnapshot,
+  useEmbed,
 } from '../hooks';
 
 describe('hooks', () => {
@@ -755,6 +756,7 @@ describe('hooks', () => {
         theme: 'theme',
         translator: 'translator',
         plugins: 'plugins',
+        embed: 'embed',
         layout: 'layout',
         appLayout: 'appLayout',
         constraints: 'constraints',
@@ -899,6 +901,14 @@ describe('hooks', () => {
       run(c);
       c.__hooks.snaps[0].fn();
       expect(spy.callCount).to.equal(1);
+    });
+    it('useEmbed', () => {
+      let value;
+      c.fn = () => {
+        value = useEmbed();
+      };
+      run(c);
+      expect(value).to.eql('embed');
     });
   });
 });

--- a/apis/supernova/src/__tests__/hooks.spec.js
+++ b/apis/supernova/src/__tests__/hooks.spec.js
@@ -756,7 +756,7 @@ describe('hooks', () => {
         theme: 'theme',
         translator: 'translator',
         plugins: 'plugins',
-        embed: 'embed',
+        nebbie: 'embed',
         layout: 'layout',
         appLayout: 'appLayout',
         constraints: 'constraints',

--- a/apis/supernova/src/creator.js
+++ b/apis/supernova/src/creator.js
@@ -66,7 +66,7 @@ function createWithHooks(generator, opts, galaxy) {
       app: opts.app,
       global: qGlobal,
       selections: opts.selections,
-      nebbie: galaxy.nebbie,
+      nebbie: opts.nebbie,
       element: undefined, // set on mount
       // ---- singletons ----
       deviceType: galaxy.deviceType,

--- a/apis/supernova/src/creator.js
+++ b/apis/supernova/src/creator.js
@@ -66,6 +66,7 @@ function createWithHooks(generator, opts, galaxy) {
       app: opts.app,
       global: qGlobal,
       selections: opts.selections,
+      nebbie: galaxy.nebbie,
       element: undefined, // set on mount
       // ---- singletons ----
       deviceType: galaxy.deviceType,

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -693,6 +693,7 @@ export function useTheme() {
 /**
  * Gets the embed instance used.
  * @entry
+ * @experimental
  * @returns {Embed} The embed instance used.
  * @example
  * import { useEmbed } from '@nebula.js/stardust';

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -691,6 +691,20 @@ export function useTheme() {
 }
 
 /**
+ * Gets the embed instance used.
+ * @entry
+ * @returns {Embed} The embed instance used.
+ * @example
+ * import { useEmbed } from '@nebula.js/stardust';
+ *
+ * const embed = useEmbed();
+ * embed.render(...)
+ */
+export function useEmbed() {
+  return useInternalContext('nebbie');
+}
+
+/**
  * Gets the translator.
  * @entry
  * @returns {Translator} The translator.

--- a/apis/supernova/src/index.js
+++ b/apis/supernova/src/index.js
@@ -24,5 +24,6 @@ export {
   usePlugins,
   useConstraints,
   useOptions,
+  useEmbed,
   onTakeSnapshot,
 } from './hooks';

--- a/commands/serve/web/components/App.jsx
+++ b/commands/serve/web/components/App.jsx
@@ -307,7 +307,7 @@ export default function App({ app, info }) {
                     )}
                   </Grid>
                 ) : (
-                  <Grid container wrap="nowrap" style={{ paddingTop: '48px' }} justify="center">
+                  <Grid container wrap="nowrap" style={{ paddingTop: '48px' }} justifyContent="center">
                     <Grid item>
                       <CircularProgress />
                     </Grid>

--- a/commands/serve/web/components/Collection.jsx
+++ b/commands/serve/web/components/Collection.jsx
@@ -38,7 +38,7 @@ export default function Collection({ types, cache }) {
   return (
     <Grid
       container
-      justify="center"
+      justifyContent="center"
       spacing={expandedObject ? 0 : 2}
       style={{
         height: expandedObject ? '100%' : undefined,

--- a/commands/serve/web/components/Stage.jsx
+++ b/commands/serve/web/components/Stage.jsx
@@ -46,7 +46,7 @@ export default function Stage({ info, storage, uid }) {
     <Grid
       item
       container
-      justify="center"
+      justifyContent="center"
       style={{
         height: '100%',
       }}

--- a/packages/ui/theme/create.js
+++ b/packages/ui/theme/create.js
@@ -1,4 +1,4 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
 import base from './definitions/base';
 import light from './definitions/light';
@@ -113,7 +113,7 @@ export default function create(definition) {
     },
   };
 
-  cache[key] = createMuiTheme({
+  cache[key] = createTheme({
     ...withDefaults,
     overrides: overrides(withDefaults),
   });

--- a/test/component/hooks/hooked.fix.js
+++ b/test/component/hooks/hooked.fix.js
@@ -7,6 +7,7 @@ import {
   useAppLayout,
   useElement,
   useTheme,
+  useEmbed,
   useTranslator,
   useDeviceType,
   usePromise,
@@ -26,6 +27,7 @@ function sn({ flags }) {
       const layout = useLayout();
       const appLayout = useAppLayout();
       const options = useOptions();
+      const embed = useEmbed();
 
       const [acted, setActed] = useState(false);
 
@@ -76,6 +78,7 @@ function sn({ flags }) {
         <div class="action">${acted}</div>
         <div class="constraints">${!!passive}:${!!active}:${!!select}</div>
         <div class="options">${options.myOption}</div>
+        <div class="embed">${typeof embed.render}</div>
         <div class="flags">${flags.isEnabled('MAGIC_FLAG')}:${flags.isEnabled('_UNKNOWN_')}</div>
       </div>
       `;

--- a/test/component/hooks/sn.comp.js
+++ b/test/component/hooks/sn.comp.js
@@ -79,6 +79,11 @@ describe('hooks', () => {
     expect(text).to.equal('opts');
   });
 
+  it('useEmbed', async () => {
+    const text = await page.$eval(`${snSelector} .embed`, (el) => el.textContent);
+    expect(text).to.equal('function'); // typeof embed.render
+  });
+
   it('should have true MAGIC_FLAG', async () => {
     const text = await page.$eval(`${snSelector} .flags`, (el) => el.textContent);
     expect(text).to.equal('true:false');


### PR DESCRIPTION
Adds a useEmbed hook allowing charts to embed other charts.

- useEmbed
- expose embed for non hooked charts
- expose getRegisteredTypes
- adds fallback for missing chart versions
- remove auto modal for inline listbox (not relevant to the rest, just a fix)

Todo
- [ ] unit tests
- [ ] verify/agree on API
- [ ] component tests?