### PR TITLE
fix: only fetch apps from qlikcloud

### DIFF
--- a/commands/serve/web/connect.js
+++ b/commands/serve/web/connect.js
@@ -133,7 +133,7 @@ const connect = () => {
         return {
           getDocList: async () => {
             const { data = [] } = await (
-              await fetch(`${rootPath}/api/v1/items?limit=30&sort=-updatedAt`, {
+              await fetch(`${rootPath}/api/v1/items?resourceType=app&limit=30&sort=-updatedAt`, {
                 credentials: 'include',
                 headers: { ...headers, 'content-type': 'application/json' },
               })


### PR DESCRIPTION
## Motivation
Currently we fetch not only apps when running `nebula serve`, which means you also get datasets. Chaning this to filter on resourceType=app