### PR TITLE
fix(cli-build): mitigate problem with require inside try catch blocks

### DIFF
--- a/commands/build/lib/build.js
+++ b/commands/build/lib/build.js
@@ -90,7 +90,9 @@ const config = ({
         nodeResolve({
           extensions,
         }),
-        commonjs(),
+        commonjs({
+          ignoreTryCatch: false, // Avoids problems with require() inside try catch (https://github.com/rollup/plugins/issues/1004)
+        }),
         json(),
         babel({
           babelrc: false,


### PR DESCRIPTION
This addresses an issue that was seen after updating `@rollup/plugin-commonjs` from 20.0.0 -> 21.0.1.
See https://github.com/rollup/plugins/issues/1004 for more info around it.