### PR TITLE
chore: add long running test

### DIFF
--- a/apis/enigma-mocker/src/__tests__/prop.spec.js
+++ b/apis/enigma-mocker/src/__tests__/prop.spec.js
@@ -67,15 +67,38 @@ describe('getPropFn', () => {
   });
 
   describe('async is enabled', () => {
+    let clock;
+
+    before(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
     it('returns promise', async () => {
       const prop = sinon.stub();
       prop.returns(500);
       const fn = getPropFn(prop, { async: true });
       const valuePromise = fn();
       expect(valuePromise).to.be.a('promise');
+      clock.tick(1);
       const value = await valuePromise;
       expect(value).to.equal(500);
     });
+
+    it('supports delay', async () => {
+      const prop = sinon.stub();
+      prop.returns(600);
+      const promise = getPropFn(prop, { async: true, delay: 500 })();
+
+      clock.tick(510);
+
+      return promise.then((value) => {
+        expect(value).to.equal(600);
+      });
+    }).timeout(2000);
   });
 
   describe('async is disabled', () => {

--- a/apis/enigma-mocker/src/from-generic-objects.js
+++ b/apis/enigma-mocker/src/from-generic-objects.js
@@ -4,6 +4,11 @@ import GetObjectMock from './mocks/get-object-mock';
 import GetAppLayoutMock from './mocks/get-app-layout-mock';
 
 /**
+ * @interface EnigmaMockerOptions
+ * @property {number} delay Simulate delay (in ms) for calls in enigma-mocker.
+ */
+
+/**
  * Mocks Engima app functionality. It accepts one / many generic objects as input argument and returns the mocked Enigma app. Each generic object represents one visulization and specifies how it behaves. For example, what layout to use the data to present.
  *
  * The generic object is represented with a Javascript object with a number of properties. The name of the property correlates to the name in the Enigma model for `app.getObject(id)`. For example, the property `getLayout` in the generic object is used to define `app.getObject(id).getLayout()`. Any property can be added to the fixture (just make sure it exists and behaves as in the Enigma model!).
@@ -11,6 +16,7 @@ import GetAppLayoutMock from './mocks/get-app-layout-mock';
  * The value for each property is either fixed (string / boolean / number / object) or a function. Arguments are forwarded to the function to allow for greater flexibility. For example, this can be used to return different hypercube data when scrolling in the chart.
  *
  * @param {Array<object>} genericObjects Generic objects controling behaviour of visualizations.
+ * @param {EnigmaMockerOptions} options Options
  * @returns {Promise<enigma.Doc>}
  * @example
  * const genericObject = {
@@ -29,14 +35,14 @@ import GetAppLayoutMock from './mocks/get-app-layout-mock';
  * };
  * const app = await EnigmaMocker.fromGenericObjects([genericObject]);
  */
-export default (genericObjects) => {
+export default (genericObjects, options = {}) => {
   if (!Array.isArray(genericObjects) || genericObjects.length === 0) {
     throw new Error('No "genericObjects" specified');
   }
 
   const session = new SessionMock();
   const createSessionObject = new CreateSessionObjectMock();
-  const getObject = new GetObjectMock(genericObjects);
+  const getObject = new GetObjectMock(genericObjects, options);
   const getAppLayout = new GetAppLayoutMock();
 
   const app = {

--- a/apis/enigma-mocker/src/mocks/get-object-mock.js
+++ b/apis/enigma-mocker/src/mocks/get-object-mock.js
@@ -27,10 +27,12 @@ function isPropAsync(name) {
 /**
  * Create a mock of a generic object. Mandatory properties are added, functions returns async values where applicable etc.
  * @param {object} genericObject Generic object describing behaviour of mock
+ * @param {EnigmaMockerOptions} options Options.
  * @returns The mocked object
  */
-function createMock(genericObject) {
-  const { id, session, delay = 0, ...props } = genericObject;
+function createMock(genericObject, options) {
+  const { delay } = options;
+  const { id, session, ...props } = genericObject;
   return {
     id: getPropValue(id, { defaultValue: `object - ${+Date.now()}` }),
     session: getPropValue(session, { defaultValue: true }),
@@ -69,11 +71,12 @@ function validate(genericObject) {
 /**
  * Creates mock of `getObject(id)` based on an array of generic objects.
  * @param {Array<object>} genericObjects Generic objects.
+ * @param {EnigmaMockerOptions} options Options.
  * @returns Function to retrieve the mocked generic object with the corresponding id.
  */
-function GetObjectMock(genericObjects = []) {
+function GetObjectMock(genericObjects = [], options) {
   genericObjects.forEach(validate);
-  const genericObjectMocks = genericObjects.map(createMock);
+  const genericObjectMocks = genericObjects.map((genericObject) => createMock(genericObject, options));
 
   return async (id) => {
     const mock = genericObjectMocks.find((m) => m.qId() === id);

--- a/apis/enigma-mocker/src/mocks/get-object-mock.js
+++ b/apis/enigma-mocker/src/mocks/get-object-mock.js
@@ -1,5 +1,4 @@
 import { getPropValue, getPropFn } from '../prop';
-import { findAsync } from '../util';
 
 /**
  * Properties on `getObject()` operating synchronously.
@@ -13,6 +12,7 @@ const PROPS_SYNC = [
   'removeAllListeners',
   'removeListener',
   'setMaxListerners',
+  'qId',
 ];
 
 /**
@@ -30,7 +30,7 @@ function isPropAsync(name) {
  * @returns The mocked object
  */
 function createMock(genericObject) {
-  const { id, session, ...props } = genericObject;
+  const { id, session, delay = 0, ...props } = genericObject;
   return {
     id: getPropValue(id, { defaultValue: `object - ${+Date.now()}` }),
     session: getPropValue(session, { defaultValue: true }),
@@ -39,7 +39,7 @@ function createMock(genericObject) {
     ...Object.entries(props).reduce(
       (fns, [name, value]) => ({
         ...fns,
-        [name]: getPropFn(value, { async: isPropAsync(name) }),
+        [name]: getPropFn(value, { async: isPropAsync(name), delay }),
       }),
       {}
     ),
@@ -63,6 +63,7 @@ function validate(genericObject) {
   if (!(layout.qInfo && layout.qInfo.qId)) {
     throw new Error('Generic object is missing "qId" for path "getLayout().qInfo.qId"');
   }
+  genericObject.qId = layout.qInfo.qId; // eslint-disable-line no-param-reassign
 }
 
 /**
@@ -75,7 +76,7 @@ function GetObjectMock(genericObjects = []) {
   const genericObjectMocks = genericObjects.map(createMock);
 
   return async (id) => {
-    const mock = findAsync(genericObjectMocks, async (m) => (await m.getLayout()).qInfo.qId === id);
+    const mock = genericObjectMocks.find((m) => m.qId() === id);
     return Promise.resolve(mock);
   };
 }

--- a/apis/enigma-mocker/src/mocks/get-object-mock.js
+++ b/apis/enigma-mocker/src/mocks/get-object-mock.js
@@ -100,7 +100,7 @@ function validate(genericObject) {
  * @param {EnigmaMockerOptions} options Options.
  * @returns Function to retrieve the mocked generic object with the corresponding id.
  */
-function GetObjectMock(genericObjects = [], options) {
+function GetObjectMock(genericObjects = [], options = {}) {
   genericObjects.forEach(validate);
   const mocks = createMocks(genericObjects, options);
 

--- a/apis/enigma-mocker/src/prop.js
+++ b/apis/enigma-mocker/src/prop.js
@@ -55,8 +55,12 @@ export const getPropValue = (prop, { args = [], defaultValue } = {}) => {
  * @returns A fixture property function
  */
 export const getPropFn =
-  (prop, { defaultValue, async = true } = {}) =>
+  (prop, { defaultValue, async = true, delay = 0 } = {}) =>
   (...args) => {
     const value = getPropValue(prop, { defaultValue, args });
-    return async ? Promise.resolve(value) : value;
+    return async
+      ? new Promise((resolve) => {
+          setTimeout(() => resolve(value), delay);
+        })
+      : value;
   };

--- a/apis/enigma-mocker/src/prop.js
+++ b/apis/enigma-mocker/src/prop.js
@@ -52,6 +52,7 @@ export const getPropValue = (prop, { args = [], defaultValue } = {}) => {
  * @param {object} options Options.
  * @param {any} options.defaultValue Default value in case not value is defined in fixture.
  * @param {boolean} options.async When `true` the returns value is wrapped in a promise, otherwise the value is directly returned.
+ * @param {number} options.number Delay before value is returned.
  * @returns A fixture property function
  */
 export const getPropFn =

--- a/apis/nucleus/src/components/LongRunningQuery.jsx
+++ b/apis/nucleus/src/components/LongRunningQuery.jsx
@@ -31,7 +31,7 @@ export function Cancel({ cancel, translator, ...props }) {
           <Progress />
         </Grid>
         <Grid item>
-          <Typography variant="h6" align="center">
+          <Typography variant="h6" align="center" data-tid="update-active">
             {translator.get('Object.Update.Active')}
           </Typography>
         </Grid>
@@ -52,7 +52,7 @@ export function Retry({ retry, translator, ...props }) {
         <WarningTriangle style={{ fontSize: '38px' }} />
       </Grid>
       <Grid item>
-        <Typography variant="h6" align="center">
+        <Typography variant="h6" align="center" data-tid="update-cancelled">
           {translator.get('Object.Update.Cancelled')}
         </Typography>
       </Grid>

--- a/test/mashup/visualize/life.int.js
+++ b/test/mashup/visualize/life.int.js
@@ -32,6 +32,21 @@ describe('object lifecycle', () => {
     await waitForTextStatus('[data-tid="error-title"]', 'Incomplete visualization');
   });
 
+  it('should render long running query', async () => {
+    const url = getScenarioUrl('long-running');
+    await page.goto(url);
+    await waitForTextStatus('[data-tid="update-active"]', 'Updating data');
+
+    // the cancel button should appear after 2000ms
+    await page.click('.njs-cell button');
+    await waitForTextStatus('[data-tid="update-cancelled"]', 'Data update was cancelled');
+    // Retry
+    await waitForTextStatus('.njs-cell button', 'Retry');
+    await page.click('.njs-cell button');
+
+    await waitForTextStatus('.rendered', 'Success!', { timeout: 7000 });
+  });
+
   // need to fix calc condition view first
   it('should show calculation unfulfilled', async () => {
     const url = getScenarioUrl('calc-unfulfilled');

--- a/test/mashup/visualize/scenarios.js
+++ b/test/mashup/visualize/scenarios.js
@@ -36,6 +36,120 @@ scenarios['valid-type'] = {
   },
 };
 
+scenarios['long-running'] = {
+  name: 'Long running query',
+  genericObject: {
+    delay: 5000,
+    session: {
+      getObjectApi() {
+        return {
+          cancelRequest() {
+            return {};
+          },
+        };
+      },
+    },
+    getLayout() {
+      return {
+        qInfo: {
+          qId: 'bb8',
+          qType: 'doesnt matter',
+        },
+        qMeta: {
+          privileges: ['read', 'update', 'delete', 'exportdata'],
+        },
+        qSelectionInfo: {},
+        visualization: 'my-chart',
+        qHyperCube: {
+          qSize: {
+            qcx: 2,
+            qcy: 1,
+          },
+          qDimensionInfo: [
+            {
+              qFallbackTitle: '=a',
+              qApprMaxGlyphCount: 1,
+              qCardinal: 0,
+              qSortIndicator: 'N',
+              qGroupFallbackTitles: ['=a'],
+              qGroupPos: 0,
+              qStateCounts: {
+                qLocked: 0,
+                qSelected: 0,
+                qOption: 0,
+                qDeselected: 0,
+                qAlternative: 0,
+                qExcluded: 0,
+                qSelectedExcluded: 0,
+                qLockedExcluded: 0,
+              },
+              qTags: [],
+              qDimensionType: 'D',
+              qGrouping: 'N',
+              qNumFormat: {
+                qType: 'U',
+                qnDec: 0,
+                qUseThou: 0,
+              },
+              qIsAutoFormat: true,
+              qGroupFieldDefs: ['=a'],
+              qMin: 'NaN',
+              qMax: 'NaN',
+              qAttrExprInfo: [],
+              qAttrDimInfo: [],
+              qIsCalculated: true,
+              qCardinalities: {
+                qCardinal: 0,
+                qHypercubeCardinal: 1,
+                qAllValuesCardinal: -1,
+              },
+            },
+          ],
+          qMeasureInfo: [
+            {
+              qFallbackTitle: '=1',
+              qApprMaxGlyphCount: 1,
+              qCardinal: 0,
+              qSortIndicator: 'N',
+              qNumFormat: {
+                qType: 'U',
+                qnDec: 0,
+                qUseThou: 0,
+              },
+              qMin: 1,
+              qMax: 1,
+              qIsAutoFormat: true,
+              qAttrExprInfo: [],
+              qAttrDimInfo: [],
+              qTrendLines: [],
+            },
+          ],
+          qEffectiveInterColumnSortOrder: [0, 1],
+          qGrandTotalRow: [
+            {
+              qText: '1',
+              qNum: 1,
+              qElemNumber: -1,
+              qState: 'X',
+              qIsTotalCell: true,
+            },
+          ],
+          qDataPages: [],
+          qPivotDataPages: [],
+          qStackedDataPages: [],
+          qMode: 'S',
+          qNoOfLeftDims: -1,
+          qTreeNodesOnDim: [],
+          qColumnOrder: [],
+        },
+      };
+    },
+    getProperties() {
+      return {};
+    },
+  },
+};
+
 scenarios['calc-unfulfilled'] = {
   name: 'Calculations unfulfilled',
   genericObject: {

--- a/test/mashup/visualize/scenarios.js
+++ b/test/mashup/visualize/scenarios.js
@@ -38,8 +38,10 @@ scenarios['valid-type'] = {
 
 scenarios['long-running'] = {
   name: 'Long running query',
-  genericObject: {
+  options: {
     delay: 5000,
+  },
+  genericObject: {
     session: {
       getObjectApi() {
         return {
@@ -583,7 +585,7 @@ function getScenario() {
 
 async function render() {
   const scenario = getScenario();
-  const app = await window.enigmaMocker.fromGenericObjects([scenario.genericObject]);
+  const app = await window.enigmaMocker.fromGenericObjects([scenario.genericObject], scenario.options);
   const element = document.querySelector('.viz');
   const viz = await configuration(app).render({ element, id: 'bb8' });
 


### PR DESCRIPTION
## Motivation

Adds a test for long runnning queries by adding a delay to the mocked engine calls. It currently doesn't properly cancel the call when you press cancel (or the test presses cancel), but it covers the functionality.

@streamside Feel free to clean up this code if you like, had to do some light hacking to get the delay to work without slowing everything down too much.
