### PR TITLE
chore: replace deprecated build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,8 @@ jobs:
       - store_artifacts:
           path: test/mashup/__artifacts__
   api-governance:
-    machine: true
+    machine:
+      image: ubuntu-2004
     working_directory: ~/project
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
           path: test/mashup/__artifacts__
   api-governance:
     machine:
-      image: ubuntu-2004
+      image: ubuntu-2004:current
     working_directory: ~/project
     steps:
       - checkout


### PR DESCRIPTION
## Motivation

The `machine:true` setting in cirlce is getting deprecated, so replacing it.
