### PR TITLE
fix: filterBox react on qsize.qcy change when searching

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -196,7 +196,7 @@ export default function ListBox({
     if (typeof setCount === 'function' && layout) {
       setCount(layout.qListObject.qSize.qcy);
     }
-  }, [layout && layout.qListObject.qSize.qcy]);
+  }, [layout, layout && layout.qListObject.qSize.qcy]);
 
   useEffect(() => {
     if (!instantPages || isLoadingData) {

--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -196,7 +196,7 @@ export default function ListBox({
     if (typeof setCount === 'function' && layout) {
       setCount(layout.qListObject.qSize.qcy);
     }
-  }, [layout]);
+  }, [layout && layout.qListObject.qSize.qcy]);
 
   useEffect(() => {
     if (!instantPages || isLoadingData) {


### PR DESCRIPTION
## Motivation

Listbox fetch It’s only listening to changes on layout.. but since layout.qListObject.qSize.qcy is deep inside the object structure it’s not reacting on qSize.qcy changing when searching

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [ ] Add code reviewers, for example @qlik-oss/nebula-core
