### PR TITLE
refactor: update build targets

### DIFF
--- a/apis/snapshooter/rollup.config.js
+++ b/apis/snapshooter/rollup.config.js
@@ -17,8 +17,8 @@ const browserList = [
   'last 2 Chrome versions',
   'last 2 Firefox versions',
   'last 2 Edge versions',
-  'Safari >= 10.0',
-  'iOS >= 11.2',
+  'Safari >= 11.0',
+  'iOS >= 12.2',
 ];
 
 const cfg = {
@@ -39,7 +39,7 @@ const cfg = {
           {
             modules: false,
             targets: {
-              browsers: [...browserList, ...['ie 11', 'chrome 47']],
+              browsers: [...browserList, 'chrome 62'],
             },
           },
         ],

--- a/commands/build/lib/build.js
+++ b/commands/build/lib/build.js
@@ -102,7 +102,7 @@ const config = ({
               {
                 modules: false,
                 targets: {
-                  browsers: ['ie 11', 'chrome 47'],
+                  browsers: ['chrome 62'],
                 },
               },
             ],

--- a/commands/sense/lib/build-legacy.js
+++ b/commands/sense/lib/build-legacy.js
@@ -84,7 +84,7 @@ async function build(argv) {
               {
                 modules: false,
                 targets: {
-                  browsers: ['ie 11', 'chrome 47'],
+                  browsers: ['chrome 62'],
                 },
               },
             ],

--- a/commands/sense/lib/build.js
+++ b/commands/sense/lib/build.js
@@ -101,7 +101,7 @@ async function build(argv) {
               {
                 modules: false,
                 targets: {
-                  browsers: ['ie 11', 'chrome 47'],
+                  browsers: ['chrome 62'],
                 },
               },
             ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -60,8 +60,8 @@ const browserList = [
   'last 2 Chrome versions',
   'last 2 Firefox versions',
   'last 2 Edge versions',
-  'Safari >= 10.0',
-  'iOS >= 11.2',
+  'Safari >= 11.0',
+  'iOS >= 12.2',
 ];
 
 const GLOBALS = {
@@ -145,7 +145,7 @@ const config = ({ format = 'umd', debug = false, file, targetPkg }) => {
             {
               modules: false,
               targets: {
-                browsers: [...browserList, ...['ie 11', 'chrome 47']],
+                browsers: [...browserList, 'chrome 62'],
               },
             },
           ],


### PR DESCRIPTION
Update build target with which nebula.js is built:
* Remove ie 11
* Chrome 47 -> 62
* Safari 10.0 -> 11.0
* iOS 11.2 -> 12.2

Update build targets used by CLI build tools:
* Remove ie 11
* Chrome 47 -> 62