### PR TITLE
fix: correct height calculation of listbox

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -151,8 +151,8 @@ export default function ListBox({
                 '/qListObjectDef',
                 // we need to ask for two payloads
                 // 2nd one is our starting index + MINIMUM_BATCH_SIZE items
-                // 1st of is 2nd ones stqarting index - MINIMUM_BATCH_SIZE items
-                // we do this because we dont want to miss any items between fast scrolls
+                // 1st one is 2nd ones starting index - MINIMUM_BATCH_SIZE items
+                // we do this because we don't want to miss any items between fast scrolls
                 [
                   {
                     qTop: lastItemInQueue.start > MINIMUM_BATCH_SIZE ? lastItemInQueue.start - MINIMUM_BATCH_SIZE : 0,

--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -126,7 +126,7 @@ export default function ListBox({
   );
 
   // The time from scroll end until new data is being fetched, may be exposed in API later on.
-  const scrollTimeout = 0;
+  const scrollTimeout = 500;
 
   const loadMoreItems = useCallback(
     (startIndex, stopIndex) => {
@@ -145,16 +145,28 @@ export default function ListBox({
       return new Promise((resolve) => {
         local.current.timeout = setTimeout(
           () => {
-            const sorted = local.current.queue.slice(-2).sort((a, b) => a.start - b.start);
+            const lastItemInQueue = local.current.queue.slice(-1)[0];
             const reqPromise = model
               .getListObjectData(
                 '/qListObjectDef',
-                sorted.map((s) => ({
-                  qTop: s.start,
-                  qHeight: s.stop - s.start + 1,
-                  qLeft: 0,
-                  qWidth: 1,
-                }))
+                // we need to ask for two payloads
+                // 2nd one is our starting index + MINIMUM_BATCH_SIZE items
+                // 1st of is 2nd ones stqarting index - MINIMUM_BATCH_SIZE items
+                // we do this because we dont want to miss any items between fast scrolls
+                [
+                  {
+                    qTop: lastItemInQueue.start > MINIMUM_BATCH_SIZE ? lastItemInQueue.start - MINIMUM_BATCH_SIZE : 0,
+                    qHeight: MINIMUM_BATCH_SIZE,
+                    qLeft: 0,
+                    qWidth: 1,
+                  },
+                  {
+                    qTop: lastItemInQueue.start,
+                    qHeight: MINIMUM_BATCH_SIZE,
+                    qLeft: 0,
+                    qWidth: 1,
+                  },
+                ]
               )
               .then((p) => {
                 const processedPages = postProcessPages ? postProcessPages(p) : p;
@@ -244,7 +256,7 @@ export default function ListBox({
   return (
     <StyledInfiniteLoader
       isItemLoaded={isItemLoaded}
-      itemCount={count}
+      itemCount={listCount}
       loadMoreItems={loadMoreItems}
       threshold={0}
       minimumBatchSize={MINIMUM_BATCH_SIZE}

--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -126,7 +126,7 @@ export default function ListBox({
   );
 
   // The time from scroll end until new data is being fetched, may be exposed in API later on.
-  const scrollTimeout = 500;
+  const scrollTimeout = 0;
 
   const loadMoreItems = useCallback(
     (startIndex, stopIndex) => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation
- fixed height calculation issue while scrolling for listbox by modifying the payload of call from engine.
- synced `itemsCount` for `<StyledInfiniteLoader />`  with `<FixedSizeList />`


## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [x] Add code reviewers, for example @qlik-oss/nebula-core
