### PR TITLE
feat(listbox): dense mode with reduced padding and text size

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -11,6 +11,20 @@ import useSelectionsInteractions from './useSelectionsInteractions';
 
 import RowColumn from './ListBoxRowColumn';
 
+function getSizeInfo({ isVertical, checkboxes, dense, height }) {
+  let sizeVertical = checkboxes ? 40 : 33;
+  if (dense) {
+    sizeVertical = 24;
+  }
+  const itemSize = isVertical ? sizeVertical : 200;
+  const listHeight = height || 8 * itemSize;
+
+  return {
+    itemSize,
+    listHeight,
+  };
+}
+
 export default function ListBox({
   model,
   selections,
@@ -21,6 +35,7 @@ export default function ListBox({
   rangeSelect = true,
   checkboxes = false,
   update = undefined,
+  dense = false,
 }) {
   const [layout] = useLayout(model);
   const [pages, setPages] = useState(null);
@@ -131,12 +146,10 @@ export default function ListBox({
   if (!layout) {
     return null;
   }
+
   const isVertical = listLayout !== 'horizontal';
   const count = layout.qListObject.qSize.qcy;
-  const SIZE_VERTICAL = checkboxes ? 40 : 33;
-  const ITEM_SIZE = isVertical ? SIZE_VERTICAL : 200;
-  const listHeight = height || 8 * ITEM_SIZE;
-
+  const { itemSize, listHeight } = getSizeInfo({ isVertical, checkboxes, dense, height });
   const isLocked = layout && layout.qListObject.qDimensionInfo.qLocked;
 
   return (
@@ -160,8 +173,15 @@ export default function ListBox({
             width={width}
             itemCount={count}
             layout={listLayout}
-            itemData={{ isLocked, column: !isVertical, pages, ...(isLocked ? {} : interactionEvents), checkboxes }}
-            itemSize={ITEM_SIZE}
+            itemData={{
+              isLocked,
+              column: !isVertical,
+              pages,
+              ...(isLocked ? {} : interactionEvents),
+              checkboxes,
+              dense,
+            }}
+            itemSize={itemSize}
             onItemsRendered={onItemsRendered}
             ref={ref}
           >

--- a/apis/nucleus/src/components/listbox/ListBoxCheckbox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxCheckbox.jsx
@@ -30,9 +30,12 @@ const useStyles = makeStyles((theme) => ({
       backgroundColor: 'inherit !important',
     },
   },
+  dense: {
+    padding: '4px 8px',
+  },
 }));
 
-export default function ListboxCheckbox({ checked, label }) {
+export default function ListboxCheckbox({ checked, label, dense }) {
   const styles = useStyles();
 
   return (
@@ -41,7 +44,7 @@ export default function ListboxCheckbox({ checked, label }) {
       checked={checked}
       tabIndex={-1}
       disableRipple
-      className={styles.checkbox}
+      className={[styles.checkbox, dense && styles.dense].filter(Boolean).join(' ')}
       inputProps={{ 'aria-labelledby': label }}
       name={label}
       icon={<span className={styles.cbIcon} />}

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -41,6 +41,7 @@ export function ListBoxInline({ app, fieldIdentifier, stateName = '$', options =
     sessionModel = undefined,
     selectionsApi = undefined,
     update = undefined,
+    dense = false,
   } = options;
 
   const listdef = {
@@ -199,7 +200,7 @@ export function ListBoxInline({ app, fieldIdentifier, stateName = '$', options =
       )}
       {search ? (
         <Grid item>
-          <ListBoxSearch model={model} autoFocus={false} />
+          <ListBoxSearch model={model} autoFocus={false} dense={dense} />
         </Grid>
       ) : (
         ''
@@ -218,6 +219,7 @@ export function ListBoxInline({ app, fieldIdentifier, stateName = '$', options =
               height={height}
               width={width}
               update={update}
+              dense={dense}
             />
           )}
         </AutoSizer>

--- a/apis/nucleus/src/components/listbox/ListBoxRowColumn.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxRowColumn.jsx
@@ -151,7 +151,7 @@ export default function RowColumn({ index, style, data, column = false }) {
 
   const getValueField = ({ lbl, ix, color, highlighted = false }) => (
     <Typography
-      component="div"
+      component="span"
       variant="body2"
       key={ix}
       className={[classes.labelText, highlighted && classes.highlighted, dense && classes.labelDense]

--- a/apis/nucleus/src/components/listbox/ListBoxRowColumn.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxRowColumn.jsx
@@ -55,6 +55,10 @@ const useStyles = makeStyles((theme) => ({
     ...ellipsis,
   },
 
+  labelDense: {
+    fontSize: 12,
+  },
+
   // Highlight is added to labelText spans, which are created as siblings to original labelText,
   // when a search string is matched.
   highlighted: {
@@ -102,7 +106,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function RowColumn({ index, style, data, column = false }) {
-  const { onClick, onMouseDown, onMouseUp, onMouseEnter, pages, isLocked, checkboxes = false } = data;
+  const { onClick, onMouseDown, onMouseUp, onMouseEnter, pages, isLocked, checkboxes = false, dense = false } = data;
 
   const [isSelected, setSelected] = useState(false);
   const [cell, setCell] = useState();
@@ -150,7 +154,7 @@ export default function RowColumn({ index, style, data, column = false }) {
       component="span"
       variant="body2"
       key={ix}
-      className={[classes.labelText, !!highlighted && classes.highlighted]
+      className={[classes.labelText, highlighted && classes.highlighted, dense && classes.labelDense]
         .filter((c) => !!c)
         .join(' ')
         .trim()}
@@ -161,7 +165,7 @@ export default function RowColumn({ index, style, data, column = false }) {
   );
 
   const getCheckboxField = ({ lbl, color, qElemNumber }) => {
-    const cb = <ListBoxCheckbox label={lbl} checked={isSelected} />;
+    const cb = <ListBoxCheckbox label={lbl} checked={isSelected} dense={dense} />;
     const labelTag = typeof lbl === 'string' ? getValueField({ lbl, color, highlighted: false }) : lbl;
     return (
       <FormControlLabel
@@ -208,7 +212,7 @@ export default function RowColumn({ index, style, data, column = false }) {
     <Grid
       container
       spacing={0}
-      className={classArr.join(' ').trim()}
+      className={['value', ...classArr].join(' ').trim()}
       style={style}
       onClick={onClick}
       onMouseDown={onMouseDown}

--- a/apis/nucleus/src/components/listbox/ListBoxRowColumn.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxRowColumn.jsx
@@ -151,7 +151,7 @@ export default function RowColumn({ index, style, data, column = false }) {
 
   const getValueField = ({ lbl, ix, color, highlighted = false }) => (
     <Typography
-      component="span"
+      component="div"
       variant="body2"
       key={ix}
       className={[classes.labelText, highlighted && classes.highlighted, dense && classes.labelDense]

--- a/apis/nucleus/src/components/listbox/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxSearch.jsx
@@ -13,10 +13,18 @@ const useStyles = makeStyles((theme) => ({
       borderColor: `${theme.palette.divider} transparent`,
     },
   },
+  dense: {
+    fontSize: 12,
+    paddingLeft: theme.spacing(1),
+    '& input': {
+      paddingTop: '5px',
+      paddingBottom: '5px',
+    },
+  },
 }));
 const TREE_PATH = '/qListObjectDef';
 
-export default function ListBoxSearch({ model, autoFocus = true }) {
+export default function ListBoxSearch({ model, autoFocus = true, dense = false }) {
   const { translator } = useContext(InstanceContext);
   const [value, setValue] = useState('');
   const onChange = (e) => {
@@ -43,10 +51,10 @@ export default function ListBoxSearch({ model, autoFocus = true }) {
     <OutlinedInput
       startAdornment={
         <InputAdornment position="start">
-          <Search />
+          <Search size={dense ? 'small' : 'normal'} />
         </InputAdornment>
       }
-      className={[classes.root].join(' ')}
+      className={['search', classes.root, dense && classes.dense].filter(Boolean).join(' ')}
       autoFocus={autoFocus}
       margin="dense"
       fullWidth

--- a/apis/nucleus/src/components/listbox/__tests__/list-box-row-column.spec.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box-row-column.spec.jsx
@@ -54,7 +54,7 @@ describe('<ListBoxRowColumn />', () => {
       expect(type.props.spacing).to.equal(0);
       expect(type.props.style).to.deep.equal({});
       expect(type.props.role).to.equal(rowCol);
-      expect(type.props.className).to.equal('');
+      expect(type.props.className).to.equal('value');
       expect(type.props.onMouseDown.callCount).to.equal(0);
       expect(type.props.onMouseUp.callCount).to.equal(0);
       expect(type.props.onMouseEnter.callCount).to.equal(0);
@@ -91,7 +91,7 @@ describe('<ListBoxRowColumn />', () => {
       expect(type.props.spacing).to.equal(0);
       expect(type.props.style).to.deep.equal({});
       expect(type.props.role).to.equal(rowCol);
-      expect(type.props.className).to.equal('');
+      expect(type.props.className).to.equal('value');
       expect(type.props.onMouseDown.callCount).to.equal(0);
       expect(type.props.onMouseUp.callCount).to.equal(0);
       expect(type.props.onMouseEnter.callCount).to.equal(0);
@@ -176,7 +176,7 @@ describe('<ListBoxRowColumn />', () => {
       );
       const testInstance = testRenderer.root;
       const type = testInstance.findByType(Grid);
-      expect(type.props.className).to.equal('selected');
+      expect(type.props.className).to.include('selected');
       await testRenderer.unmount();
     });
     it('should set alternative', async () => {
@@ -210,7 +210,7 @@ describe('<ListBoxRowColumn />', () => {
       );
       const testInstance = testRenderer.root;
       const type = testInstance.findByType(Grid);
-      expect(type.props.className).to.equal('alternative');
+      expect(type.props.className).to.include('alternative');
       await testRenderer.unmount();
     });
     it('should set excluded - qState X', async () => {
@@ -244,7 +244,7 @@ describe('<ListBoxRowColumn />', () => {
       );
       const testInstance = testRenderer.root;
       const type = testInstance.findByType(Grid);
-      expect(type.props.className).to.equal('excluded');
+      expect(type.props.className).to.include('excluded');
       await testRenderer.unmount();
     });
     it('should set excluded - qState XS', async () => {
@@ -278,7 +278,7 @@ describe('<ListBoxRowColumn />', () => {
       );
       const testInstance = testRenderer.root;
       const type = testInstance.findByType(Grid);
-      expect(type.props.className).to.equal('excluded');
+      expect(type.props.className).to.include('excluded');
       await testRenderer.unmount();
     });
     it('should set excluded - qState XL', async () => {
@@ -312,7 +312,7 @@ describe('<ListBoxRowColumn />', () => {
       );
       const testInstance = testRenderer.root;
       const type = testInstance.findByType(Grid);
-      expect(type.props.className).to.equal('excluded');
+      expect(type.props.className).to.include('excluded');
       await testRenderer.unmount();
     });
     it('should highlight ranges', async () => {
@@ -351,7 +351,7 @@ describe('<ListBoxRowColumn />', () => {
       const testInstance = testRenderer.root;
       const types = testInstance.findAllByType(Typography);
       expect(types[0].props.children.props.children).to.equal('nebula.js');
-      expect(types[0].props.className).to.equal('highlighted');
+      expect(types[0].props.className).to.include('highlighted');
       expect(types[1].props.children.props.children).to.equal(' ftw');
       await testRenderer.unmount();
     });
@@ -392,7 +392,7 @@ describe('<ListBoxRowColumn />', () => {
       const types = testInstance.findAllByType(Typography);
       expect(types[0].props.children.props.children).to.equal('nebula.js ');
       expect(types[1].props.children.props.children).to.equal('ftw');
-      expect(types[1].props.className).to.equal('highlighted');
+      expect(types[1].props.className).to.include('highlighted');
       const hits = testInstance.findAllByProps({ className: 'highlighted' });
       expect(hits).to.have.length(2);
       await testRenderer.unmount();
@@ -434,7 +434,7 @@ describe('<ListBoxRowColumn />', () => {
       const types = testInstance.findAllByType(Typography);
       expect(types[0].props.children.props.children).to.equal('nebula.js ftw ');
       expect(types[1].props.children.props.children).to.equal('yeah');
-      expect(types[1].props.className).to.equal('highlighted');
+      expect(types[1].props.className).to.include('highlighted');
       expect(types[2].props.children.props.children).to.equal(' buddy');
       await testRenderer.unmount();
     });
@@ -475,7 +475,7 @@ describe('<ListBoxRowColumn />', () => {
       const types = testInstance.findAllByType(Typography);
       expect(types[1].props.children.props.children).to.equal('nebula.js ftw ');
       expect(types[2].props.children.props.children).to.equal('yeah');
-      expect(types[2].props.className).to.equal('highlighted');
+      expect(types[2].props.className).to.include('highlighted');
       expect(types[3].props.children.props.children).to.equal(' buddy');
       await testRenderer.unmount();
     });
@@ -504,7 +504,7 @@ describe('<ListBoxRowColumn />', () => {
       expect(type.props.spacing).to.equal(0);
       expect(type.props.style).to.deep.equal({});
       expect(type.props.role).to.equal(rowCol);
-      expect(type.props.className).to.equal('');
+      expect(type.props.className).to.equal('value');
       expect(type.props.onMouseDown.callCount).to.equal(0);
       expect(type.props.onMouseUp.callCount).to.equal(0);
       expect(type.props.onMouseEnter.callCount).to.equal(0);

--- a/apis/nucleus/src/components/listbox/__tests__/list-box-row-column.spec.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box-row-column.spec.jsx
@@ -61,7 +61,7 @@ describe('<ListBoxRowColumn />', () => {
 
       const types = testInstance.findAllByType(Typography);
       expect(types).to.have.length(1);
-      expect(types[0].props.component).to.equal('div');
+      expect(types[0].props.component).to.equal('span');
       expect(types[0].props.children.type).to.equal('span');
 
       const cbs = testInstance.findAllByType(ListBoxCheckbox);
@@ -529,7 +529,7 @@ describe('<ListBoxRowColumn />', () => {
 
       const types = testInstance.findAllByType(Typography);
       expect(types).to.have.length(1);
-      expect(types[0].props.component).to.equal('div');
+      expect(types[0].props.component).to.equal('span');
       expect(types[0].props.children.props.children).to.equal('');
 
       const cbs = testInstance.findAllByType(ListBoxCheckbox);

--- a/apis/nucleus/src/components/listbox/__tests__/list-box-row-column.spec.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box-row-column.spec.jsx
@@ -62,7 +62,7 @@ describe('<ListBoxRowColumn />', () => {
 
       const types = testInstance.findAllByType(Typography);
       expect(types).to.have.length(1);
-      expect(types[0].props.component).to.equal('span');
+      expect(types[0].props.component).to.equal('div');
       expect(types[0].props.children.type).to.equal('span');
 
       const cbs = testInstance.findAllByType(ListBoxCheckbox);
@@ -512,7 +512,7 @@ describe('<ListBoxRowColumn />', () => {
 
       const types = testInstance.findAllByType(Typography);
       expect(types).to.have.length(1);
-      expect(types[0].props.component).to.equal('span');
+      expect(types[0].props.component).to.equal('div');
       expect(types[0].props.children.props.children).to.equal('');
 
       const cbs = testInstance.findAllByType(ListBoxCheckbox);

--- a/apis/nucleus/src/components/listbox/__tests__/list-box-row-column.spec.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box-row-column.spec.jsx
@@ -54,7 +54,6 @@ describe('<ListBoxRowColumn />', () => {
       expect(type.props.spacing).to.equal(0);
       expect(type.props.style).to.deep.equal({});
       expect(type.props.role).to.equal(rowCol);
-      expect(type.props.className).to.equal('value');
       expect(type.props.onMouseDown.callCount).to.equal(0);
       expect(type.props.onMouseUp.callCount).to.equal(0);
       expect(type.props.onMouseEnter.callCount).to.equal(0);
@@ -69,7 +68,27 @@ describe('<ListBoxRowColumn />', () => {
       expect(cbs).to.have.length(0);
       await testRenderer.unmount();
     });
+    it('should have css class `value`', async () => {
+      const index = 0;
+      const style = {};
+      const data = {
+        onMouseDown: sinon.spy(),
+        onMouseUp: sinon.spy(),
+        onMouseEnter: sinon.spy(),
+        onClick: sinon.spy(),
+        pages: [],
+      };
+      const testRenderer = await render(
+        <ListBoxRowColumn index={index} style={style} data={data} column={rowCol === 'column'} />
+      );
+      const testInstance = testRenderer.root;
 
+      const type = testInstance.findByType(Grid);
+      const { className } = type.props;
+      expect(className).to.be.a('string');
+      expect(className.split(' ')).to.include('value');
+      await testRenderer.unmount();
+    });
     it('should render with checkboxes', async () => {
       const index = 0;
       const style = {};
@@ -91,7 +110,6 @@ describe('<ListBoxRowColumn />', () => {
       expect(type.props.spacing).to.equal(0);
       expect(type.props.style).to.deep.equal({});
       expect(type.props.role).to.equal(rowCol);
-      expect(type.props.className).to.equal('value');
       expect(type.props.onMouseDown.callCount).to.equal(0);
       expect(type.props.onMouseUp.callCount).to.equal(0);
       expect(type.props.onMouseEnter.callCount).to.equal(0);
@@ -504,7 +522,6 @@ describe('<ListBoxRowColumn />', () => {
       expect(type.props.spacing).to.equal(0);
       expect(type.props.style).to.deep.equal({});
       expect(type.props.role).to.equal(rowCol);
-      expect(type.props.className).to.equal('value');
       expect(type.props.onMouseDown.callCount).to.equal(0);
       expect(type.props.onMouseUp.callCount).to.equal(0);
       expect(type.props.onMouseEnter.callCount).to.equal(0);
@@ -517,6 +534,27 @@ describe('<ListBoxRowColumn />', () => {
 
       const cbs = testInstance.findAllByType(ListBoxCheckbox);
       expect(cbs).to.have.length(0);
+      await testRenderer.unmount();
+    });
+    it('should have css class `value`', async () => {
+      const index = 0;
+      const style = {};
+      const data = {
+        onMouseDown: sinon.spy(),
+        onMouseUp: sinon.spy(),
+        onMouseEnter: sinon.spy(),
+        onClick: sinon.spy(),
+        pages: [],
+      };
+      const testRenderer = await render(
+        <ListBoxRowColumn index={index} style={style} data={data} column={rowCol === 'column'} />
+      );
+      const testInstance = testRenderer.root;
+
+      const type = testInstance.findByType(Grid);
+      const { className } = type.props;
+      expect(className).to.be.a('string');
+      expect(className.split(' ')).to.include('value');
       await testRenderer.unmount();
     });
   });

--- a/apis/nucleus/src/components/listbox/__tests__/list-box-search.spec.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box-search.spec.jsx
@@ -33,6 +33,23 @@ describe('<ListBoxSearch />', () => {
     expect(types[0].props.onChange).to.be.a('function');
     expect(types[0].props.onKeyDown).to.be.a('function');
   });
+  it('should have css class `search`', () => {
+    const model = {
+      searchListObjectFor: sinon.spy(),
+      acceptListObjectSearch: sinon.spy(),
+      abortListObjectSearch: sinon.spy(),
+    };
+    const testRenderer = renderer.create(
+      <InstanceContext.Provider value={{ translator: { get: () => 'Search' } }}>
+        <ListBoxSearch model={model} />
+      </InstanceContext.Provider>
+    );
+    const testInstance = testRenderer.root;
+    const [input] = testInstance.findAllByType(OutlinedInput);
+    const { className } = input.props;
+    expect(className).to.be.a('string');
+    expect(className.split(' ')).to.include('search');
+  });
   it('should update `OutlinedInput` and search `onChange`', () => {
     const model = {
       searchListObjectFor: sinon.spy(),

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -350,6 +350,7 @@ function nuked(configuration = {}) {
            * @param {boolean=} [options.toolbar=true] Show the toolbar
            * @param {boolean=} [options.checkboxes=false] Show values as checkboxes instead of as fields
            * @param {boolean=} [options.rangeSelect=true] Enable range selection
+           * @param {boolean=} [options.dense] Reduces padding and text size
            * @param {boolean=} [options.stateName="$"] Sets the state to make selections in
            * @param {object=} [options.properties={}] Properties object to extend default properties with
            * @param {object} [options.sessionModel] Use a custom sessionModel.


### PR DESCRIPTION
## Motivation

Add `dense` option for listbox component. When running in dense mode the padding and text size is reduced.

Add static class names to the search input and for each value. The class names are `search` and `value`. This enables possibility to override styling.

### Examples

*Normal mode (as-is today)*
<img width="247" alt="image" src="https://user-images.githubusercontent.com/7684435/155115527-3e82510f-cefe-4e5c-b0ce-5b28720831af.png">

*Dense mode*
<img width="247" alt="image" src="https://user-images.githubusercontent.com/7684435/155115701-67235798-0381-4da9-ab53-8a927b555002.png">

*With custom styling*
<img width="247" alt="image" src="https://user-images.githubusercontent.com/7684435/155115834-b60e3227-d61e-4927-b62c-5c97a1d4b0b2.png">
