### PR TITLE
fix: disabling on enter select on listbox searches

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxSearch.jsx
@@ -19,8 +19,9 @@ export default function ListBoxSearch({ model, keyboard, dense = false }) {
   const onKeyDown = (e) => {
     switch (e.key) {
       case 'Enter':
-        model.acceptListObjectSearch(TREE_PATH, true);
-        setValue('');
+        // This is disabled to "solve" QB-10955 with the lowest risk
+        // await model.acceptListObjectSearch(TREE_PATH, true);
+        // setValue('');
         break;
       case 'Escape':
         model.abortListObjectSearch(TREE_PATH);

--- a/apis/nucleus/src/components/listbox/__tests__/list-box-search.spec.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box-search.spec.jsx
@@ -90,25 +90,26 @@ describe('<ListBoxSearch />', () => {
     type = testInstance.findByType(OutlinedInput);
     expect(type.props.value).to.equal('foo');
   });
-  it('should reset `OutlinedInput` and `acceptListObjectSearch` on `Enter`', () => {
-    const model = {
-      searchListObjectFor: sinon.spy(),
-      acceptListObjectSearch: sinon.spy(),
-      abortListObjectSearch: sinon.spy(),
-    };
-    const testRenderer = create(
-      <InstanceContext.Provider value={{ translator: { get: () => 'Search' } }}>
-        <ListBoxSearch model={model} keyboard={keyboard} />
-      </InstanceContext.Provider>
-    );
-    const testInstance = testRenderer.root;
-    const type = testInstance.findByType(OutlinedInput);
-    type.props.onChange({ target: { value: 'foo' } });
-    expect(type.props.value).to.equal('foo');
-    type.props.onKeyDown({ key: 'Enter' });
-    expect(model.acceptListObjectSearch).to.have.been.calledWith('/qListObjectDef', true);
-    expect(type.props.value).to.equal('');
-  });
+  // This is disabled to "solve" QB-10955 with the lowest risk
+  // it('should reset `OutlinedInput` and `acceptListObjectSearch` on `Enter`', () => {
+  //   const model = {
+  //     searchListObjectFor: sinon.spy(),
+  //     acceptListObjectSearch: sinon.spy(),
+  //     abortListObjectSearch: sinon.spy(),
+  //   };
+  //   const testRenderer = create(
+  //     <InstanceContext.Provider value={{ translator: { get: () => 'Search' } }}>
+  //       <ListBoxSearch model={model} keyboard={keyboard} />
+  //     </InstanceContext.Provider>
+  //   );
+  //   const testInstance = testRenderer.root;
+  //   const type = testInstance.findByType(OutlinedInput);
+  //   type.props.onChange({ target: { value: 'foo' } });
+  //   expect(type.props.value).to.equal('foo');
+  //   type.props.onKeyDown({ key: 'Enter' });
+  //   expect(model.acceptListObjectSearch).to.have.been.calledWith('/qListObjectDef', true);
+  //   expect(type.props.value).to.equal('');
+  // });
   it('should `abortListObjectSearch` on `Escape`', () => {
     const model = {
       searchListObjectFor: sinon.spy(),


### PR DESCRIPTION
## Motivation

"Fix" https://jira.qlikdev.com/browse/QB-10955 by disabling apply selections on enter in listbox search

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [ ] Add code reviewers, for example @qlik-oss/nebula-core
