### PR TITLE
fix(listbox): prop to disable confirming selections on blur events

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -59,7 +59,7 @@ export default function ListBoxInline({ app, fieldIdentifier, stateName = '$', o
     sortByState = 1,
     scrollState = undefined,
     setCount = undefined,
-    shouldConfirmOnBlur,
+    shouldConfirmOnBlur = undefined,
   } = options;
   let { frequencyMode, histogram = false } = options;
 

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -59,6 +59,7 @@ export default function ListBoxInline({ app, fieldIdentifier, stateName = '$', o
     sortByState = 1,
     scrollState = undefined,
     setCount = undefined,
+    shouldConfirmOnBlur,
   } = options;
   let { frequencyMode, histogram = false } = options;
 
@@ -210,7 +211,7 @@ export default function ListBoxInline({ app, fieldIdentifier, stateName = '$', o
   }, [selections]);
 
   const listBoxRef = useRef(null);
-  useConfirmUnfocus(listBoxRef, selections);
+  useConfirmUnfocus(listBoxRef, selections, shouldConfirmOnBlur);
 
   useEffect(() => {
     if (!searchContainer || !searchContainer.current) {

--- a/apis/nucleus/src/components/listbox/useConfirmUnfocus.jsx
+++ b/apis/nucleus/src/components/listbox/useConfirmUnfocus.jsx
@@ -15,7 +15,7 @@ export default function useConfirmUnfocus(ref, selections, shouldConfirmOnBlur) 
   };
 
   useEffect(() => {
-    if (!shouldConfirmOnBlur) return () => {};
+    if (!shouldConfirmOnBlur) return undefined;
 
     const handleEvent = (event) => {
       const interactInside = ref.current && ref.current.contains(event.target);

--- a/apis/nucleus/src/components/listbox/useConfirmUnfocus.jsx
+++ b/apis/nucleus/src/components/listbox/useConfirmUnfocus.jsx
@@ -5,7 +5,7 @@ import { useRef, useEffect, useState } from 'react';
  * user interact outside of passed element ref.
  */
 
-export default function useConfirmUnfocus(ref, selections, enabledConfirmOnBlur) {
+export default function useConfirmUnfocus(ref, selections, shouldConfirmOnBlur) {
   const [_isConfirmed, _setIsConfirmed] = useState(false);
   // Wrap state in ref to use inside eventListener callback
   const isConfirmedRef = useRef(_isConfirmed);
@@ -15,7 +15,7 @@ export default function useConfirmUnfocus(ref, selections, enabledConfirmOnBlur)
   };
 
   useEffect(() => {
-    if (!enabledConfirmOnBlur) return () => {};
+    if (!shouldConfirmOnBlur) return () => {};
 
     const handleEvent = (event) => {
       const interactInside = ref.current && ref.current.contains(event.target);
@@ -34,5 +34,5 @@ export default function useConfirmUnfocus(ref, selections, enabledConfirmOnBlur)
       document.removeEventListener('mousedown', handleEvent);
       document.removeEventListener('keydown', handleEvent);
     };
-  }, [ref, selections, enabledConfirmOnBlur]);
+  }, [ref, selections, shouldConfirmOnBlur]);
 }

--- a/apis/nucleus/src/components/listbox/useConfirmUnfocus.jsx
+++ b/apis/nucleus/src/components/listbox/useConfirmUnfocus.jsx
@@ -5,7 +5,7 @@ import { useRef, useEffect, useState } from 'react';
  * user interact outside of passed element ref.
  */
 
-export default function useConfirmUnfocus(ref, selections) {
+export default function useConfirmUnfocus(ref, selections, enabledConfirmOnBlur) {
   const [_isConfirmed, _setIsConfirmed] = useState(false);
   // Wrap state in ref to use inside eventListener callback
   const isConfirmedRef = useRef(_isConfirmed);
@@ -15,6 +15,8 @@ export default function useConfirmUnfocus(ref, selections) {
   };
 
   useEffect(() => {
+    if (!enabledConfirmOnBlur) return () => {};
+
     const handleEvent = (event) => {
       const interactInside = ref.current && ref.current.contains(event.target);
       const isConfirmed = isConfirmedRef.current;
@@ -32,5 +34,5 @@ export default function useConfirmUnfocus(ref, selections) {
       document.removeEventListener('mousedown', handleEvent);
       document.removeEventListener('keydown', handleEvent);
     };
-  }, [ref, selections]);
+  }, [ref, selections, enabledConfirmOnBlur]);
 }

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -137,6 +137,7 @@ const mergeConfigs = (base, c) => ({
  * @property {{setScrollPos:function(number):void, initScrollPos:number}} [options.scrollState=] Object including a setScrollPos function that sets current scroll position index. A initial scroll position index.
  * @property {number=} [options.sortByState=1] Sort by state, detault 1 = sort descending, 0 = no sorting, -1 sort ascending.
  * @property {function(number):void} [options.setCount=] A function that gets called with the length of the data in the Listbox.
+ * @property {boolean} [options.shouldConfirmOnBlur=] A boolean that determines if the listbox should actively confirm selections on blur events.
  */
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Temporary fix to disable confirming selections on blur events. This should eventually be refactored, see issue #863


## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [x] Add code reviewers, for example @qlik-oss/nebula-core
