### PR TITLE
fix: get back the styled scrollbar

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -49,11 +49,12 @@ const StyledFixedSizeList = styled(FixedSizeList)(() => ({
 }));
 
 function getSizeInfo({ isVertical, checkboxes, dense, height }) {
+  const sizeHorizontal = 50;
   let sizeVertical = checkboxes ? 40 : 33;
   if (dense) {
     sizeVertical = 20;
   }
-  const itemSize = isVertical ? sizeVertical : 200;
+  const itemSize = isVertical ? sizeVertical : sizeHorizontal;
   const listHeight = height || 8 * itemSize;
 
   return {

--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -24,8 +24,8 @@ const classes = {
   styledScrollbars: `${PREFIX}-styledScrollbars`,
 };
 
-const StyledInfiniteLoader = styled(InfiniteLoader)(() => ({
-  [`& .${classes.styledScrollbars}`]: {
+const StyledFixedSizeList = styled(FixedSizeList)(() => ({
+  [`&.${classes.styledScrollbars}`]: {
     scrollbarColor: `${scrollBarThumb} ${scrollBarBackground}`,
 
     '&::-webkit-scrollbar': {
@@ -248,7 +248,7 @@ export default function ListBox({
   const { frequencyMax } = layout;
 
   return (
-    <StyledInfiniteLoader
+    <InfiniteLoader
       isItemLoaded={isItemLoaded}
       itemCount={listCount || 1} // must be more than 0 or loadMoreItems will never be called again
       loadMoreItems={loadMoreItems}
@@ -259,11 +259,10 @@ export default function ListBox({
       {({ onItemsRendered, ref }) => {
         local.current.listRef = ref;
         return (
-          <FixedSizeList
+          <StyledFixedSizeList
             direction={direction}
             data-testid="fixed-size-list"
             useIsScrolling
-            style={{}}
             height={listHeight}
             width={width}
             itemCount={listCount}
@@ -298,9 +297,9 @@ export default function ListBox({
             ref={ref}
           >
             {RowColumn}
-          </FixedSizeList>
+          </StyledFixedSizeList>
         );
       }}
-    </StyledInfiniteLoader>
+    </InfiniteLoader>
   );
 }

--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -49,7 +49,7 @@ const StyledFixedSizeList = styled(FixedSizeList)(() => ({
 }));
 
 function getSizeInfo({ isVertical, checkboxes, dense, height }) {
-  const sizeHorizontal = 50;
+  const sizeHorizontal = 200;
   let sizeVertical = checkboxes ? 40 : 33;
   if (dense) {
     sizeVertical = 20;

--- a/apis/nucleus/src/components/listbox/ListBoxRowColumn.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxRowColumn.jsx
@@ -174,6 +174,7 @@ const Root = styled('div')(({ theme }) => ({
   [`&.${classes.barContainer}`]: {
     height: '100%',
     display: 'inline-block',
+    float: 'left',
   },
 
   [`& .${classes.bar}`]: {

--- a/apis/nucleus/src/components/listbox/ListBoxRowColumn.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxRowColumn.jsx
@@ -174,7 +174,6 @@ const Root = styled('div')(({ theme }) => ({
   [`&.${classes.barContainer}`]: {
     height: '100%',
     display: 'inline-block',
-    float: 'left',
   },
 
   [`& .${classes.bar}`]: {

--- a/examples/dev-mashup/package.json
+++ b/examples/dev-mashup/package.json
@@ -2,7 +2,6 @@
   "name": "local-mashup",
   "version": "1.0.0",
   "description": "Simple local mashup",
-  "main": "index.js",
   "scripts": {
     "start": "parcel index.html --open --no-hmr",
     "build": "parcel build index.html"


### PR DESCRIPTION
## Motivation

Minor fixes for the Listbox:
- Add back the styled scrollbar to get a cross-browser fixed width (stopped working after the mui5 update)
- Remove the `main` property in package.json to prevent parcel build error


## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [x] Add code reviewers, for example @qlik-oss/nebula-core
