### PR TITLE
chore: make typescript optional in build

### DIFF
--- a/commands/build/lib/build.js
+++ b/commands/build/lib/build.js
@@ -11,7 +11,6 @@ const postcss = require('rollup-plugin-postcss');
 const replace = require('@rollup/plugin-replace');
 const sourcemaps = require('rollup-plugin-sourcemaps');
 const jsxPlugin = require('@babel/plugin-transform-react-jsx');
-const typescriptPlugin = require('@rollup/plugin-typescript');
 const json = require('@rollup/plugin-json');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const commonjs = require('@rollup/plugin-commonjs');
@@ -78,8 +77,15 @@ const config = ({
   const auth = typeof author === 'object' ? `${author.name} <${author.email}>` : author || '';
   const moduleName = name.split('/').reverse()[0];
   const extensions = ['.mjs', '.js', '.jsx', '.json', '.node'];
+
+  let typescriptPlugin;
   if (typescript) {
     extensions.push('.tsx', '.ts');
+    try {
+      typescriptPlugin = require('@rollup/plugin-typescript'); // eslint-disable-line
+    } catch (e) {
+      throw new Error(`Please install '@rollup/plugin-typescript' to build using typescript.`);
+    }
   }
 
   const banner = `/*

--- a/commands/build/package.json
+++ b/commands/build/package.json
@@ -29,7 +29,6 @@
     "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "13.3.0",
     "@rollup/plugin-replace": "4.0.0",
-    "@rollup/plugin-typescript": "8.3.2",
     "chalk": "4.1.2",
     "extend": "3.0.2",
     "postcss": "^8.4.13",
@@ -42,6 +41,7 @@
   },
   "devDependencies": {
     "tslib": "*",
+    "@rollup/plugin-typescript": "8.3.2",
     "typescript": ">=4.6.4"
   }
 }

--- a/commands/cli/lib/index.js
+++ b/commands/cli/lib/index.js
@@ -11,15 +11,21 @@ yargs.usage('nebula <command> [options]');
 
 const tryAddCommand = (m) => {
   let cmd;
+  let error;
   try {
     cmd = require(`${m}/command`); // eslint-disable-line
   } catch (e) {
+    error = e;
     cmd = importCwd.silent(`${m}/command`);
   }
 
   if (cmd) {
     yargs.command(cmd);
   } else {
+    // Print the error
+    if (error) {
+      console.log(`Error from import: ${error.message}`);
+    }
     // add dummy command in order to instruct user how to install missing package
     const comm = m.split('-')[1];
     yargs.command({


### PR DESCRIPTION

## Motivation

cli-build would throw errors if certain typescript libraries wasn't present in the current node_modules scope, this attempts to remedy that and throw better errors.
