### PR TITLE
refactor(listbox): instant selection feedback on click

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -13,7 +13,7 @@ import InfiniteLoader from 'react-window-infinite-loader';
 
 import useLayout from '../../hooks/useLayout';
 
-import useSelectionsInteractions from './use-selections-interactions';
+import useSelectionsInteractions from './useSelectionsInteractions';
 
 import Row from './ListBoxRow';
 import Column from './ListBoxColumn';
@@ -34,6 +34,7 @@ export default function ListBox({
     layout,
     selections,
     pages,
+    doc: document,
   });
   const loaderRef = useRef(null);
   const local = useRef({

--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -25,7 +25,6 @@ export default function ListBox({
   height,
   width,
   listLayout = 'vertical',
-  rangeSelect = true,
   update = undefined,
 }) {
   const [layout] = useLayout(model);
@@ -35,7 +34,6 @@ export default function ListBox({
     layout,
     selections,
     pages,
-    rangeSelect,
   });
   const loaderRef = useRef(null);
   const local = useRef({

--- a/apis/nucleus/src/components/listbox/ListBoxColumn.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxColumn.jsx
@@ -56,7 +56,7 @@ export default function Column({ index, style, data }) {
   const classArr = [classes.column];
 
   let label = '';
-  const { onClick, pages } = data;
+  const { onMouseDown, pages } = data;
   let cell;
   if (pages) {
     const page = pages.filter((p) => p.qArea.qTop <= index && index < p.qArea.qTop + p.qArea.qHeight)[0];
@@ -114,8 +114,8 @@ export default function Column({ index, style, data }) {
       spacing={0}
       className={classArr.join(' ').trim()}
       style={style}
-      onClick={onClick}
       alignItems="center"
+      onMouseDown={onMouseDown}
       role="row"
       tabIndex={0}
       data-n={cell && cell.qElemNumber}

--- a/apis/nucleus/src/components/listbox/ListBoxRow.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxRow.jsx
@@ -56,7 +56,7 @@ export default function Row({ index, style, data }) {
   const classArr = [classes.row];
 
   let label = '';
-  const { onClick, pages } = data;
+  const { onMouseDown, pages } = data;
   let cell;
   if (pages) {
     const page = pages.filter((p) => p.qArea.qTop <= index && index < p.qArea.qTop + p.qArea.qHeight)[0];
@@ -114,7 +114,7 @@ export default function Row({ index, style, data }) {
       spacing={0}
       className={classArr.join(' ').trim()}
       style={style}
-      onClick={onClick}
+      onMouseDown={onMouseDown}
       role="row"
       tabIndex={0}
       data-n={cell && cell.qElemNumber}

--- a/apis/nucleus/src/components/listbox/__tests__/list-box-column.spec.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box-column.spec.jsx
@@ -25,7 +25,7 @@ describe('<ListBoxColumn />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [],
     };
     const testRenderer = renderer.create(<ListBoxColumn index={index} style={style} data={data} />);
@@ -37,7 +37,7 @@ describe('<ListBoxColumn />', () => {
     expect(type.props.style).to.deep.equal({});
     expect(type.props.role).to.equal('row');
     expect(type.props.className).to.equal('');
-    expect(type.props.onClick.callCount).to.equal(0);
+    expect(type.props.onMouseDown.callCount).to.equal(0);
 
     const types = testInstance.findAllByType(Typography);
     expect(types).to.have.length(1);
@@ -49,7 +49,7 @@ describe('<ListBoxColumn />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -78,7 +78,7 @@ describe('<ListBoxColumn />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -106,7 +106,7 @@ describe('<ListBoxColumn />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -134,7 +134,7 @@ describe('<ListBoxColumn />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -162,7 +162,7 @@ describe('<ListBoxColumn />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -190,7 +190,7 @@ describe('<ListBoxColumn />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -218,7 +218,7 @@ describe('<ListBoxColumn />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -252,7 +252,7 @@ describe('<ListBoxColumn />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -286,7 +286,7 @@ describe('<ListBoxColumn />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {

--- a/apis/nucleus/src/components/listbox/__tests__/list-box-row.spec.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box-row.spec.jsx
@@ -25,7 +25,7 @@ describe('<ListBoxRow />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [],
     };
     const testRenderer = renderer.create(<ListBoxRow index={index} style={style} data={data} />);
@@ -37,7 +37,7 @@ describe('<ListBoxRow />', () => {
     expect(type.props.style).to.deep.equal({});
     expect(type.props.role).to.equal('row');
     expect(type.props.className).to.equal('');
-    expect(type.props.onClick.callCount).to.equal(0);
+    expect(type.props.onMouseDown.callCount).to.equal(0);
 
     const types = testInstance.findAllByType(Typography);
     expect(types).to.have.length(1);
@@ -49,7 +49,7 @@ describe('<ListBoxRow />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -78,7 +78,7 @@ describe('<ListBoxRow />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -106,7 +106,7 @@ describe('<ListBoxRow />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -134,7 +134,7 @@ describe('<ListBoxRow />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -162,7 +162,7 @@ describe('<ListBoxRow />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -190,7 +190,7 @@ describe('<ListBoxRow />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -218,7 +218,7 @@ describe('<ListBoxRow />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -252,7 +252,7 @@ describe('<ListBoxRow />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {
@@ -286,7 +286,7 @@ describe('<ListBoxRow />', () => {
     const index = 0;
     const style = {};
     const data = {
-      onClick: sinon.spy(),
+      onMouseDown: sinon.spy(),
       pages: [
         {
           qArea: {

--- a/apis/nucleus/src/components/listbox/__tests__/listbox-selections.spec.js
+++ b/apis/nucleus/src/components/listbox/__tests__/listbox-selections.spec.js
@@ -1,0 +1,181 @@
+import * as listboxSelections from '../listbox-selections';
+
+describe('use-listbox-interactions', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  beforeEach(() => {});
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  it('getUniques should return unique values', () => {
+    expect(listboxSelections.getUniques([1, 1, 2, 5, 7, 7, 7, 1000000, 1000000])).to.deep.equal([1, 2, 5, 7, 1000000]);
+    expect(listboxSelections.getUniques([])).to.deep.equal([]);
+    expect(listboxSelections.getUniques(['hey hey', 'hey hey'])).to.deep.equal(['hey hey']);
+    expect(listboxSelections.getUniques(undefined)).to.equal(undefined);
+    expect(listboxSelections.getUniques(null)).to.equal(undefined);
+    expect(listboxSelections.getUniques({})).to.equal(undefined);
+  });
+
+  it('getSelectedValues should return unique values', () => {
+    const pages = [
+      {
+        qMatrix: [
+          [{ qState: 'S', qElemNumber: 0 }],
+          [{ qState: 'XS', qElemNumber: 1 }],
+          [{ qState: 'L', qElemNumber: 2 }],
+          [{ qState: 'A', qElemNumber: 3 }],
+          [{ qState: 'XL', qElemNumber: 4 }],
+          [{ qState: 'XS', qElemNumber: 5 }],
+          [{ qState: 'A', qElemNumber: 6 }],
+        ],
+      },
+    ];
+
+    expect(listboxSelections.getSelectedValues(undefined)).to.deep.equal([]);
+    expect(listboxSelections.getSelectedValues(pages)).to.deep.equal([0, 1, 5]);
+  });
+
+  describe('applySelectionsOnPages should modify pages so that selections are applied', () => {
+    let pages;
+
+    beforeEach(() => {
+      pages = [
+        {
+          qMatrix: [
+            [{ qState: 'S', qElemNumber: 0 }],
+            [{ qState: 'XS', qElemNumber: 1 }],
+            [{ qState: 'L', qElemNumber: 2 }],
+            [{ qState: 'A', qElemNumber: 3 }],
+            [{ qState: 'XL', qElemNumber: 4 }],
+            [{ qState: 'XS', qElemNumber: 5 }],
+            [{ qState: 'A', qElemNumber: 6 }],
+          ],
+        },
+      ];
+    });
+
+    it('should add selection for element number 2', () => {
+      const toggle = false;
+      const selectedPages = listboxSelections.applySelectionsOnPages(pages, [2], toggle);
+      expect(selectedPages).to.deep.equal([
+        {
+          qMatrix: [
+            [{ qState: 'S', qElemNumber: 0 }, []],
+            [{ qState: 'XS', qElemNumber: 1 }, []],
+            [{ qState: 'S', qElemNumber: 2 }, []],
+            [{ qState: 'A', qElemNumber: 3 }, []],
+            [{ qState: 'XL', qElemNumber: 4 }, []],
+            [{ qState: 'XS', qElemNumber: 5 }, []],
+            [{ qState: 'A', qElemNumber: 6 }, []],
+          ],
+        },
+      ]);
+    });
+
+    it('should toggle selection (turn it off)', () => {
+      const toggle = true;
+      const selectedPages = listboxSelections.applySelectionsOnPages(pages, [0], toggle);
+      expect(selectedPages).to.deep.equal([
+        {
+          qMatrix: [
+            [{ qState: 'A', qElemNumber: 0 }, []],
+            [{ qState: 'XS', qElemNumber: 1 }, []],
+            [{ qState: 'L', qElemNumber: 2 }, []],
+            [{ qState: 'A', qElemNumber: 3 }, []],
+            [{ qState: 'XL', qElemNumber: 4 }, []],
+            [{ qState: 'XS', qElemNumber: 5 }, []],
+            [{ qState: 'A', qElemNumber: 6 }, []],
+          ],
+        },
+      ]);
+    });
+
+    it('should select a range without toggling any already selected values', () => {
+      const toggle = false;
+      const selectedPages = listboxSelections.applySelectionsOnPages(pages, [0, 1, 2, 3, 4, 5], toggle);
+      expect(selectedPages).to.deep.equal([
+        {
+          qMatrix: [
+            [{ qState: 'S', qElemNumber: 0 }, []],
+            [{ qState: 'S', qElemNumber: 1 }, []],
+            [{ qState: 'S', qElemNumber: 2 }, []],
+            [{ qState: 'S', qElemNumber: 3 }, []],
+            [{ qState: 'S', qElemNumber: 4 }, []],
+            [{ qState: 'S', qElemNumber: 5 }, []],
+            [{ qState: 'A', qElemNumber: 6 }, []],
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe('selectValues should call the select method', () => {
+    let selections;
+
+    beforeEach(() => {
+      const SUCCESS = true;
+      selections = {
+        select: sandbox.stub().resolves(SUCCESS),
+      };
+    });
+
+    it('should abort if nan values exist', async () => {
+      const promise = listboxSelections.selectValues({
+        selections,
+        elemNumbers: [1, 2, NaN, 4],
+        isSingleSelect: false,
+      });
+      expect(promise.then, 'should return a promise').to.be.a('function');
+      const resp = await promise;
+      expect(resp, 'should return unsuccessful').to.equal(false);
+      expect(selections.select).not.called;
+    });
+
+    it('should call select', async () => {
+      const resp = await listboxSelections.selectValues({
+        selections,
+        elemNumbers: [1, 2, 3, 4],
+        isSingleSelect: false,
+      });
+      expect(resp, 'success').to.equal(true);
+      expect(selections.select).calledOnce.calledWithExactly({
+        method: 'selectListObjectValues',
+        params: ['/qListObjectDef', [1, 2, 3, 4], true],
+      });
+    });
+
+    it('single select true should translate to toggle false', async () => {
+      const resp = await listboxSelections.selectValues({
+        selections,
+        elemNumbers: [4],
+        isSingleSelect: true,
+      });
+      expect(resp, 'success').to.equal(true);
+      expect(selections.select).calledOnce.calledWithExactly({
+        method: 'selectListObjectValues',
+        params: ['/qListObjectDef', [4], false],
+      });
+    });
+
+    it('should catch errors in backend call', async () => {
+      selections.select.rejects('error');
+      expect(async () => {
+        await listboxSelections.selectValues({
+          selections,
+          elemNumbers: [4],
+          isSingleSelect: false,
+        });
+      }).not.to.throw();
+    });
+  });
+});

--- a/apis/nucleus/src/components/listbox/__tests__/listbox-selections.spec.js
+++ b/apis/nucleus/src/components/listbox/__tests__/listbox-selections.spec.js
@@ -7,8 +7,6 @@ describe('use-listbox-interactions', () => {
     sandbox = sinon.createSandbox();
   });
 
-  beforeEach(() => {});
-
   afterEach(() => {
     sandbox.reset();
   });

--- a/apis/nucleus/src/components/listbox/__tests__/use-selections-interactions.spec.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/use-selections-interactions.spec.jsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import { create, act } from 'react-test-renderer';
+import * as listboxSelections from '../listbox-selections';
+
+import useSelectionsInteractions from '../useSelectionsInteractions';
+
+const TestHook = React.forwardRef(({ hook, hookProps = [] }, ref) => {
+  const result = hook(...hookProps);
+  React.useImperativeHandle(ref, () => ({
+    result,
+  }));
+  return null;
+});
+
+describe('use-listbox-interactions', () => {
+  let sandbox;
+  let layout;
+  let selections;
+  let pages;
+  let ref;
+  let render;
+  let getUniques;
+  let selectValues;
+  let applySelectionsOnPages;
+
+  before(() => {
+    sandbox = sinon.createSandbox({ useFakeTimers: true });
+
+    getUniques = sandbox.stub(listboxSelections, 'getUniques');
+    selectValues = sandbox.stub(listboxSelections, 'selectValues');
+    applySelectionsOnPages = sandbox.stub(listboxSelections, 'applySelectionsOnPages');
+  });
+
+  beforeEach(() => {
+    global.document = {
+      addEventListener: sandbox.stub(),
+      removeEventListener: sandbox.stub(),
+    };
+
+    getUniques.callsFake((input) => input);
+    selectValues.resolves();
+    applySelectionsOnPages.returns('instant pages');
+
+    layout = {
+      qListObject: { qDimensionInfo: { qIsOneAndOnlyOne: false } },
+    };
+    selections = { key: 'selections' };
+    pages = [];
+
+    ref = React.createRef();
+    render = async () => {
+      await act(async () => {
+        create(
+          <TestHook
+            ref={ref}
+            hook={useSelectionsInteractions}
+            hookProps={[{ layout, selections, pages, doc: global.document }]}
+          />
+        );
+      });
+    };
+  });
+
+  afterEach(() => {
+    sandbox.reset();
+    delete global.document;
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  describe('it should behave', () => {
+    it('should behave', async () => {
+      await render();
+      const arg0 = ref.current.result;
+      expect(Object.keys(arg0)).to.deep.equal(['instantPages', 'interactionEvents']);
+      expect(arg0.instantPages).to.equal('instant pages');
+      expect(Object.keys(arg0.interactionEvents)).to.deep.equal(['onMouseDown']);
+
+      expect(applySelectionsOnPages).calledOnce.calledWithExactly([], [], false, false);
+      expect(global.document.addEventListener.args[0][0]).to.equal('mouseup');
+      expect(global.document.removeEventListener).not.called;
+
+      expect(listboxSelections.selectValues).not.called;
+
+      arg0.interactionEvents.onMouseDown({
+        currentTarget: {
+          getAttribute: sandbox.stub().withArgs('data-n').returns(23),
+        },
+      });
+      await render();
+      expect(listboxSelections.selectValues).calledOnce.calledWithExactly({
+        selections: { key: 'selections' },
+        elemNumbers: [23],
+        isSingleSelect: false,
+      });
+      const arg1 = ref.current.result;
+      expect(applySelectionsOnPages).calledThrice;
+      expect(applySelectionsOnPages.args[1]).to.deep.equal([[], [23], false, true]);
+      expect(arg1.instantPages).to.equal('instant pages');
+    });
+  });
+});

--- a/apis/nucleus/src/components/listbox/listbox-selections.js
+++ b/apis/nucleus/src/components/listbox/listbox-selections.js
@@ -33,10 +33,9 @@ export function applySelectionsOnPages(pages, elmNumbers, toggle = false) {
       const qState = selectionMatchesElement ? getNewSelectionState(p0.qState) : p0.qState;
       return [{ ...p0, qState }, p.slice(1)];
     });
-    return qMatrix;
+    return { ...page, qMatrix };
   });
-  const newPages = pages.map((page, i) => ({ ...page, qMatrix: matrices[i] }));
-  return newPages;
+  return matrices;
 }
 
 export async function selectValues({ selections, elemNumbers, isSingleSelect = false }) {

--- a/apis/nucleus/src/components/listbox/listbox-selections.js
+++ b/apis/nucleus/src/components/listbox/listbox-selections.js
@@ -7,7 +7,7 @@ function isStateSelected(qState) {
 }
 
 export function getUniques(arr) {
-  return Array.from(new Set(arr));
+  return Array.isArray(arr) ? Array.from(new Set(arr)) : undefined;
 }
 
 export function getSelectedValues(pages) {
@@ -24,9 +24,8 @@ export function getSelectedValues(pages) {
   return flattenArr(elementNbrs);
 }
 
-export function applySelectionsOnPages(pages, elmNumbers, mouseDown, toggle = false) {
-  const getNewSelectionState = (qState) =>
-    /* !mouseDown &&  */ toggle && elmNumbers.length === 1 && isStateSelected(qState) ? 'A' : 'S';
+export function applySelectionsOnPages(pages, elmNumbers, toggle = false) {
+  const getNewSelectionState = (qState) => (toggle && elmNumbers.length === 1 && isStateSelected(qState) ? 'A' : 'S');
   const matrices = pages.map((page) => {
     const qMatrix = page.qMatrix.map((p) => {
       const [p0] = p;
@@ -41,8 +40,7 @@ export function applySelectionsOnPages(pages, elmNumbers, mouseDown, toggle = fa
 }
 
 export async function selectValues({ selections, elemNumbers, isSingleSelect = false }) {
-  const SUCCESS = false;
-  let resolved = Promise.resolve(SUCCESS);
+  let resolved = Promise.resolve(false);
   const hasNanValues = elemNumbers.some((elemNumber) => Number.isNaN(elemNumber));
   if (!hasNanValues) {
     const elemNumbersToSelect = elemNumbers;

--- a/apis/nucleus/src/components/listbox/listbox-selections.js
+++ b/apis/nucleus/src/components/listbox/listbox-selections.js
@@ -1,4 +1,45 @@
-// eslint-disable-next-line import/prefer-default-export
+const SELECTED_STATES = ['S', 'XS'];
+
+const flattenArr = (arr) => arr.reduce((prev, cur) => prev.concat(cur));
+
+function isStateSelected(qState) {
+  return SELECTED_STATES.includes(qState);
+}
+
+export function getUniques(arr) {
+  return Array.from(new Set(arr));
+}
+
+export function getSelectedValues(pages) {
+  if (!pages) {
+    return [];
+  }
+  const elementNbrs = pages.map((page) => {
+    const elementNumbers = page.qMatrix.map((p) => {
+      const [p0] = p;
+      return isStateSelected(p0.qState) ? p0.qElemNumber : false;
+    });
+    return elementNumbers.filter((n) => n !== false);
+  });
+  return flattenArr(elementNbrs);
+}
+
+export function applySelectionsOnPages(pages, elmNumbers, mouseDown, toggle = false) {
+  const getNewSelectionState = (qState) =>
+    /* !mouseDown &&  */ toggle && elmNumbers.length === 1 && isStateSelected(qState) ? 'A' : 'S';
+  const matrices = pages.map((page) => {
+    const qMatrix = page.qMatrix.map((p) => {
+      const [p0] = p;
+      const selectionMatchesElement = elmNumbers.includes(p0.qElemNumber);
+      const qState = selectionMatchesElement ? getNewSelectionState(p0.qState) : p0.qState;
+      return [{ ...p0, qState }, p.slice(1)];
+    });
+    return qMatrix;
+  });
+  const newPages = pages.map((page, i) => ({ ...page, qMatrix: matrices[i] }));
+  return newPages;
+}
+
 export async function selectValues({ selections, elemNumbers, isSingleSelect = false }) {
   const SUCCESS = false;
   let resolved = Promise.resolve(SUCCESS);

--- a/apis/nucleus/src/components/listbox/use-selections-interactions.js
+++ b/apis/nucleus/src/components/listbox/use-selections-interactions.js
@@ -1,0 +1,72 @@
+import { useEffect, useState, useCallback } from 'react';
+import { getUniques, selectValues, applySelectionsOnPages } from './listbox-selections';
+
+export default function useSelectionInteractions({ layout, selections, pages = [] }) {
+  // eslint-disable-next-line no-param-reassign
+  const [mouseDown, setMouseDown] = useState(false);
+  const [selectedElementNumbers, setSelectedElementNumbers] = useState([]);
+  const [selectingValues, setSelectingValues] = useState(false);
+  const [instantPages, setInstantPages] = useState(pages);
+
+  const select = ({ elemNumbers }) => {
+    setSelectingValues(true);
+    const isSingleSelect = layout.qListObject.qDimensionInfo.qIsOneAndOnlyOne;
+    return selectValues({ selections, elemNumbers, isSingleSelect }).then(() => {
+      setSelectingValues(false);
+    });
+  };
+
+  const onMouseDown = useCallback(
+    (event) => {
+      if (selectingValues) {
+        return;
+      }
+      const elemNumber = +event.currentTarget.getAttribute('data-n');
+      setSelectedElementNumbers([elemNumber]);
+      setMouseDown(true);
+    },
+    [selectingValues, layout]
+  );
+
+  const onMouseUpDoc = useCallback(() => {
+    setMouseDown(false);
+  }, []);
+
+  useEffect(() => {
+    if (!mouseDown) {
+      return;
+    }
+    const elemNumbers = getUniques(selectedElementNumbers);
+    if (elemNumbers.length) {
+      select({ elemNumbers });
+    }
+  }, [selectedElementNumbers, mouseDown]);
+
+  useEffect(() => {
+    document.addEventListener('mouseup', onMouseUpDoc);
+    return () => {
+      document.removeEventListener('mouseup', onMouseUpDoc);
+    };
+  }, []);
+
+  // Effect for instant UI update of selection states by modifying pages directly.
+  useEffect(() => {
+    if (selectingValues || !pages /*  || !selectedElementNumbers.length */) {
+      return;
+    }
+    const newPages = applySelectionsOnPages(
+      pages,
+      selectedElementNumbers,
+      mouseDown,
+      selectedElementNumbers.length === 1
+    );
+    setInstantPages(newPages);
+  }, [selectedElementNumbers]);
+
+  return {
+    instantPages,
+    interactionEvents: {
+      onMouseDown,
+    },
+  };
+}

--- a/apis/nucleus/src/components/listbox/use-selections-interactions.js
+++ b/apis/nucleus/src/components/listbox/use-selections-interactions.js
@@ -2,7 +2,6 @@ import { useEffect, useState, useCallback } from 'react';
 import { getUniques, selectValues, applySelectionsOnPages } from './listbox-selections';
 
 export default function useSelectionInteractions({ layout, selections, pages = [] }) {
-  // eslint-disable-next-line no-param-reassign
   const [mouseDown, setMouseDown] = useState(false);
   const [selectedElementNumbers, setSelectedElementNumbers] = useState([]);
   const [selectingValues, setSelectingValues] = useState(false);
@@ -49,9 +48,8 @@ export default function useSelectionInteractions({ layout, selections, pages = [
     };
   }, []);
 
-  // Effect for instant UI update of selection states by modifying pages directly.
   useEffect(() => {
-    if (selectingValues || !pages /*  || !selectedElementNumbers.length */) {
+    if (selectingValues || !pages) {
       return;
     }
     const newPages = applySelectionsOnPages(

--- a/apis/nucleus/src/components/listbox/useSelectionsInteractions.js
+++ b/apis/nucleus/src/components/listbox/useSelectionsInteractions.js
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { getUniques, selectValues, applySelectionsOnPages } from './listbox-selections';
 
-export default function useSelectionInteractions({ layout, selections, pages = [] }) {
+export default function useSelectionsInteractions({ layout, selections, pages = [], doc = document }) {
   const [mouseDown, setMouseDown] = useState(false);
   const [selectedElementNumbers, setSelectedElementNumbers] = useState([]);
   const [selectingValues, setSelectingValues] = useState(false);
@@ -42,9 +42,9 @@ export default function useSelectionInteractions({ layout, selections, pages = [
   }, [selectedElementNumbers, mouseDown]);
 
   useEffect(() => {
-    document.addEventListener('mouseup', onMouseUpDoc);
+    doc.addEventListener('mouseup', onMouseUpDoc);
     return () => {
-      document.removeEventListener('mouseup', onMouseUpDoc);
+      doc.removeEventListener('mouseup', onMouseUpDoc);
     };
   }, []);
 


### PR DESCRIPTION
## Motivation

- Get instant selection feedback on click (replaced by `onMouseDown`) by modifying the pages directly for better user experience
- This is also needed for range selections (next PR)
