### PR TITLE
chore: update parcel and bypass hmr bug

### DIFF
--- a/.codesandbox/mekko/package.json
+++ b/.codesandbox/mekko/package.json
@@ -4,7 +4,7 @@
   "description": "Simple Parcel Sandbox",
   "main": "index.html",
   "scripts": {
-    "start": "parcel index.html --open",
+    "start": "parcel index.html --open --no-hmr",
     "build": "parcel build index.html"
   },
   "dependencies": {
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "@babel/core": "7.17.5",
-    "parcel-bundler": "^1.12.5"
+    "parcel": "^2.3.2"
   }
 }

--- a/commands/create/templates/mashup/_package.json
+++ b/commands/create/templates/mashup/_package.json
@@ -7,13 +7,13 @@
   },
   "keywords": ["qlik", "nebula"],
   "scripts": {
-    "start": "parcel src/index.html --open",
+    "start": "parcel src/index.html --open --no-hmr",
     "build": "parcel build src/index.html --dist-dir ./dist"
   },
   "dependencies": {
     "@nebula.js/stardust": "<%= nebulaVersion %>",
     "@nebula.js/sn-bar-chart": "^0.8.24",
     "enigma.js": "^2.6.3",
-    "parcel": "^2.0.0-rc.0"
+    "parcel": "^2.3.2"
   }
 }

--- a/examples/chart-conversion/package.json
+++ b/examples/chart-conversion/package.json
@@ -4,7 +4,7 @@
   "description": "Simple local mashup",
   "main": "index.html",
   "scripts": {
-    "start": "parcel index.html --open",
+    "start": "parcel index.html --open --no-hmr",
     "build": "parcel build index.html"
   },
   "dependencies": {
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "@babel/core": "7.12.3",
-    "parcel": "^2.0.0-rc.0"
+    "parcel": "^2.3.2"
   }
 }

--- a/examples/dev-mashup/package.json
+++ b/examples/dev-mashup/package.json
@@ -4,7 +4,7 @@
   "description": "Simple local mashup",
   "main": "index.html",
   "scripts": {
-    "start": "parcel index.html --open",
+    "start": "parcel index.html --open --no-hmr",
     "build": "parcel build index.html"
   },
   "dependencies": {
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "@babel/core": "7.12.3",
-    "parcel-bundler": "^1.12.5"
+    "parcel": "^2.3.2"
   }
 }


### PR DESCRIPTION
## Motivation

Updates Parcel from the RC to 2.3.2 for all packages. Also adds the `--no-hmr` option which resolves issues with `yarn link`-ing local stardust versions
