### PR TITLE
fix: bug in serve types

### DIFF
--- a/commands/serve/web/components/App.jsx
+++ b/commands/serve/web/components/App.jsx
@@ -104,7 +104,7 @@ export default function App({ app, info }) {
     n.__DO_NOT_USE__.types.register(info.supernova);
     if (info.types) {
       info.types.forEach((t) => {
-        n.__DO_NOT_USE__.types.register(t.name);
+        n.__DO_NOT_USE__.types.register(t);
       });
     }
     setNebbie(n);


### PR DESCRIPTION
## Motivation

Noticed that the types weren't actually registered correctlöy, it just happend to work anyway as the load function was seperated out. If you added more that one extra type it broke. This fixes that.

- [ ] Add a test this time
