### PR TITLE
fix: the selections is missing in dependency arrays

### DIFF
--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -392,7 +392,7 @@ const Cell = forwardRef(
       load(layout.visualization, withVersion);
 
       return () => {};
-    }, [types, state.sn, model, layout, appLayout, language]);
+    }, [types, state.sn, model, selections, layout, appLayout, language]);
 
     // Long running query
     useEffect(() => {


### PR DESCRIPTION
## Motivation

Fix [an issue in the mashup development using sn-table 
](https://github.com/qlik-oss/sn-table/issues/570) 
- missing the selections in dependency arrays causes the value of `selections` in 

```
loadType({
          dispatch,
          types,
          visualization,
          version,
          model,
          app,
          selections,
          nebbie,
          focusHandler: focusHandler.current,
        }); 
```
is undefined

- then `params.selections` is undefined

```
create(params) {
      const ss = create(generator, params, galaxy);
      return ss;
    },
``` 

in generator.js

- then `opts.selections` is undefined

```
function createWithHooks(generator, opts, galaxy) {
	const c = {
		context: {
			selections: opts.selections,
		}
	}
}
``` 

in creator.js

- then `useSelections() `is undefined

```
export function useSelections() {
  return useInternalContext('selections');
}
```

in hooks.js


## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [x] Add code reviewers, for example @qlik-oss/nebula-core
