### PR TITLE
fix: add check for rtl-ltr for direction prop

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -261,7 +261,8 @@ export default function ListBox({
         local.current.listRef = ref;
         return (
           <StyledFixedSizeList
-            direction={direction}
+            // explicitly set this as it accepts horizontal as well, leading to confusion
+            direction={direction === 'rtl' ? 'rtl' : 'ltr'}
             data-testid="fixed-size-list"
             useIsScrolling
             height={listHeight}


### PR DESCRIPTION
The direction prop for listbox is quite confusing if you don't read the API, as when passed as "horizontal" into the FixedList it will display as horizontal. It should actually only take the form of rtl/ltr, so now we'll explicitly check that.