### PR TITLE
docs: add missing context in createconfiguration

### DIFF
--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -439,7 +439,9 @@ function nuked(configuration = {}) {
    * // create an alternate config with dark theme
    * // and inherit the config from the previous
    * const d = m.createConfiguration({
-   *  theme: 'dark'
+   *  context: {
+   *    theme: 'dark'
+   *  }
    * });
    *
    * m(app).render({ type: 'mekko' }); // will render the object with default theme

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -43,7 +43,7 @@
             "type": "#/entries/embed"
           },
           "examples": [
-            "import { embed } from '@nebula.js/stardust';\n// create a 'master' config which registers all types\nconst m = embed.createConfiguration({\n  types: [{\n    name: 'mekko',\n    version: '1.0.0',\n    load: () => Promise.resolve(mekko)\n  }],\n});\n\n// create an alternate config with dark theme\n// and inherit the config from the previous\nconst d = m.createConfiguration({\n theme: 'dark'\n});\n\nm(app).render({ type: 'mekko' }); // will render the object with default theme\nd(app).render({ type: 'mekko' }); // will render the object with 'dark' theme\nembed(app).render({ type: 'mekko' }); // will throw error since 'mekko' is not a register type on the default instance"
+            "import { embed } from '@nebula.js/stardust';\n// create a 'master' config which registers all types\nconst m = embed.createConfiguration({\n  types: [{\n    name: 'mekko',\n    version: '1.0.0',\n    load: () => Promise.resolve(mekko)\n  }],\n});\n\n// create an alternate config with dark theme\n// and inherit the config from the previous\nconst d = m.createConfiguration({\n context: {\n   theme: 'dark'\n }\n});\n\nm(app).render({ type: 'mekko' }); // will render the object with default theme\nd(app).render({ type: 'mekko' }); // will render the object with 'dark' theme\nembed(app).render({ type: 'mekko' }); // will throw error since 'mekko' is not a register type on the default instance"
           ]
         }
       }
@@ -445,7 +445,7 @@
         "type": "#/definitions/Constraints"
       },
       "examples": [
-        "// configure embed to disallow active interactions when rendering\nembed(app, {\n  constraints: {\n    active: true, // do not allow interactions\n  }\n}).render({ element, id: 'sdfsdf' });",
+        "// configure embed to disallow active interactions when rendering\nembed(app, {\n context: {\n   constraints: {\n     active: true, // do not allow interactions\n   }\n }\n}).render({ element, id: 'sdfsdf' });",
         "import { useConstraints } from '@nebula.js/stardust';\n// ...\nconst constraints = useConstraints();\nuseEffect(() => {\n  if (constraints.active) {\n    // do not add any event listener if active constraint is set\n    return undefined;\n  }\n  const listener = () => {};\n  element.addEventListener('click', listener);\n  return () => {\n    element.removeEventListener('click', listener);\n  };\n}, [constraints])"
       ]
     },
@@ -790,13 +790,25 @@
                   "type": "string"
                 },
                 "search": {
-                  "description": "To show the search bar",
+                  "description": "Show the search bar",
                   "optional": true,
                   "defaultValue": true,
                   "type": "boolean"
                 },
                 "toolbar": {
-                  "description": "To show the toolbar",
+                  "description": "Show the toolbar",
+                  "optional": true,
+                  "defaultValue": true,
+                  "type": "boolean"
+                },
+                "checkboxes": {
+                  "description": "Show values as checkboxes instead of as fields",
+                  "optional": true,
+                  "defaultValue": false,
+                  "type": "boolean"
+                },
+                "rangeSelect": {
+                  "description": "Enable range selection",
                   "optional": true,
                   "defaultValue": true,
                   "type": "boolean"

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -250,6 +250,8 @@ declare namespace stardust {
             listLayout?: string;
             search?: boolean;
             toolbar?: boolean;
+            checkboxes?: boolean;
+            rangeSelect?: boolean;
             stateName?: boolean;
             properties?: object;
             sessionModel?: object;

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -847,9 +847,11 @@ export function useAction(fn, deps) {
  * @example
  * // configure embed to disallow active interactions when rendering
  * embed(app, {
- *   constraints: {
- *     active: true, // do not allow interactions
- *   }
+ *  context: {
+ *    constraints: {
+ *      active: true, // do not allow interactions
+ *    }
+ *  }
  * }).render({ element, id: 'sdfsdf' });
  *
  * @example

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -134,7 +134,9 @@ const m = embed.createConfiguration({
 // create an alternate config with dark theme
 // and inherit the config from the previous
 const d = m.createConfiguration({
-  theme: 'dark',
+  context: {
+    theme: 'dark',
+  },
 });
 
 m(app).render({ type: 'mekko' }); // will render the object with default theme
@@ -424,8 +426,10 @@ and should respected by you when implementing the supernova.
 ```js
 // configure embed to disallow active interactions when rendering
 embed(app, {
-  constraints: {
-    active: true, // do not allow interactions
+  context: {
+    constraints: {
+      active: true, // do not allow interactions
+    },
   },
 }).render({ element, id: 'sdfsdf' });
 ```


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

```
embed(app, {
  constraints: {
    active: true, // do not allow interactions
  }
})
```
should be
```
embed(app, {
  context: {
    constraints: {
      active: true, // do not allow interactions
    }
  }
})
```
```
const d = m.createConfiguration({
 theme: 'dark'
});
```
should also be
```
const d = m.createConfiguration({
  context: {
    theme: 'dark'
  }
});
```