### PR TITLE
fix(ListBox): Prevent empty list because of 0 items

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -231,13 +231,7 @@ export default function ListBox({
 
   const isVertical = listLayout !== 'horizontal';
 
-  let count = layout.qListObject.qSize.qcy;
-
-  // Should not allow a count of zero since it will stop executing loadMoreItems
-  // this could happen if a seach returns an empty result
-  if (count === 0) {
-    count = 1;
-  }
+  const count = layout.qListObject.qSize.qcy;
 
   const getCalculatedHeight = (ps) => {
     // If values have been filtered in the currently loaded page, we want to
@@ -256,7 +250,7 @@ export default function ListBox({
   return (
     <StyledInfiniteLoader
       isItemLoaded={isItemLoaded}
-      itemCount={listCount}
+      itemCount={listCount || 1} // must be more than 0 or loadMoreItems will never be called again
       loadMoreItems={loadMoreItems}
       threshold={0}
       minimumBatchSize={MINIMUM_BATCH_SIZE}

--- a/apis/nucleus/src/components/listbox/__tests__/list-box.spec.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box.spec.jsx
@@ -17,6 +17,7 @@ describe('<Listbox />', () => {
   let useCallbackStub;
   let setTimeoutStub;
   let useSelectionsInteractions;
+  let infiniteProps;
 
   before(() => {
     sandbox = sinon.createSandbox({ useFakeTimers: true });
@@ -61,6 +62,7 @@ describe('<Listbox />', () => {
           require.resolve('react-window-infinite-loader'),
           () => (props) => {
             const func = props.children;
+            infiniteProps = props;
             return func({ onItemsRendered: {} });
           },
         ],
@@ -241,6 +243,12 @@ describe('<Listbox />', () => {
       await render();
       const { itemData } = FixedSizeList.args[FixedSizeList.callCount - 1][0];
       expect(itemData.isLocked).to.equal(true);
+    });
+
+    it('should prevent InfiniteLoader to get itemCount == 0', async () => {
+      layout.qListObject.qSize.qcy = 0;
+      await render();
+      expect(infiniteProps.itemCount).to.equal(1);
     });
   });
 });

--- a/apis/nucleus/src/components/listbox/__tests__/list-box.spec.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box.spec.jsx
@@ -23,7 +23,6 @@ describe('<Listbox />', () => {
     sandbox = sinon.createSandbox({ useFakeTimers: true });
 
     setTimeoutStub = sandbox.stub();
-
     global.document = 'document';
 
     layout = {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

When `<InfiniteLoader />` gets `0` items, it will never fetch data again (it will not call `loadMoreItems`). Therefore, this value should always be `> 0`. This solves both the previously solved search issue (no hits) and the issue where zero items blocks new requests.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [x] API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [ ] Add code reviewers, for example @qlik-oss/nebula-core
