### PR TITLE
feat(build): watch systemjs build

### DIFF
--- a/commands/build/README.md
+++ b/commands/build/README.md
@@ -19,7 +19,8 @@ Options:
   --version        Show version number                                 [boolean]
   --config, -c     Path to JSON config file
                                           [string] [default: "nebula.config.js"]
-  --watch, -w      Watch source files                 [boolean] [default: false]
+  --watch, -w      Watch source files
+                                   [choices: "umd", "systemjs"] [default: "umd"]
   --sourcemap, -m  Generate source map                 [boolean] [default: true]
   --mode           Explicitly set mode
                                  [string] [choices: "production", "development"]
@@ -141,6 +142,15 @@ Tips:
 In the package.json file, the main field makes sure that Node users using require
 can be served the umd version. The module field is a common convention to designate
 how to import an esm version of your code.
+
+### SystemJS build
+
+You can build a bundle using the SystemJS format by adding a `systemjs` field in the
+package.json which specifies the output file from the build:
+
+```json
+"systemjs": "dist/hello.systemjs.js"
+```
 
 ### Typescript
 

--- a/commands/build/lib/build.js
+++ b/commands/build/lib/build.js
@@ -251,7 +251,7 @@ function clearScreen(msg) {
 
 const getPackage = (argv, cwd = process.cwd()) => require(path.resolve(argv.cwd || cwd, 'package.json')); // eslint-disable-line
 
-const validateWatch = (argv) => {
+const validateWatchInput = (argv) => {
   if (argv.watch === 'systemjs') {
     const pkg = getPackage(argv);
     if (!pkg.systemjs) {
@@ -266,27 +266,31 @@ const validateWatch = (argv) => {
   return true;
 };
 
-const getWatchOptions = (argv) => {
+const getWatchConfig = (argv) => {
   const base = {
     mode: argv.mode || 'development',
     argv,
   };
 
+  let opts;
+
   switch (argv.watch) {
     case 'systemjs':
-      return { ...base, format: 'systemjs', behaviours: systemjsBehaviours };
+      opts = { ...base, format: 'systemjs', behaviours: systemjsBehaviours };
+      break;
     case 'umd':
     default:
-      return { ...base, format: 'umd' };
+      opts = { ...base, format: 'umd' };
+      break;
   }
+  return config(opts);
 };
 
 const watch = async (argv) => {
-  if (!validateWatch(argv)) {
+  if (!validateWatchInput(argv)) {
     return undefined;
   }
-  const options = getWatchOptions(argv);
-  const c = config(options);
+  const c = getWatchConfig(argv);
 
   let hasWarnings = false;
 

--- a/commands/build/lib/build.js
+++ b/commands/build/lib/build.js
@@ -249,18 +249,42 @@ function clearScreen(msg) {
   }
 }
 
+const getPackage = (argv, cwd = process.cwd()) => require(path.resolve(argv.cwd || cwd, 'package.json')); // eslint-disable-line
+
+const validateWatch = (argv) => {
+  if (argv.watch === 'systemjs') {
+    const pkg = getPackage(argv);
+    if (!pkg.systemjs) {
+      console.log(
+        `${chalk.white.bgRed(' ERROR ')} ${chalk.red(
+          'No "systemjs" field specifying output file found in package.json'
+        )}`
+      );
+      return false;
+    }
+  }
+  return true;
+};
+
 const getWatchOptions = (argv) => {
   const base = {
     mode: argv.mode || 'development',
     argv,
   };
 
-  return argv.watch === 'systemjs'
-    ? { ...base, format: 'systemjs', behaviours: systemjsBehaviours }
-    : { ...base, format: 'umd' };
+  switch (argv.watch) {
+    case 'systemjs':
+      return { ...base, format: 'systemjs', behaviours: systemjsBehaviours };
+    case 'umd':
+    default:
+      return { ...base, format: 'umd' };
+  }
 };
 
 const watch = async (argv) => {
+  if (!validateWatch(argv)) {
+    return undefined;
+  }
   const options = getWatchOptions(argv);
   const c = config(options);
 


### PR DESCRIPTION
## Motivation

Add support to output build on SystemJS format when watching.

Examples how to use it:

```sh
// Output build on UMD format (as-is today)
nebula build --watch

// Specify UMD format explicitly
nebula build --watch umd

// Specify SystemJS format
nebula build --watch systemjs
```

In case no `systemjs` bundle is specified in package.json the command fails gracefully informing the user about the problem.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [x] Add code reviewers, for example @qlik-oss/nebula-core
