### PR TITLE
feat: handle tabbing from cell header

### DIFF
--- a/apis/nucleus/src/components/ActionsToolbar.jsx
+++ b/apis/nucleus/src/components/ActionsToolbar.jsx
@@ -34,7 +34,6 @@ const useStyles = makeStyles((theme) => ({
 
 const ActionsGroup = React.forwardRef(({ actions = [], first = false, last = false, addAnchor = false }, ref) => {
   const { itemSpacing, firstItemSpacing, lastItemSpacing } = useStyles();
-
   return actions.length > 0 ? (
     <Grid item container spacing={0} wrap="nowrap">
       {actions.map((e, ix) => {
@@ -167,14 +166,7 @@ const ActionsToolbar = ({
           <Divider orientation="vertical" />
         </Grid>
       )}
-      {selections.show && (
-        <ActionsGroup
-          actions={defaultSelectionActions}
-          first={!showActions && !showMore}
-          // refocusContent={refocusContent}
-          last
-        />
-      )}
+      {selections.show && <ActionsGroup actions={defaultSelectionActions} first={!showActions && !showMore} last />}
       {showMoreItems && (
         <More
           show={showMoreItems}

--- a/apis/nucleus/src/components/ActionsToolbar.jsx
+++ b/apis/nucleus/src/components/ActionsToolbar.jsx
@@ -199,16 +199,17 @@ const ActionsToolbar = ({
     }
   };
 
-  focusHandler.on('focus_toolbar_first', () => {
-    if (!actionsRef.current) return;
-    focusActionButton(actionsRef.current.getElementsByTagName('BUTTON'));
-  });
-
-  focusHandler.on('focus_toolbar_last', () => {
-    if (!actionsRef.current) return;
-    const actionButtons = actionsRef.current.getElementsByTagName('BUTTON');
-    focusActionButton([...actionButtons].reverse());
-  });
+  if (focusHandler) {
+    focusHandler.on('focus_toolbar_first', () => {
+      if (!actionsRef.current) return;
+      focusActionButton(actionsRef.current.getElementsByTagName('BUTTON'));
+    });
+    focusHandler.on('focus_toolbar_last', () => {
+      if (!actionsRef.current) return;
+      const actionButtons = actionsRef.current.getElementsByTagName('BUTTON');
+      focusActionButton([...actionButtons].reverse());
+    });
+  }
 
   return popover.show ? (
     <Popover

--- a/apis/nucleus/src/components/ActionsToolbar.jsx
+++ b/apis/nucleus/src/components/ActionsToolbar.jsx
@@ -150,18 +150,12 @@ const ActionsToolbar = ({
   const showActions = newActions.length > 0;
   const showMore = moreActions.length > 0;
   const showDivider = (showActions && selections.show) || (showMore && selections.show);
+  const refocusContent = keyboardNavigation && focusHandler ? focusHandler.refocusContent : null;
   const Actions = (
     <Grid ref={actionsRef} container spacing={0} wrap="nowrap">
       {showActions && <ActionsGroup actions={newActions} first last={!showMore && !selections.show} />}
       {showMore && (
-        <ActionsGroup
-          ref={moreRef}
-          actions={[moreItem]}
-          first={!showActions}
-          last={!selections.show}
-          refocusContent={keyboardNavigation && focusHandler && focusHandler.refocusContent}
-          addAnchor
-        />
+        <ActionsGroup ref={moreRef} actions={[moreItem]} first={!showActions} last={!selections.show} addAnchor />
       )}
       {showDivider && (
         <Grid item className={itemSpacing} style={dividerStyle}>
@@ -172,7 +166,7 @@ const ActionsToolbar = ({
         <ActionsGroup
           actions={defaultSelectionActions}
           first={!showActions && !showMore}
-          refocusContent={keyboardNavigation && focusHandler && focusHandler.refocusContent}
+          refocusContent={refocusContent}
           last
         />
       )}

--- a/apis/nucleus/src/components/ActionsToolbar.jsx
+++ b/apis/nucleus/src/components/ActionsToolbar.jsx
@@ -123,7 +123,7 @@ const ActionsToolbar = ({
     // if there keyboardNavigation is true, create a callback to handle tabbing from the first/last button in the toolbar that resets focus on the content
     keyboardNavigation && focusHandler && focusHandler.refocusContent
       ? (evt) => {
-          if (evt.key !== 'Tab') return;
+          if (evt.key !== 'Tab' || !actionsRef.current) return;
           const buttons = actionsRef.current.getElementsByTagName('button');
           const isTabbingOut =
             (evt.shiftKey && getFirstEnabledButton([...buttons]) === evt.target) ||

--- a/apis/nucleus/src/components/ActionsToolbarItem.jsx
+++ b/apis/nucleus/src/components/ActionsToolbarItem.jsx
@@ -17,7 +17,7 @@ const ActionElement = {
   className: 'njs-cell-action',
 };
 
-const Item = React.forwardRef(({ item, addAnchor = false }, ref) => {
+const Item = React.forwardRef(({ item, addAnchor = false, handleTab }, ref) => {
   const theme = useTheme();
   const { hidden, disabled, style, hasSvgIconShape } = useActionState(item);
   if (hidden) return null;
@@ -30,6 +30,7 @@ const Item = React.forwardRef(({ item, addAnchor = false }, ref) => {
       disabled={disabled}
       style={style}
       className={ActionElement.className}
+      onKeyDown={handleTab}
     >
       {hasSvgIconShape && SvgIcon(item.getSvgIconShape())}
       {addAnchor && (

--- a/apis/nucleus/src/components/ActionsToolbarItem.jsx
+++ b/apis/nucleus/src/components/ActionsToolbarItem.jsx
@@ -27,6 +27,7 @@ const Item = React.forwardRef(({ item, addAnchor = false }, ref) => {
       ref={!addAnchor ? ref : null}
       title={item.label}
       onClick={item.action}
+      // onKeyDown={item.keyboardAction}
       disabled={disabled}
       style={style}
       className={ActionElement.className}

--- a/apis/nucleus/src/components/ActionsToolbarItem.jsx
+++ b/apis/nucleus/src/components/ActionsToolbarItem.jsx
@@ -17,7 +17,7 @@ const ActionElement = {
   className: 'njs-cell-action',
 };
 
-const Item = React.forwardRef(({ item, addAnchor = false, handleTab }, ref) => {
+const Item = React.forwardRef(({ item, addAnchor = false }, ref) => {
   const theme = useTheme();
   const { hidden, disabled, style, hasSvgIconShape } = useActionState(item);
   if (hidden) return null;
@@ -30,7 +30,6 @@ const Item = React.forwardRef(({ item, addAnchor = false, handleTab }, ref) => {
       disabled={disabled}
       style={style}
       className={ActionElement.className}
-      onKeyDown={handleTab}
     >
       {hasSvgIconShape && SvgIcon(item.getSvgIconShape())}
       {addAnchor && (

--- a/apis/nucleus/src/components/ActionsToolbarItem.jsx
+++ b/apis/nucleus/src/components/ActionsToolbarItem.jsx
@@ -27,7 +27,6 @@ const Item = React.forwardRef(({ item, addAnchor = false }, ref) => {
       ref={!addAnchor ? ref : null}
       title={item.label}
       onClick={item.action}
-      // onKeyDown={item.keyboardAction}
       disabled={disabled}
       style={style}
       className={ActionElement.className}

--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -476,14 +476,12 @@ const Cell = forwardRef(
     return (
       <Paper
         style={{ position: 'relative', width: '100%', height: '100%', overflow: 'hidden' }}
-        tabIndex={keyboardNavigation ? 0 : -1}
         elevation={0}
         square
         className={CellElement.className}
         ref={cellRef}
         onMouseEnter={handleOnMouseEnter}
         onMouseLeave={handleOnMouseLeave}
-        onKeyDown={keyboardNavigation ? handleKeyDown : null}
       >
         <Grid
           container
@@ -503,6 +501,8 @@ const Cell = forwardRef(
             </Header>
           )}
           <Grid
+            tabIndex={keyboardNavigation ? 0 : -1}
+            onKeyDown={keyboardNavigation ? handleKeyDown : null}
             item
             xs
             style={{

--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -291,7 +291,7 @@ const Cell = forwardRef(
     const [state, dispatch] = useReducer(contentReducer, initialState(initialError));
     const [layout, { validating, canCancel, canRetry }, longrunning] = useLayout(model);
     const [appLayout] = useAppLayout(app);
-    const [contentRef, contentRect] = useRect();
+    const [contentRef, contentRect, contentNode] = useRect();
     const [snOptions, setSnOptions] = useState(initialSnOptions);
     const [snPlugins, setSnPlugins] = useState(initialSnPlugins);
     const [selections] = useObjectSelections(app, model);
@@ -328,8 +328,8 @@ const Cell = forwardRef(
 
     focusHandler.blurCallback = (resetFocus) => {
       halo.root.toggleFocusOfCells();
-      if (resetFocus && cellNode) {
-        cellNode.focus();
+      if (resetFocus && contentNode) {
+        contentNode.focus();
       }
     };
 

--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -255,15 +255,15 @@ const getType = async ({ types, name, version }) => {
   return SN;
 };
 
-const focusHandlerObj = {
+const focusHandler = {
   focusToolbarButton(last) {
     this.emit(last ? 'focus_toolbar_last' : 'focus_toolbar_first');
   },
 };
 
-eventmixin(focusHandlerObj);
+eventmixin(focusHandler);
 
-const loadType = async ({ dispatch, types, visualization, version, model, app, selections, focusHandler, nebbie }) => {
+const loadType = async ({ dispatch, types, visualization, version, model, app, selections, nebbie }) => {
   try {
     const snType = await getType({ types, name: visualization, version });
     const sn = snType.create({
@@ -326,15 +326,16 @@ const Cell = forwardRef(
       }
     };
 
-    focusHandlerObj.blurCallback = (resetFocus) => {
+    focusHandler.blurCallback = (resetFocus) => {
       halo.root.toggleFocusOfCells();
       if (resetFocus && cellNode) {
         cellNode.focus();
       }
     };
 
-    focusHandlerObj.refocusContent = () =>
+    focusHandler.refocusContent = () => {
       state.sn.component && typeof state.sn.component.focus === 'function' && state.sn.component.focus();
+    };
 
     useEffect(() => {
       if (initialError || !appLayout || !layout) {
@@ -360,7 +361,6 @@ const Cell = forwardRef(
           app,
           selections,
           nebbie,
-          focusHandler: focusHandlerObj,
         });
         if (sn) {
           dispatch({ type: 'LOADED', sn, visualization });
@@ -498,13 +498,7 @@ const Cell = forwardRef(
           }}
         >
           {cellNode && layout && state.sn && (
-            <Header
-              layout={layout}
-              sn={state.sn}
-              anchorEl={cellNode}
-              hovering={hovering}
-              focusHandler={focusHandlerObj}
-            >
+            <Header layout={layout} sn={state.sn} anchorEl={cellNode} hovering={hovering} focusHandler={focusHandler}>
               &nbsp;
             </Header>
           )}

--- a/apis/nucleus/src/components/Header.jsx
+++ b/apis/nucleus/src/components/Header.jsx
@@ -71,7 +71,12 @@ const Header = ({ layout, sn, anchorEl, hovering, focusHandler }) => {
   const Toolbar = (
     <ActionsToolbar
       show={showToolbar}
-      selections={{ show: showInSelectionActions, api: sn.component.selections }}
+      selections={{
+        show: showInSelectionActions,
+        api: sn.component.selections,
+        onConfirm: focusHandler.refocusContent,
+        onCancel: focusHandler.refocusContent,
+      }}
       actions={actions}
       popover={{ show: showPopoverToolbar, anchorEl }}
       focusHandler={focusHandler}

--- a/apis/nucleus/src/components/Header.jsx
+++ b/apis/nucleus/src/components/Header.jsx
@@ -71,12 +71,7 @@ const Header = ({ layout, sn, anchorEl, hovering, focusHandler }) => {
   const Toolbar = (
     <ActionsToolbar
       show={showToolbar}
-      selections={{
-        show: showInSelectionActions,
-        api: sn.component.selections,
-        onConfirm: focusHandler.refocusContent,
-        onCancel: focusHandler.refocusContent,
-      }}
+      selections={{ show: showInSelectionActions, api: sn.component.selections }}
       actions={actions}
       popover={{ show: showPopoverToolbar, anchorEl }}
       focusHandler={focusHandler}

--- a/apis/nucleus/src/components/Header.jsx
+++ b/apis/nucleus/src/components/Header.jsx
@@ -74,6 +74,7 @@ const Header = ({ layout, sn, anchorEl, hovering, focusHandler }) => {
       selections={{
         show: showInSelectionActions,
         api: sn.component.selections,
+        onConfirm: focusHandler.refocusContent,
         onCancel: focusHandler.refocusContent,
       }}
       actions={actions}

--- a/apis/nucleus/src/components/Header.jsx
+++ b/apis/nucleus/src/components/Header.jsx
@@ -71,7 +71,11 @@ const Header = ({ layout, sn, anchorEl, hovering, focusHandler }) => {
   const Toolbar = (
     <ActionsToolbar
       show={showToolbar}
-      selections={{ show: showInSelectionActions, api: sn.component.selections }}
+      selections={{
+        show: showInSelectionActions,
+        api: sn.component.selections,
+        onCancel: focusHandler.refocusContent,
+      }}
       actions={actions}
       popover={{ show: showPopoverToolbar, anchorEl }}
       focusHandler={focusHandler}

--- a/apis/nucleus/src/components/Header.jsx
+++ b/apis/nucleus/src/components/Header.jsx
@@ -67,6 +67,7 @@ const Header = ({ layout, sn, anchorEl, hovering }) => {
   const classes = [containerStyle, ...(showTitles ? [containerTitleStyle] : [])];
   const showPopoverToolbar = (hovering || showInSelectionActions) && (shouldShowPopoverToolbar || !showTitles);
   const showToolbar = showTitles && !showPopoverToolbar && !shouldShowPopoverToolbar;
+  const refocusContent = () => sn.component && typeof sn.component.focus === 'function' && sn.component.focus();
 
   const Toolbar = (
     <ActionsToolbar
@@ -74,6 +75,7 @@ const Header = ({ layout, sn, anchorEl, hovering }) => {
       selections={{ show: showInSelectionActions, api: sn.component.selections }}
       actions={actions}
       popover={{ show: showPopoverToolbar, anchorEl }}
+      refocusContent={refocusContent}
     />
   );
 

--- a/apis/nucleus/src/hooks/useDefaultSelectionActions.js
+++ b/apis/nucleus/src/hooks/useDefaultSelectionActions.js
@@ -22,8 +22,8 @@ export default function useDefaultSelectionActions({ api, onConfirm = () => {}, 
       label: translator.get('Selection.Cancel'),
       enabled: api.canCancel,
       action: () => {
-        api.cancel();
         onCancel();
+        api.cancel();
       },
       getSvgIconShape: close,
     },
@@ -33,10 +33,9 @@ export default function useDefaultSelectionActions({ api, onConfirm = () => {}, 
       label: translator.get('Selection.Confirm'),
       enabled: api.canConfirm,
       action: () => {
-        api.confirm();
         onConfirm();
+        api.confirm();
       },
-      // keyboardAction: onKeyDown,
       getSvgIconShape: tick,
     },
   ];

--- a/apis/nucleus/src/hooks/useDefaultSelectionActions.js
+++ b/apis/nucleus/src/hooks/useDefaultSelectionActions.js
@@ -12,15 +12,15 @@ export default function useDefaultSelectionActions({ api, onConfirm = () => {}, 
       key: 'clear',
       type: 'icon-button',
       label: translator.get('Selection.Clear'),
-      enabled: () => api.canClear(),
-      action: () => api.clear(),
+      enabled: api.canClear,
+      action: api.clear,
       getSvgIconShape: clearSelections,
     },
     {
       key: 'cancel',
       type: 'icon-button',
       label: translator.get('Selection.Cancel'),
-      enabled: () => api.canCancel(),
+      enabled: api.canCancel,
       action: () => {
         api.cancel();
         onCancel();
@@ -31,11 +31,12 @@ export default function useDefaultSelectionActions({ api, onConfirm = () => {}, 
       key: 'confirm',
       type: 'icon-button',
       label: translator.get('Selection.Confirm'),
-      enabled: () => api.canConfirm(),
+      enabled: api.canConfirm,
       action: () => {
         api.confirm();
         onConfirm();
       },
+      // keyboardAction: onKeyDown,
       getSvgIconShape: tick,
     },
   ];

--- a/apis/nucleus/src/hooks/useDefaultSelectionActions.js
+++ b/apis/nucleus/src/hooks/useDefaultSelectionActions.js
@@ -21,9 +21,9 @@ export default function useDefaultSelectionActions({ api, onConfirm = () => {}, 
       type: 'icon-button',
       label: translator.get('Selection.Cancel'),
       enabled: () => api.canCancel(),
-      action: (evt) => {
+      action: () => {
         api.cancel();
-        onCancel(evt);
+        onCancel();
       },
       getSvgIconShape: close,
     },
@@ -32,9 +32,9 @@ export default function useDefaultSelectionActions({ api, onConfirm = () => {}, 
       type: 'icon-button',
       label: translator.get('Selection.Confirm'),
       enabled: () => api.canConfirm(),
-      action: (evt) => {
+      action: () => {
         api.confirm();
-        onConfirm(evt);
+        onConfirm();
       },
       getSvgIconShape: tick,
     },

--- a/apis/nucleus/src/hooks/useDefaultSelectionActions.js
+++ b/apis/nucleus/src/hooks/useDefaultSelectionActions.js
@@ -21,9 +21,9 @@ export default function useDefaultSelectionActions({ api, onConfirm = () => {}, 
       type: 'icon-button',
       label: translator.get('Selection.Cancel'),
       enabled: () => api.canCancel(),
-      action: () => {
+      action: (evt) => {
         api.cancel();
-        onCancel();
+        onCancel(evt);
       },
       getSvgIconShape: close,
     },
@@ -32,9 +32,9 @@ export default function useDefaultSelectionActions({ api, onConfirm = () => {}, 
       type: 'icon-button',
       label: translator.get('Selection.Confirm'),
       enabled: () => api.canConfirm(),
-      action: () => {
+      action: (evt) => {
         api.confirm();
-        onConfirm();
+        onConfirm(evt);
       },
       getSvgIconShape: tick,
     },

--- a/apis/supernova/src/creator.js
+++ b/apis/supernova/src/creator.js
@@ -76,7 +76,6 @@ function createWithHooks(generator, opts, galaxy) {
       layout: {},
       appLayout: {},
       keyboardNavigation: opts.keyboardNavigation,
-      blurCallback: opts.blurCallback,
       focusHandler: opts.focusHandler,
       constraints: forcedConstraints,
       options: {},
@@ -108,9 +107,8 @@ function createWithHooks(generator, opts, galaxy) {
           changed = true;
         }
 
-        if (r.context && r.context.blurCallback) {
+        if (r.context && r.context.focusHandler) {
           // Needs to be added here due to how the client renders
-          this.context.blurCallback = r.context.blurCallback;
           this.context.focusHandler = r.context.focusHandler;
         }
 

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -1069,8 +1069,8 @@ export function useKeyboard() {
   if (!currentComponent.__hooks.accessibility.exitFunction) {
     const exitFunction = function (resetFocus) {
       const acc = this.__hooks.accessibility;
-      if (acc.enabled && acc.active) {
-        blur(this);
+      if (acc.enabled) {
+        acc.active && blur(this);
         focusHandler && focusHandler.blurCallback && focusHandler.blurCallback(resetFocus);
       }
     }.bind(currentComponent);

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -1029,6 +1029,7 @@ export function useRenderState() {
  * @property {boolean} active Set to true when the chart is activated, ie a user tabs to the chart and presses Enter or Space.
  * @property {function=} blur Function used by the visualization to tell Nebula to it wants to relinquish focus
  * @property {function=} focus Function used by the visualization to tell Nebula to it wants focus
+ * @property {function=} focusSelection Function used by the visualization to tell Nebula to focus the selection toolbar
  */
 
 /**
@@ -1087,12 +1088,8 @@ export function useKeyboard() {
     currentComponent.__hooks.accessibility.focusFunction = focusFunction;
 
     const focusSelectionFunction = function (focusLast) {
-      // const acc = this.__hooks.accessibility;
-      // if (acc.enabled && !acc.active) {
       focusHandler && focusHandler.focusToolbarButton(focusLast);
-      // }
     };
-    // .bind(currentComponent);
 
     currentComponent.__hooks.accessibility.focusSelectionFunction = focusSelectionFunction;
   }

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -1063,14 +1063,13 @@ export function useRenderState() {
 
 export function useKeyboard() {
   const keyboardNavigation = useInternalContext('keyboardNavigation');
-  // const blurCallback = useInternalContext('blurCallback');
   const focusHandler = useInternalContext('focusHandler');
 
   if (!currentComponent.__hooks.accessibility.exitFunction) {
     const exitFunction = function (resetFocus) {
       const acc = this.__hooks.accessibility;
-      if (acc.enabled) {
-        acc.active && blur(this);
+      if (acc.enabled && acc.active) {
+        blur(this);
         focusHandler && focusHandler.blurCallback && focusHandler.blurCallback(resetFocus);
       }
     }.bind(currentComponent);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation
part of https://github.com/qlik-oss/sn-table/issues/356

When `keyboardNavigation` is true, the selection toolbar should refocus the chart when you tab out of it (tab on last element or shift tab on first element). Also adding a method to the `keyboard` hook so that you can set focus on the selection toolbar from the chart