### PR TITLE
feat: useRenderState hook

### DIFF
--- a/apis/nucleus/src/components/Supernova.jsx
+++ b/apis/nucleus/src/components/Supernova.jsx
@@ -88,7 +88,10 @@ const Supernova = ({ sn, snOptions: options, snPlugins: plugins, layout, appLayo
                 }),
           },
         })
-      ).then(() => {
+      ).then((done) => {
+        if (done === false) {
+          return;
+        }
         if (renderCnt === 0 && typeof options.onInitialRender === 'function') {
           options.onInitialRender.call(null);
         }

--- a/apis/stardust/src/index.js
+++ b/apis/stardust/src/index.js
@@ -34,7 +34,7 @@ export {
   useConstraints,
   useOptions,
   useEmbed,
-  useWaitOn,
+  useRenderState,
   onTakeSnapshot,
 } from '@nebula.js/supernova';
 

--- a/apis/stardust/src/index.js
+++ b/apis/stardust/src/index.js
@@ -34,6 +34,7 @@ export {
   useConstraints,
   useOptions,
   useEmbed,
+  useWaitOn,
   onTakeSnapshot,
 } from '@nebula.js/supernova';
 

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -994,14 +994,14 @@ export function onTakeSnapshot(cb) {
  * Used to update properties and get a new layout without triggering onInitialRender.
  * @entry
  * @experimental
- * @returns {{ setPending, restore }} The render state.
+ * @returns {{ pending, restore }} The render state.
  * @example
  * import { useRenderState } from '@nebula.js/stardust';
  *
  * const renderState = useRenderState();
  * useState(() => {
  *   if(needProperteisUpdate(...)) {
- *      useRenderState.setPending();
+ *      useRenderState.pending();
  *      updateProperties(...);
  *   } else {
  *      useRenderState.restore();
@@ -1013,7 +1013,7 @@ export function useRenderState() {
   getHook(++currentIndex);
   const hooks = currentComponent.__hooks;
   return {
-    setPending: () => {
+    pending: () => {
       hooks.waitForData = true;
     },
     restore: () => {

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -29,6 +29,7 @@ export function initiate(component, { explicitResize = false } = {}) {
   component.__hooks = {
     obsolete: false,
     error: false,
+    waitForData: false,
     chain: {
       promise: null,
       resolve: () => {},
@@ -148,7 +149,7 @@ function maybeEndChain(hooks) {
     return;
   }
   hooks.chain.promise = null;
-  hooks.chain.resolve();
+  hooks.chain.resolve(!hooks.waitForData);
 }
 
 export function runSnaps(component, layout) {
@@ -985,6 +986,19 @@ export function onTakeSnapshot(cb) {
     currentComponent.__hooks.snaps.push(h);
   }
   h.fn = cb;
+}
+
+export function useWaitOn() {
+  getHook(++currentIndex);
+  const hooks = currentComponent.__hooks;
+  return {
+    wait: () => {
+      hooks.waitForData = true;
+    },
+    continue: () => {
+      hooks.waitForData = false;
+    },
+  };
 }
 
 /**

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -988,14 +988,35 @@ export function onTakeSnapshot(cb) {
   h.fn = cb;
 }
 
-export function useWaitOn() {
+/**
+ * Gets render state instance.
+ *
+ * Used to update properties and get a new layout without triggering onInitialRender.
+ * @entry
+ * @experimental
+ * @returns {{ setPending, restore }} The render state.
+ * @example
+ * import { useRenderState } from '@nebula.js/stardust';
+ *
+ * const renderState = useRenderState();
+ * useState(() => {
+ *   if(needProperteisUpdate(...)) {
+ *      useRenderState.setPending();
+ *      updateProperties(...);
+ *   } else {
+ *      useRenderState.restore();
+ *      ...
+ *   }
+ * }, [...]);
+ */
+export function useRenderState() {
   getHook(++currentIndex);
   const hooks = currentComponent.__hooks;
   return {
-    wait: () => {
+    setPending: () => {
       hooks.waitForData = true;
     },
-    continue: () => {
+    restore: () => {
       hooks.waitForData = false;
     },
   };

--- a/apis/supernova/src/index.js
+++ b/apis/supernova/src/index.js
@@ -26,6 +26,6 @@ export {
   useKeyboard,
   useOptions,
   useEmbed,
-  useWaitOn,
+  useRenderState,
   onTakeSnapshot,
 } from './hooks';

--- a/apis/supernova/src/index.js
+++ b/apis/supernova/src/index.js
@@ -26,5 +26,6 @@ export {
   useKeyboard,
   useOptions,
   useEmbed,
+  useWaitOn,
   onTakeSnapshot,
 } from './hooks';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Add useRenderState hook

Used to update properties and get a new layout without triggering onInitialRender.