### PR TITLE
feat: add types to nebula serve

### DIFF
--- a/commands/serve/README.md
+++ b/commands/serve/README.md
@@ -46,6 +46,30 @@ Start the server and connect to enigma on port `9077`
 nebula serve --enigma.port 9077
 ```
 
+### Config file
+
+nebula.config.js
+
+```js
+module.exports = {
+  serve: {
+    ...,
+  },
+};
+```
+
+Serve properties:
+
+- types: Additional types to load into the serve instance. Useful in conjunction with useEmbed.
+  - `ex: types: [{ name: 'barchart', url: "https://unpkg.com/@nebula.js/sn-bar-chart"}],`
+- themes: Theme files to load
+  - `ex: themes: [{ id: 'sense', theme: { /* valid sense json theme */ } }],`
+- renderConfigs: configuration for the test renderer
+- flags: Additional flag settings for feature toggling
+  - `flags: { SOME_FEATURE: true }`
+- resources: Adds path to /resources
+- snapshots: Snapshots property structure, generally used for automated tests.
+
 ### node.js API
 
 ```js

--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -128,6 +128,7 @@ module.exports = async ({
           },
           flags: serveConfig.flags,
           themes: themes.map((theme) => theme.id),
+          types: serveConfig.types,
         });
       });
 

--- a/commands/serve/web/components/App.jsx
+++ b/commands/serve/web/components/App.jsx
@@ -101,6 +101,11 @@ export default function App({ app, info }) {
         : null,
     });
     n.__DO_NOT_USE__.types.register(info.supernova);
+    if (info.types) {
+      info.types.forEach((t) => {
+        n.__DO_NOT_USE__.types.register(t.name);
+      });
+    }
     setNebbie(n);
   }, [app]);
 

--- a/commands/serve/web/hot.js
+++ b/commands/serve/web/hot.js
@@ -46,6 +46,13 @@ export default function initiateWatch(info) {
       window[info.supernova.name] = mo;
       lightItUp(info.supernova.name);
     });
+    if (info.types) {
+      info.types.forEach((t) => {
+        getModule(t.name, t.url).then((mo) => {
+          window[t.name] = mo;
+        });
+      });
+    }
   };
 
   if (info.sock.port) {


### PR DESCRIPTION
## Motivation

Allows for the serve configuration to register extra types to the embed instance:
```
module.exports = {
  serve: {
    types: [{ name: 'barchart', url: "https://unpkg.com/@nebula.js/sn-bar-chart"}],
  },
};
```
This allows an chart to render the extra types using `useEmbed`.

Todo:

- [x] Docs
- [x] Tests?