### PR TITLE
fix(listbox): empty search calls abort query

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxSearch.jsx
@@ -14,7 +14,11 @@ export default function ListBoxSearch({ model, keyboard, dense = false }) {
 
   const onChange = (e) => {
     setValue(e.target.value);
-    model.searchListObjectFor(TREE_PATH, e.target.value);
+    if (e.target.value.length === 0) {
+      model.abortListObjectSearch(TREE_PATH);
+    } else {
+      model.searchListObjectFor(TREE_PATH, e.target.value);
+    }
   };
   const onKeyDown = (e) => {
     switch (e.key) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

When emptying the search list the results should be restored. The implementation in angular client was used as inspiration and should be safe to "re-use".

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [ ] Add code reviewers, for example @qlik-oss/nebula-core
