### PR TITLE
feat(build): add system js build

### DIFF
--- a/commands/build/lib/build.js
+++ b/commands/build/lib/build.js
@@ -29,10 +29,6 @@ const resolveReplacementStrings = (replacementStrings) => {
   return replacementStrings;
 };
 
-const mergeArray = (a1 = [], a2 = []) =>
-  // Simple merge and deduplication
-  [...a1, ...a2].filter((v, i, a) => a.indexOf(v) === i);
-
 const setupReactNative = (argv) => {
   const { reactNative } = argv;
   let reactNativePath;
@@ -224,8 +220,8 @@ const systemjs = async (argv, core) => {
     behaviours: {
       getExternal: ({ config: cfg }) => {
         const defaultExternal = ['@nebula.js/stardust', 'picasso.js', 'picasso-plugin-q', 'react', 'react-dom'];
-        const { external = [] } = cfg.systemjs || {};
-        return mergeArray(defaultExternal, external);
+        const { external } = cfg.systemjs || {};
+        return Array.isArray(external) ? external : defaultExternal;
       },
       getOutputFile: ({ pkg }) => pkg.systemjs,
       getOutputName: () => undefined,

--- a/commands/build/lib/build.js
+++ b/commands/build/lib/build.js
@@ -205,18 +205,17 @@ const esm = async (argv, core) => {
     },
   });
   if (!c) {
-    return Promise.resolve();
+    return undefined;
   }
   const bundle = await rollup.rollup(c.input);
   return bundle.write(c.output);
 };
 
-const systemjs = async (argv, core) => {
+const systemjs = async (argv) => {
   const c = config({
     mode: argv.mode || 'production',
     format: 'systemjs',
     argv,
-    core,
     behaviours: {
       getExternal: ({ config: cfg }) => {
         const defaultExternal = ['@nebula.js/stardust', 'picasso.js', 'picasso-plugin-q', 'react', 'react-dom'];
@@ -229,7 +228,7 @@ const systemjs = async (argv, core) => {
     },
   });
   if (!c) {
-    return Promise.resolve();
+    return undefined;
   }
   const bundle = await rollup.rollup(c.input);
   return bundle.write(c.output);
@@ -319,15 +318,13 @@ async function build(argv = {}) {
     return watch(buildConfig);
   }
 
-  // Standalone
   await umd(buildConfig);
   await esm(buildConfig);
+  await systemjs(buildConfig);
 
-  // Core
   if (argv.core) {
     const core = path.resolve(process.cwd(), argv.core);
     await esm(buildConfig, core);
-    await systemjs(buildConfig, core);
   }
 
   return undefined;

--- a/commands/build/lib/build.js
+++ b/commands/build/lib/build.js
@@ -330,7 +330,7 @@ async function build(argv = {}) {
     await systemjs(buildConfig, core);
   }
 
-  return Promise.resolve();
+  return undefined;
 }
 
 module.exports = build;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Add build using systemjs format which for example can be used in MFE context.

Changes:

* Add systemjs build which is performed when the property `systemjs` in `package.json` specifies where to output the bundle. No build performed in case no filename is present.
* Configure external dependencies. Specify an array at path `systemjs.external` in `nebula.config`.
* Refactor: Inject variations in behaviour per build format to `config()` in order to prevent if/elseif/else for each format. Each format specifies, for example, what the output file name should be.
* Refactor: Rename UMD build to `umd` (was `minified` which made more sense when there was only one format to build) 

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [ ] Add code reviewers, for example @qlik-oss/nebula-core
