### PR TITLE
fix: do not skip all updates if the rendering take long time

### DIFF
--- a/apis/nucleus/src/utils/__tests__/render-debouncer.spec.js
+++ b/apis/nucleus/src/utils/__tests__/render-debouncer.spec.js
@@ -1,0 +1,79 @@
+import RenderDebouncer from '../render-debouncer';
+
+function waitForPromise() {
+  return new Promise((resolve) => {
+    resolve();
+  });
+}
+
+describe('RenderDebouncer', () => {
+  let sandbox;
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.useFakeTimers();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  // tick the time in 10 ms steps and run resolved promises in between
+  // workaround for using an old sinon.js that do not support clock.tickAsync
+  async function tick(time) {
+    for (let i = 0; i < time / 10; ++i) {
+      sandbox.clock.tick(Math.min(time - i * 10, 10));
+      // eslint-disable-next-line no-await-in-loop
+      await waitForPromise();
+    }
+  }
+
+  it('should call scheduled function', async () => {
+    const fn = sinon.stub().resolves();
+    const debouncer = new RenderDebouncer();
+    debouncer.schedule(fn);
+    sandbox.clock.tick(50);
+    await waitForPromise();
+    expect(fn).to.be.called;
+  });
+
+  it('should only call second scheduled function if two are scheduled soon after each other', async () => {
+    const fn1 = sinon.stub().resolves();
+    const fn2 = sinon.stub().resolves();
+    const debouncer = new RenderDebouncer();
+    debouncer.schedule(fn1);
+    await tick(1);
+    debouncer.schedule(fn2);
+    await tick(50);
+    expect(fn1).to.not.be.called;
+    expect(fn2).to.be.called;
+  });
+
+  it('should both scheduled function if two are scheduled with some time between', async () => {
+    const fn1 = sinon.stub().resolves();
+    const fn2 = sinon.stub().resolves();
+    const debouncer = new RenderDebouncer();
+    debouncer.schedule(fn1);
+    await tick(50);
+    debouncer.schedule(fn2);
+    await tick(50);
+    expect(fn1).to.be.called;
+    expect(fn2).to.be.called;
+  });
+
+  it('should both scheduled function if two are scheduled with some time between and the first take a long time to run', async () => {
+    let resolve;
+    const promise = new Promise((r) => {
+      resolve = r;
+    });
+    const fn1 = sinon.stub().callsFake(() => promise);
+    const fn2 = sinon.stub().resolves();
+    const debouncer = new RenderDebouncer();
+    debouncer.schedule(fn1);
+    await tick(50);
+    debouncer.schedule(fn2);
+    await tick(50);
+    resolve();
+    await tick(50);
+    expect(fn1).to.be.called;
+    expect(fn2).to.be.called;
+  });
+});

--- a/apis/nucleus/src/utils/render-debouncer.js
+++ b/apis/nucleus/src/utils/render-debouncer.js
@@ -1,0 +1,46 @@
+export default class RenderDebouncer {
+  constructor() {
+    this.timer = null;
+    this.next = null;
+    this.running = false;
+  }
+
+  start() {
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+    this.scheduleNext();
+  }
+
+  scheduleNext() {
+    this.timer = setTimeout(() => {
+      this.doNext();
+    }, 10);
+  }
+
+  async doNext() {
+    const fn = this.next;
+    this.next = null;
+    if (fn) {
+      await fn();
+      this.scheduleNext();
+    } else {
+      this.stop();
+    }
+  }
+
+  schedule(fn) {
+    this.next = fn;
+    this.start();
+  }
+
+  stop() {
+    if (!this.running) {
+      return;
+    }
+    clearTimeout(this.timer);
+    this.timer = null;
+    this.running = false;
+  }
+}


### PR DESCRIPTION
## Motivation

If the rendering of an object took long time it was possible to skip updates and end up with a last render call that was not up to date with the latest layout.

Only seen in objects that modify its on properties on render


Simple example supernova with this problem:
```
function randomValue() {
  return Math.floor(Math.random() * 100);
}

export default function supernova() {
  return {
    component() {
      const layout = useStaleLayout();
      const element = useElement();
      const model = useModel();
      const [value] = useState(() => randomValue());
      const str = `The value is: ${value}`;
      const text = layout.text || 'Hello!';

      usePromise(async () => {
        if (str === text) {
          return;
        }
        const props = await model.getProperties();
        props.text = str;
        await model.setProperties(props);
        await model.getLayout();
      }, [layout]);

      if (str === text) {
        element.innerHTML = `<div>${text}</div>`; // eslint-disable-line
      } else {
        element.innerHTML = `<div>Updating</div>`; // eslint-disable-line
      }
    },
  };
}
```