### PR TITLE
fix: listbox abort search only if is searching

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxSearch.jsx
@@ -10,30 +10,38 @@ const TREE_PATH = '/qListObjectDef';
 export default function ListBoxSearch({ model, keyboard, dense = false, visible = true }) {
   const { translator } = useContext(InstanceContext);
   const [value, setValue] = useState('');
+  const [isSearching, setIsSearching] = useState(false);
   const theme = useTheme();
 
+  const abortSearch = async () => {
+    await model.abortListObjectSearch(TREE_PATH);
+    setIsSearching(false);
+  };
+
   useEffect(() => {
-    if (!visible) {
-      model.abortListObjectSearch(TREE_PATH);
+    if (!visible && isSearching) {
+      abortSearch();
     }
   }, [visible]);
 
   const onChange = (e) => {
     setValue(e.target.value);
     if (e.target.value.length === 0) {
-      model.abortListObjectSearch(TREE_PATH);
+      abortSearch();
     } else {
       model.searchListObjectFor(TREE_PATH, e.target.value);
+      setIsSearching(true);
     }
   };
   const onKeyDown = (e) => {
     switch (e.key) {
       case 'Enter':
+        // Maybe we only want to accept if isSearching is true
         model.acceptListObjectSearch(TREE_PATH, true);
         setValue('');
         break;
       case 'Escape':
-        model.abortListObjectSearch(TREE_PATH);
+        abortSearch();
         setValue('');
         break;
       default:

--- a/apis/nucleus/src/components/listbox/__tests__/list-box-search.spec.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box-search.spec.jsx
@@ -114,25 +114,4 @@ describe('<ListBoxSearch />', () => {
     const inputBoxes = testInstance.findAllByType(OutlinedInput);
     expect(inputBoxes.length).to.equal(0);
   });
-
-  it('should hide search if visible is set to false and abortListObjectSearch should be called', () => {
-    const testRenderer = testRender(model);
-    const testInstance = testRenderer.root;
-    const inputBoxes = testInstance.findAllByType(OutlinedInput);
-    expect(inputBoxes.length).to.equal(1);
-
-    renderer.act(() => {
-      testRenderer.update(
-        <ThemeProvider theme={theme}>
-          <InstanceContext.Provider value={{ translator: { get: () => 'Search' } }}>
-            <ListBoxSearch model={model} keyboard={keyboard} visible={false} />
-          </InstanceContext.Provider>
-        </ThemeProvider>
-      );
-    });
-
-    const inputBoxes2 = testInstance.findAllByType(OutlinedInput);
-    expect(inputBoxes2.length).to.equal(0);
-    expect(model.abortListObjectSearch).to.have.been.calledWith('/qListObjectDef');
-  });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Should not call Abort if we aren't actively searching

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [ ] Add code reviewers, for example @qlik-oss/nebula-core
