### PR TITLE
refactor(listbox): Allow hiding the toolbar

### DIFF
--- a/apis/nucleus/src/components/__tests__/actions-toolbar-item.spec.jsx
+++ b/apis/nucleus/src/components/__tests__/actions-toolbar-item.spec.jsx
@@ -18,7 +18,7 @@ const [{ default: ActionsToolbarItem }] = aw.mock(
   ['../ActionsToolbarItem']
 );
 
-describe('<ActionsToolbarItem />', () => {
+describe.skip('<ActionsToolbarItem />', () => {
   let sandbox;
   let renderer;
   let render;

--- a/apis/nucleus/src/components/__tests__/actions-toolbar-item.spec.jsx
+++ b/apis/nucleus/src/components/__tests__/actions-toolbar-item.spec.jsx
@@ -18,7 +18,7 @@ const [{ default: ActionsToolbarItem }] = aw.mock(
   ['../ActionsToolbarItem']
 );
 
-describe.skip('<ActionsToolbarItem />', () => {
+describe('<ActionsToolbarItem />', () => {
   let sandbox;
   let renderer;
   let render;

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -29,7 +29,7 @@ export default function ListBoxPortal({ app, fieldIdentifier, stateName, element
 }
 
 export function ListBoxInline({ app, fieldIdentifier, stateName = '$', options = {} }) {
-  const { title, direction, listLayout, search = true, properties = {} } = options;
+  const { title, direction, listLayout, search = true, toolbar = true, properties = {} } = options;
   const listdef = {
     qInfo: {
       qType: 'njsListbox',
@@ -112,11 +112,13 @@ export function ListBoxInline({ app, fieldIdentifier, stateName = '$', options =
 
   const isLocked = layout.qListObject.qDimensionInfo.qLocked === true;
 
-  const listboxSelectionToolbarItems = createListboxSelectionToolbar({
-    layout,
-    model,
-    translator,
-  });
+  const listboxSelectionToolbarItems = toolbar
+    ? createListboxSelectionToolbar({
+        layout,
+        model,
+        translator,
+      })
+    : [];
 
   const counts = layout.qListObject.qDimensionInfo.qStateCounts;
 
@@ -128,49 +130,51 @@ export function ListBoxInline({ app, fieldIdentifier, stateName = '$', options =
 
   return (
     <Grid container direction="column" spacing={0} style={{ height: '100%', minHeight: `${minHeight}px` }}>
-      <Grid item container style={{ padding: theme.spacing(1), borderBottom: `1px solid ${theme.palette.divider}` }}>
-        <Grid item>
-          {isLocked ? (
-            <IconButton onClick={unlock} disabled={!isLocked}>
-              <Lock />
-            </IconButton>
-          ) : (
-            <IconButton onClick={lock} disabled={!hasSelections}>
-              <Unlock />
-            </IconButton>
-          )}
+      {toolbar && (
+        <Grid item container style={{ padding: theme.spacing(1), borderBottom: `1px solid ${theme.palette.divider}` }}>
+          <Grid item>
+            {isLocked ? (
+              <IconButton onClick={unlock} disabled={!isLocked}>
+                <Lock />
+              </IconButton>
+            ) : (
+              <IconButton onClick={lock} disabled={!hasSelections}>
+                <Unlock />
+              </IconButton>
+            )}
+          </Grid>
+          <Grid item>
+            {showTitle && (
+              <Typography variant="h6" noWrap>
+                {layout.title || layout.qListObject.qDimensionInfo.qFallbackTitle}
+              </Typography>
+            )}
+          </Grid>
+          <Grid item xs />
+          <Grid item>
+            <ActionsToolbar
+              more={{
+                enabled: !isLocked,
+                actions: listboxSelectionToolbarItems,
+                alignTo: moreAlignTo,
+                popoverProps: {
+                  elevation: 0,
+                },
+                popoverPaperStyle: {
+                  boxShadow: '0 12px 8px -8px rgba(0, 0, 0, 0.2)',
+                  minWidth: '250px',
+                },
+              }}
+              selections={{
+                show: showToolbar,
+                api: selections,
+                onConfirm: () => {},
+                onCancel: () => {},
+              }}
+            />
+          </Grid>
         </Grid>
-        <Grid item>
-          {showTitle && (
-            <Typography variant="h6" noWrap>
-              {layout.title || layout.qListObject.qDimensionInfo.qFallbackTitle}
-            </Typography>
-          )}
-        </Grid>
-        <Grid item xs />
-        <Grid item>
-          <ActionsToolbar
-            more={{
-              enabled: !isLocked,
-              actions: listboxSelectionToolbarItems,
-              alignTo: moreAlignTo,
-              popoverProps: {
-                elevation: 0,
-              },
-              popoverPaperStyle: {
-                boxShadow: '0 12px 8px -8px rgba(0, 0, 0, 0.2)',
-                minWidth: '250px',
-              },
-            }}
-            selections={{
-              show: showToolbar,
-              api: selections,
-              onConfirm: () => {},
-              onCancel: () => {},
-            }}
-          />
-        </Grid>
-      </Grid>
+      )}
       {search ? (
         <Grid item>
           <ListBoxSearch model={model} autoFocus={false} />

--- a/apis/nucleus/src/components/listbox/__tests__/ListBoxInline.spec.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/ListBoxInline.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { IconButton, Grid, Typography } from '@material-ui/core';
 
-describe('<ListboxInline />', () => {
+describe.skip('<ListboxInline />', () => {
   const sandbox = sinon.createSandbox({ useFakeTimers: true });
   const app = {};
   const fieldIdentifier = { qLibraryId: 'qLibraryId' };

--- a/apis/nucleus/src/components/listbox/__tests__/ListBoxInline.spec.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/ListBoxInline.spec.jsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { IconButton, Grid, Typography } from '@material-ui/core';
+
+describe('<ListboxInline />', () => {
+  const sandbox = sinon.createSandbox({ useFakeTimers: true });
+  const app = {};
+  const fieldIdentifier = { qLibraryId: 'qLibraryId' };
+  const stateName = '$';
+  const options = {
+    title: 'title',
+    direction: 'vertical',
+    listLayout: 'vertical',
+    search: true,
+    toolbar: true,
+    properties: {},
+  };
+
+  const useState = sandbox.stub(React, 'useState');
+  const useEffect = sandbox.stub(React, 'useEffect');
+  const useCallback = sandbox.stub(React, 'useCallback');
+  const useContext = sandbox.stub(React, 'useContext');
+  const useRef = sandbox.stub(React, 'useRef');
+
+  const sessionModel = {
+    lock: sandbox.stub(),
+    unlock: sandbox.stub(),
+  };
+
+  const selections = {
+    key: 'selections',
+    isModal: () => false,
+    isActive: () => 'isActive',
+    on: sandbox.stub().callsFake((event, func) => (eventTriggered) => {
+      if (event === eventTriggered) func();
+    }),
+  };
+
+  let ListBoxInline;
+  const ActionsToolbar = sandbox.stub();
+  const ListBoxSearch = sandbox.stub();
+  const createListboxSelectionToolbar = sandbox.stub();
+  const useTheme = sandbox.stub();
+  const theme = {
+    spacing: sandbox.stub(),
+    palette: { divider: 'red' },
+  };
+  const layout = {
+    title: 'title',
+
+    qListObject: {
+      qDimensionInfo: {
+        qFallbackTitle: 'qFallbackTitle',
+        qLocked: false,
+        qStateCounts: { qSelected: 2, qSelectedExcluded: 10, qLocked: 0, qLockedExcluded: 0 },
+      },
+    },
+  };
+
+  before(() => {
+    [{ ListBoxInline }] = aw.mock(
+      [
+        [
+          require.resolve('@material-ui/core'),
+          () => ({
+            IconButton,
+            Grid,
+            Typography,
+          }),
+        ],
+        [require.resolve('react-virtualized-auto-sizer'), () => (props) => props.children],
+        [require.resolve('@nebula.js/ui/icons/unlock'), () => () => 'unlock'],
+        [require.resolve('@nebula.js/ui/icons/lock'), () => () => 'lock'],
+        [require.resolve('@nebula.js/ui/theme'), () => ({ makeStyles: () => () => ({ icon: 'icon' }), useTheme })],
+        [require.resolve('../../../contexts/InstanceContext'), () => 'context'],
+        [require.resolve('../../../hooks/useObjectSelections'), () => () => [selections]],
+        [require.resolve('../../../hooks/useSessionModel'), () => () => [sessionModel]],
+        [require.resolve('../../../hooks/useLayout'), () => () => [layout]],
+        [require.resolve('../../ActionsToolbar'), () => ActionsToolbar],
+        [require.resolve('../ListBoxSearch'), () => ListBoxSearch],
+        [require.resolve('../listbox-selection-toolbar'), () => createListboxSelectionToolbar],
+      ],
+      ['../ListBoxInline']
+    );
+  });
+
+  beforeEach(() => {
+    theme.spacing.returns('padding');
+    useState.callsFake((startValue) => [startValue, () => {}]);
+    useContext.returns({ translator: 'translator' });
+    useRef.returns({ current: 'current' });
+    useTheme.returns(theme);
+    createListboxSelectionToolbar.returns('actions');
+
+    ActionsToolbar.returns('ActionsToolbar');
+    ListBoxSearch.returns('ListBoxSearch');
+
+    useEffect
+      .onCall(0)
+      .callsFake((effectFunc, watchArr) => {
+        expect(watchArr[0].key).to.equal('selections');
+        effectFunc();
+      })
+      .onCall(1)
+      .callsFake((effectFunc, watchArr) => {
+        expect(watchArr[0].key).to.equal('selections');
+        effectFunc();
+      });
+
+    useCallback
+      .onCall(0)
+      .callsFake((effectFunc, watchArr) => {
+        expect(watchArr).to.deep.equal([sessionModel]);
+        return effectFunc;
+      })
+      .onCall(1)
+      .callsFake((effectFunc, watchArr) => {
+        expect(watchArr).to.deep.equal([sessionModel]);
+        return effectFunc;
+      });
+  });
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  it('should call expected stuff', () => {
+    const response = ListBoxInline({ app, fieldIdentifier, stateName, options });
+
+    expect(response).to.be.an('object');
+    expect(useEffect).calledTwice;
+    expect(useState).calledOnce.calledWith(false);
+    expect(useCallback).calledTwice;
+    expect(theme.spacing).calledOnce;
+    expect(sessionModel.lock).not.called;
+    expect(sessionModel.unlock).not.called;
+    expect(selections.on).calledTwice;
+  });
+});

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -341,6 +341,7 @@ function nuked(configuration = {}) {
            * @param {string=} [options.direction=ltr] Direction setting ltr|rtl.
            * @param {string=} [options.listLayout=vertical] Layout direction vertical|horizontal
            * @param {boolean=} [options.search=true] To show the search bar
+           * @param {boolean=} [options.toolbar=true] To show the toolbar.
            * @param {boolean=} [options.stateName="$"] Sets the state to make selections in
            * @param {object=} [options.properties={}] Properties object to extend default properties with
            * @since 1.1.0


### PR DESCRIPTION
## Motivation

Allow hiding the toolbar. This is needed for instance when using your own toolbar, which is the case when using from sense-client. The default option is still to show the toolbar (`toolbar: true`).

With toolbar:
<img width="200" alt="image" src="https://user-images.githubusercontent.com/5780544/149887351-e3cd7ddf-92a2-41f7-9d38-7bf43de52ae4.png">

Without toolbar:
<img width="200" alt="image" src="https://user-images.githubusercontent.com/5780544/149887244-dd9a02da-1c45-4eee-8bbe-1bddcf1c597e.png">
