### PR TITLE
feat: type guesser

### DIFF
--- a/apis/conversion/src/__tests__/type-alias.spec.js
+++ b/apis/conversion/src/__tests__/type-alias.spec.js
@@ -1,0 +1,32 @@
+import getMatch from '../type-alias';
+
+describe('type matcher', () => {
+  it('should match client known charts', () => {
+    expect(getMatch('bar chart', ['barchart'])).to.equal('barchart');
+    expect(getMatch('combochart', ['combochart'])).to.equal('combochart');
+    expect(getMatch('lineChart', ['linechart'])).to.equal('linechart');
+    expect(getMatch('mekko-chart', ['mekkochart'])).to.equal('mekkochart');
+    expect(getMatch('sn-pie-chart', ['piechart'])).to.equal('piechart');
+  });
+  it('should match themes known charts', () => {
+    expect(getMatch('bar chart', ['barChart'])).to.equal('barChart');
+    expect(getMatch('combochart', ['comboChart'])).to.equal('comboChart');
+    expect(getMatch('lineChart', ['lineChart'])).to.equal('lineChart');
+    expect(getMatch('mekko-chart', ['mekkoChart'])).to.equal('mekkoChart');
+    expect(getMatch('sn-pie-chart', ['pieChart'])).to.equal('pieChart');
+  });
+  it('should match dash known charts', () => {
+    expect(getMatch('bar chart', ['bar-chart'])).to.equal('bar-chart');
+    expect(getMatch('combochart', ['combo-chart'])).to.equal('combo-chart');
+    expect(getMatch('lineChart', ['line-chart'])).to.equal('line-chart');
+    expect(getMatch('mekko-chart', ['mekko-chart'])).to.equal('mekko-chart');
+    expect(getMatch('sn-pie-chart', ['pie-chart'])).to.equal('pie-chart');
+  });
+  it('should match sn prefixed known charts', () => {
+    expect(getMatch('bar chart', ['sn-bar-chart'])).to.equal('sn-bar-chart');
+    expect(getMatch('combochart', ['sn-combo-chart'])).to.equal('sn-combo-chart');
+    expect(getMatch('lineChart', ['sn-line-chart'])).to.equal('sn-line-chart');
+    expect(getMatch('mekko-chart', ['sn-mekko-chart'])).to.equal('sn-mekko-chart');
+    expect(getMatch('sn-pie-chart', ['sn-pie-chart'])).to.equal('sn-pie-chart');
+  });
+});

--- a/apis/conversion/src/index.js
+++ b/apis/conversion/src/index.js
@@ -2,6 +2,8 @@ import hypercube from './hypercube';
 import utils from './utils';
 import helpers from './helpers';
 
+export { default as getMatch } from './type-alias';
+
 const getType = async ({ halo, name, version }) => {
   const { types } = halo;
   const SN = await types

--- a/apis/conversion/src/type-alias.js
+++ b/apis/conversion/src/type-alias.js
@@ -1,0 +1,66 @@
+const toSplitForm = {
+  // Sense client names -> Theme
+  barchart: ['bar', 'chart'],
+  boxplot: ['box', 'plot'],
+  bulletchart: ['bullet', 'chart'],
+  // 'action-button': ['action','button'],
+  combochart: ['combo', 'chart'],
+  // container: ['container'],
+  distributionplot: ['distribution', 'plot'],
+  filterpane: ['filter', 'pane'],
+  listbox: ['list', 'box'],
+  // gauge:
+  // histogram
+  // kpi
+  linechart: ['line', 'chart'],
+  map: ['map', 'chart'],
+  mapchart: ['map', 'chart'],
+  mekkochart: ['mekko', 'chart'],
+  piechart: ['pie', 'chart'],
+  // 'pivot-table': ['pivot','table'],
+  pivottable: ['pivot', 'table'],
+  scatterplot: ['scatter', 'plot'],
+  straightable: ['straight', 'table'],
+  table: ['straight', 'table'],
+  // 'text-image': ['text','Image'],
+  treemap: ['treemap'],
+  waterfallchart: ['waterfall', 'chart'],
+
+  datacolors: ['data', 'colors'],
+  referenceline: ['reference', 'line'],
+};
+
+function split(s) {
+  if (s.indexOf('-') !== -1) {
+    return s.split('-');
+  }
+  if (s.indexOf('_') !== -1) {
+    return s.split('_');
+  }
+
+  const camelOrPascalSplit = s.match(/([A-Z]?[^A-Z]*)/g).slice(0, -1);
+  if (camelOrPascalSplit.length > 1) {
+    return camelOrPascalSplit;
+  }
+  return false;
+}
+
+export default function getMatch(type, list) {
+  // Convert to known format
+  const inLowerCase = type.toLowerCase();
+  const inSplitForm = split(inLowerCase) || toSplitForm[inLowerCase];
+
+  const possibleForms = [type];
+  if (inSplitForm) {
+    // Kebab-case
+    possibleForms.push(inSplitForm.join('-'));
+    // nocase
+    possibleForms.push(inSplitForm.join(''));
+    // camelCase
+    possibleForms.push(inSplitForm.map((s, i) => (i === 0 ? s : s.charAt(0).toUpperCase() + s.slice(1))).join(''));
+  } else {
+    possibleForms.push(inLowerCase);
+  }
+  const target = possibleForms.find((s) => list.indexOf(s) !== -1);
+  return target;
+}

--- a/apis/conversion/src/type-alias.js
+++ b/apis/conversion/src/type-alias.js
@@ -38,6 +38,10 @@ function split(s) {
     return s.split('_');
   }
 
+  if (s.indexOf(' ') !== -1) {
+    return s.split(' ');
+  }
+
   const camelOrPascalSplit = s.match(/([A-Z]?[^A-Z]*)/g).slice(0, -1);
   if (camelOrPascalSplit.length > 1) {
     return camelOrPascalSplit;
@@ -52,8 +56,14 @@ export default function getMatch(type, list) {
 
   const possibleForms = [type];
   if (inSplitForm) {
+    if (inSplitForm[0] === 'sn') {
+      // Remove the sn prefix to re-add later
+      inSplitForm.shift();
+    }
     // Kebab-case
     possibleForms.push(inSplitForm.join('-'));
+    // Kebab with sn-prefix
+    possibleForms.push(`sn-${inSplitForm.join('-')}`);
     // nocase
     possibleForms.push(inSplitForm.join(''));
     // camelCase

--- a/apis/nucleus/src/components/Supernova.jsx
+++ b/apis/nucleus/src/components/Supernova.jsx
@@ -15,7 +15,6 @@ const VizElement = {
 
 const Supernova = ({ sn, snOptions: options, snPlugins: plugins, layout, appLayout, halo }) => {
   const { component } = sn;
-  const { theme: chartTheme } = halo.public;
 
   const { theme: themeName, language, constraints } = useContext(InstanceContext);
   const [renderDebouncer] = useState(() => new RenderDebouncer());
@@ -116,7 +115,6 @@ const Supernova = ({ sn, snOptions: options, snPlugins: plugins, layout, appLayo
       style={{
         position: 'relative',
         height: '100%',
-        backgroundColor: chartTheme.getStyle(`object.${layout.visualization}`, '', 'backgroundColor'),
       }}
       className={VizElement.className}
     >

--- a/apis/nucleus/src/components/Supernova.jsx
+++ b/apis/nucleus/src/components/Supernova.jsx
@@ -15,6 +15,7 @@ const VizElement = {
 
 const Supernova = ({ sn, snOptions: options, snPlugins: plugins, layout, appLayout, halo }) => {
   const { component } = sn;
+  const { theme: chartTheme } = halo.public;
 
   const { theme: themeName, language, constraints } = useContext(InstanceContext);
   const [renderDebouncer] = useState(() => new RenderDebouncer());
@@ -112,7 +113,11 @@ const Supernova = ({ sn, snOptions: options, snPlugins: plugins, layout, appLayo
     <div
       ref={containerRef}
       data-render-count={renderCnt}
-      style={{ position: 'relative', height: '100%' }}
+      style={{
+        position: 'relative',
+        height: '100%',
+        backgroundColor: chartTheme.getStyle(`object.${layout.visualization}`, '', 'backgroundColor'),
+      }}
       className={VizElement.className}
     >
       <div ref={snRef} style={{ position: 'absolute', width: '100%', height: '100%' }} />

--- a/apis/nucleus/src/components/__tests__/supernova.spec.jsx
+++ b/apis/nucleus/src/components/__tests__/supernova.spec.jsx
@@ -21,7 +21,7 @@ describe('<Supernova />', () => {
       snPlugins = [],
       layout = {},
       appLayout = {},
-      halo = {},
+      halo = { public: { theme: { getStyle: () => {} } } },
       rendererOptions,
     } = {}) => {
       await act(async () => {

--- a/apis/nucleus/src/components/__tests__/supernova.spec.jsx
+++ b/apis/nucleus/src/components/__tests__/supernova.spec.jsx
@@ -7,7 +7,9 @@ describe('<Supernova />', () => {
   let sandbox;
   let renderer;
   let render;
+  let initializedHalo;
   beforeEach(() => {
+    initializedHalo = { public: { theme: { getStyle: () => {} }, nebbie: 'embedAPI' }, app: { session: {} } };
     sandbox = sinon.createSandbox();
     const addEventListener = sandbox.spy();
     const removeEventListener = sandbox.spy();
@@ -21,7 +23,7 @@ describe('<Supernova />', () => {
       snPlugins = [],
       layout = {},
       appLayout = {},
-      halo = { public: { theme: { getStyle: () => {} } } },
+      halo = initializedHalo,
       rendererOptions,
     } = {}) => {
       await act(async () => {
@@ -45,7 +47,7 @@ describe('<Supernova />', () => {
     delete global.window;
   });
   it('should render default', async () => {
-    await render();
+    await render({ halo: initializedHalo });
     expect(renderer.root.props).to.deep.equal({
       sn: {
         component: {},
@@ -54,7 +56,7 @@ describe('<Supernova />', () => {
       snPlugins: [],
       layout: {},
       appLayout: {},
-      halo: {},
+      halo: initializedHalo,
     });
   });
   it('should mount', async () => {
@@ -107,7 +109,6 @@ describe('<Supernova />', () => {
       snPlugins: [],
       layout: 'layout',
       appLayout: { qLocaleInfo: 'loc' },
-      halo: { public: { theme: 'theme', nebbie: 'embedAPI' }, app: { session: {} } },
       rendererOptions: {
         createNodeMock: () => ({
           style: {},
@@ -130,7 +131,7 @@ describe('<Supernova />', () => {
       context: {
         constraints: {},
         appLayout: { qLocaleInfo: 'loc' },
-        theme: 'theme',
+        theme: initializedHalo.public.theme,
         permissions: ['passive', 'interact', 'select', 'fetch'],
         localeInfo: 'loc',
         logicalSize: 'logical',
@@ -154,7 +155,6 @@ describe('<Supernova />', () => {
         component,
       },
       layout: {},
-      halo: { public: {} },
       rendererOptions: {
         createNodeMock: () => ({
           style: {},

--- a/apis/nucleus/src/sn/__tests__/types.spec.js
+++ b/apis/nucleus/src/sn/__tests__/types.spec.js
@@ -86,6 +86,15 @@ describe('types', () => {
       expect(c.get({ name: 'pie', version: '1.7.0' })).to.eql({ name: 'pie', version: '1.0.3' });
     });
 
+    it('should match against similar types', () => {
+      type.withArgs({ name: 'piechart', version: '1.0.3' }).returns({ name: 'piechart', version: '1.0.3' });
+      type.withArgs({ name: 'sn-bar-chart', version: '1.0.3' }).returns({ name: 'sn-bar-chart', version: '1.0.3' });
+      c.register({ name: 'piechart', version: '1.0.3' }, 'opts');
+      c.register({ name: 'sn-bar-chart', version: '1.0.3' }, 'opts');
+      expect(c.get({ name: 'pie-chart', version: '1.0.3' })).to.eql({ name: 'piechart', version: '1.0.3' });
+      expect(c.get({ name: 'barchart', version: '2.0.0' })).to.eql({ name: 'sn-bar-chart', version: '1.0.3' });
+    });
+
     it('should find 1.5.1 as matching version from properties', () => {
       const supportsPropertiesVersion = sinon.stub();
       supportsPropertiesVersion.withArgs('1.2.0').returns(true);

--- a/apis/nucleus/src/sn/types.js
+++ b/apis/nucleus/src/sn/types.js
@@ -1,3 +1,4 @@
+import { getMatch } from '@nebula.js/conversion';
 import type from './type';
 import { clearFromCache } from './load';
 
@@ -71,15 +72,24 @@ export function create({ halo, parent }) {
       return tc[name].getMatchingVersionFromProperties(propertyVersion);
     },
     get(typeInfo) {
-      const { name } = typeInfo;
-      let { version } = typeInfo;
+      let { name, version } = typeInfo;
       if (!tc[name]) {
-        // Fall back to existing version
+        // Try find matching name
+        const matchingName = getMatch(name, Object.keys(tc));
         if (__NEBULA_DEV__) {
-          console.warn(`Visualization ${name} is not registered.`); // eslint-disable-line no-console
+          if (matchingName) {
+            console.warn(`Visualization ${name} is not registered. Using ${matchingName}`); // eslint-disable-line no-console
+          } else {
+            console.warn(`Visualization ${name} is not registered.`); // eslint-disable-line no-console
+          }
         }
-        this.register({ name, version });
-      } else if (!tc[name].versions[version]) {
+        if (!matchingName) {
+          this.register({ name, version });
+        } else {
+          name = matchingName;
+        }
+      }
+      if (!tc[name].versions[version]) {
         // Fall back to existing version
         const versionToUse = Object.keys(tc[name].versions)[0];
         if (__NEBULA_DEV__) {

--- a/apis/theme/package.json
+++ b/apis/theme/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "src/index.js",
   "devDependencies": {
-    "@nebula.js/conversion": "latest",
+    "@nebula.js/conversion": "^1.4.0",
     "d3-color": "2.0.0",
     "extend": "3.0.2",
     "node-event-emitter": "0.0.1"

--- a/apis/theme/package.json
+++ b/apis/theme/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "main": "src/index.js",
   "devDependencies": {
+    "@nebula.js/conversion": "latest",
     "d3-color": "2.0.0",
     "extend": "3.0.2",
     "node-event-emitter": "0.0.1"

--- a/apis/theme/src/style-resolver.js
+++ b/apis/theme/src/style-resolver.js
@@ -1,3 +1,4 @@
+import { getMatch } from '@nebula.js/conversion';
 import extend from 'extend';
 import generateScales from './theme-scale-generator';
 
@@ -78,6 +79,13 @@ function searchValue(path, attribute, baseSteps, component) {
 
 export default function styleResolver(basePath, themeJSON) {
   const basePathSteps = basePath.split('.');
+  if (basePathSteps && basePathSteps[0] === 'object' && basePathSteps.length > 1) {
+    const types = Object.keys(themeJSON.object);
+    const matchedType = getMatch(basePathSteps[1], types);
+    if (matchedType) {
+      basePathSteps[1] = matchedType;
+    }
+  }
 
   const api = {
     /**

--- a/apis/theme/src/style-resolver.js
+++ b/apis/theme/src/style-resolver.js
@@ -80,10 +80,12 @@ function searchValue(path, attribute, baseSteps, component) {
 export default function styleResolver(basePath, themeJSON) {
   const basePathSteps = basePath.split('.');
   if (basePathSteps && basePathSteps[0] === 'object' && basePathSteps.length > 1) {
-    const types = Object.keys(themeJSON.object);
-    const matchedType = getMatch(basePathSteps[1], types);
-    if (matchedType) {
-      basePathSteps[1] = matchedType;
+    const types = themeJSON && themeJSON.object ? Object.keys(themeJSON.object) : [];
+    if (types) {
+      const matchedType = getMatch(basePathSteps[1], types);
+      if (matchedType) {
+        basePathSteps[1] = matchedType;
+      }
     }
   }
 


### PR DESCRIPTION
## Motivation

While looking on how to expand theming capabilities I ran into type matching issues. Basically the sense-client uses two type names, ex: "barchart" and "barChart". First one is type and other one is theme key. This is fine as long as you only need to access theme attributes from within the chart, but as soon as you need them outside it becomes an issue.

Say that you aim to render charts in an existing app, and want to manipulate the theme:
```js
const nebbie = stardust.embed(app, {
      types: [ { name: "barchart" , load:()=>{..}} ],
      themes: [...]
    });

nebbie.render({ id: "BHF75"}); // of type "barchart"
```
This setup would render the chart correctly, but the theme would not find it properly as the type there is "barChart".
Other examples we have involves loading types as "bar-chart" for example, and that would also cause issues.

TODO

- [x] Test
- [x] More tests
- [x] Handle chart titles


Edit: Will limit this to reading chart background color from the sense theme. When you get into using it for chart titles it starts messing with the selections toolbar and overall Nebula look and feel, so that should be handled using a proper solution tied to Material.