### PR TITLE
docs: linking nebula docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -67,8 +67,7 @@ When you use Nebula.js as a dependency in your project, and you want to edit or 
 
 ### Linking Nebula when using `nebula serve`
 
-With `npm`: When using `nebula serve` to serve your project's files, you must run `npm link` in the folder: `nebula.js/commands/serve`.
-Then use it in your own repo by running `npm link @nebula.js/cli-serve` (run this in your own repo).
+With `npm`: Before using `nebula serve` to serve your project's files, you must run `npm link` in the folder: `nebula.js/commands/serve` and use it in your own repo by running `npm link @nebula.js/cli-serve` (run this in your own repo).
 To include source maps, so you can easier debug the Nebula.js code, you should also run `yarn build:dev` in the `nebula.js/commands/serve` folder.
 
 With `yarn`: Same as for `npm` but replace `npm` with `yarn` in the commands above.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -61,15 +61,15 @@ You should only use these during the development phase of your project, never in
 <script src="https://cdn.jsdelivr.net/npm/@nebula.js/stardust@0.6.0/dist/stardust.dev.js" crossorigin></script>
 ```
 
-## Linking Nebula packages to your own repository
+## Linking nebula packages to your own repository
 
-When you use Nebula.js as a dependency in your project, and you want to edit or debug the Nebula.js source code, you can use either `npm link` or `yarn link` to accomplish this.
+When you use nebula.js as a dependency in your project, and you want to edit or debug the nebula.js source code, you can use either `npm link` or `yarn link` to accomplish this.
 
-### Linking Nebula when using `nebula serve`
+### Linking nebula when using `nebula serve`
 
 With `npm`: Before using `nebula serve` to serve your project's files, you must run `npm link` in the folder: `nebula.js/commands/serve` and use it in your own repo by running `npm link @nebula.js/cli-serve` (run this in your own repo).
-To include source maps, so you can easier debug the Nebula.js code, you should also run `yarn build:dev` in the `nebula.js/commands/serve` folder.
+To include source maps, so you can easier debug the nebula.js code, you should also run `yarn build:dev` in the `nebula.js/commands/serve` folder.
 
 With `yarn`: Same as for `npm` but replace `npm` with `yarn` in the commands above.
 
-In your browser's debugging tool you should now be able to see the Nebula.js source code and to add breakpoints inside of the Nebula.js files.
+In your browser's debugging tool you should now be able to see the nebula.js source code and to add breakpoints inside of the nebula.js files.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,3 +60,17 @@ You should only use these during the development phase of your project, never in
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@nebula.js/stardust@0.6.0/dist/stardust.dev.js" crossorigin></script>
 ```
+
+## Linking Nebula packages to your own repository
+
+When you use Nebula.js as a dependency in your project, and you want to edit or debug the Nebula.js source code, you can use either `npm link` or `yarn link` to accomplish this.
+
+### Linking Nebula when using `nebula serve`
+
+With `npm`: When using `nebula serve` to serve your project's files, you must run `npm link` in the folder: `nebula.js/commands/serve`.
+Then use it in your own repo by running `npm link @nebula.js/cli-serve` (run this in your own repo).
+To include source maps, so you can easier debug the Nebula.js code, you should also run `yarn build:dev` in the `nebula.js/commands/serve` folder.
+
+With `yarn`: Same as for `npm` but replace `npm` with `yarn` in the commands above.
+
+In your browser's debugging tool you should now be able to see the Nebula.js source code and to add breakpoints inside of the Nebula.js files.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Prevent a common mistake when linking repos using `nebula serve` by documenting it here: https://github.com/qlik-oss/nebula.js/blob/master/docs/installation.md 


## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [ ] Add code reviewers, for example @qlik-oss/nebula-core
