### PR TITLE
feat: get the value of style with the exact given attributes seprated by dots 

### DIFF
--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -3,7 +3,7 @@
 /* eslint no-console: 0 */
 /* eslint no-use-before-define: 0 */
 
-// Hooks implementation heavily inspired by prect hooks
+// Hooks implementation heavily inspired by preact hooks
 
 let currentComponent;
 let currentIndex;

--- a/apis/theme/src/__tests__/style-resolver.spec.js
+++ b/apis/theme/src/__tests__/style-resolver.spec.js
@@ -36,7 +36,21 @@ describe('style-resolver', () => {
     };
     const s = create('object.bar', t);
 
+    expect(s.getStyle('', 'fontSize')).to.equal('16px');
+    expect(s.getStyle('legend', 'fontSize')).to.equal('16px');
+    expect(s.getStyle('legend.content', 'fontSize')).to.equal('16px');
+    expect(s.getStyle('title', 'fontSize')).to.equal('16px');
+
     expect(s.getStyle('legend.title', 'fontSize')).to.equal('13px');
+    expect(s.getStyle('legend.content', 'color')).to.equal(undefined);
+
+    expect(s.getStyle('.', 'legend.title.fontSize')).to.equal('13px');
+    expect(s.getStyle('legend.', 'title.fontSize')).to.equal('13px');
+    expect(s.getStyle('legend.', 'content.fontSize')).to.equal(undefined);
+    expect(s.getStyle('legend.', 'content.color')).to.equal(undefined);
+
+    expect(s.getStyle('table', 'fontSize')).to.equal('16px');
+    expect(s.getStyle('table', 'content.fontSize')).to.equal(undefined);
   });
 
   it('resolveRawTheme', () => {

--- a/apis/theme/src/index.js
+++ b/apis/theme/src/index.js
@@ -73,29 +73,31 @@ export default function theme() {
     },
 
     /**
-     * Get the value of a style attribute in the theme by searching in the theme's JSON structure.
-     * The search starts at the specified base path and continues upwards until the value is found.
+     * Get the value of a style attribute in the theme
+     * by searching in the theme's JSON structure.
+     * The search starts at the specified base path
+     * and continues upwards until the value is found.
      * If possible it will get the attribute's value using the given path.
-     * When a default value is provided and there is no value of
-     * a style attribute found with that exactly specified path,
-     * the default value will be returned.
+     * When attributes separated by dots are provided, such as 'hover.color',
+     * they are required in the theme JSON file
      *
      * @param {string} basePath - Base path in the theme's JSON structure to start the search in (specified as a name path separated by dots).
      * @param {string} path - Expected path for the attribute (specified as a name path separated by dots).
-     * @param {string} attribute - Name of the style attribute.
-     * @param {string|null} [defaultValue] - Set a default value if no style value found.
-     * @returns {string|undefined|null} The style value or the default value or undefined
+     * @param {string} attribute - Name of the style attribute. (specified as a name attribute separated by dots).
+     * @returns {string|undefined} The style value or undefined if not found
      *
      * @example
      * theme.getStyle('object', 'title.main', 'fontSize');
+     * theme.getStyle('object', 'title', 'main.fontSize');
+     * theme.getStyle('object', '', 'title.main.fontSize');
      * theme.getStyle('', '', 'fontSize');
      */
-    getStyle(basePath, path, attribute, defaultValue) {
+    getStyle(basePath, path, attribute) {
       if (!styleResolverInstanceCache[basePath]) {
         styleResolverInstanceCache[basePath] = styleResolverFn(basePath, resolvedThemeJSON);
       }
 
-      return styleResolverInstanceCache[basePath].getStyle(path, attribute, defaultValue);
+      return styleResolverInstanceCache[basePath].getStyle(path, attribute);
     },
   };
 

--- a/apis/theme/src/index.js
+++ b/apis/theme/src/index.js
@@ -76,21 +76,26 @@ export default function theme() {
      * Get the value of a style attribute in the theme by searching in the theme's JSON structure.
      * The search starts at the specified base path and continues upwards until the value is found.
      * If possible it will get the attribute's value using the given path.
+     * When a default value is provided and there is no value of
+     * a style attribute found with that exactly specified path,
+     * the default value will be returned.
      *
      * @param {string} basePath - Base path in the theme's JSON structure to start the search in (specified as a name path separated by dots).
      * @param {string} path - Expected path for the attribute (specified as a name path separated by dots).
      * @param {string} attribute - Name of the style attribute.
-     * @returns {string} The style value
+     * @param {string|null} [defaultValue] - Set a default value if no style value found.
+     * @returns {string|undefined|null} The style value or the default value or undefined
      *
      * @example
      * theme.getStyle('object', 'title.main', 'fontSize');
      * theme.getStyle('', '', 'fontSize');
      */
-    getStyle(basePath, path, attribute) {
+    getStyle(basePath, path, attribute, defaultValue) {
       if (!styleResolverInstanceCache[basePath]) {
         styleResolverInstanceCache[basePath] = styleResolverFn(basePath, resolvedThemeJSON);
       }
-      return styleResolverInstanceCache[basePath].getStyle(path, attribute, false);
+
+      return styleResolverInstanceCache[basePath].getStyle(path, attribute, defaultValue);
     },
   };
 

--- a/apis/theme/src/style-resolver.js
+++ b/apis/theme/src/style-resolver.js
@@ -49,7 +49,7 @@ function getObject(root, steps) {
     if (obj[steps[i]]) {
       obj = obj[steps[i]];
     } else {
-      return null;
+      return undefined;
     }
   }
   return obj;
@@ -58,15 +58,8 @@ function getObject(root, steps) {
 function searchPathArray(pathArray, attribute, theme) {
   const attributeArray = attribute.split('.');
   for (let i = 0; i < pathArray.length; i++) {
-    const target = getObject(theme, pathArray[i]);
-    if (target !== null) {
-      if (attributeArray.length === 1 && target[attribute]) {
-        return target[attribute];
-      }
-      if (attributeArray.length > 1) {
-        return getObject(target, attributeArray);
-      }
-    }
+    const restult = getObject(theme, [...pathArray[i], ...attributeArray]);
+    if (restult !== undefined) return restult;
   }
 
   return undefined;

--- a/apis/theme/src/style-resolver.js
+++ b/apis/theme/src/style-resolver.js
@@ -107,11 +107,12 @@ export default function styleResolver(basePath, themeJSON) {
      * object - fontSize
      * fontSize
      * When defaultValue is provided,
-     * it get the value of a style attribute with the given base path + path
+     * it gets the value of a style attribute with the given base path + path
      * Ex: object.barChart - legend.title - fontSize
+     * if not found, it will fallback to the defaultValue
      * @ignore
      *
-     * @param {string} component String of properties seperated by dots to search in
+     * @param {string} component String of properties separated by dots to search in
      * @param {string} attribute Name of the style attribute
      * @param {string|null} [defaultValue] Set a default value if no style value found.
      * @returns {string|undefined|null} The style value of the resolved path, undefined if not found or the default value


### PR DESCRIPTION
…

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation
Like in https://github.com/qlik-oss/sn-table/pull/453, sometimes we want to get a style value by exact search without a fallback.

When attributes separated by dots is provided, such as 'hover.color', they are required in the theme JSON file
Ex.
`const hoverFontColorFromTheme = theme.getStyle('object', 'straightTable.content', 'hover.color');`

that would require a hover: { color: ... } } in the theme but still fallback to look for that on multiple levels, supporting a theme with a global hover.color fallback.

and if you want more exact you can just call

`const hoverFontColorFromTheme = theme.getStyle('object', '', 'straightTable.content.hover.color');`

