### PR TITLE
fix: add stardust as external dependency (when missing)

### DIFF
--- a/commands/build/lib/build.js
+++ b/commands/build/lib/build.js
@@ -119,6 +119,7 @@ const config = ({
   if (external.indexOf('@nebula.js/stardust') === -1) {
     // eslint-disable-next-line no-console
     console.warn('@nebula.js/stardust should be specified as a peer dependency');
+    external.push('@nebula.js/stardust');
   }
 
   return {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

The `@nebula.js/stardust` is added as external dependency in case it's not present. Building a visualisation with the stardust dependency bundled causes it to fail as stardust must only be loaded once. The change in this PR will improve DX and hopefully reduce time spent debugging.

Previously only a warning message was written in the log that stardust is missing as external dependency. When reading the code carefully it seems like the intention is that the dependency always should be marked as external.

Code previously (before introducing system js builds):

```js
  const peers = pkg.peerDependencies || {};
  const external = Object.keys(peers);

  // stardust should always be external
  if (!peers['@nebula.js/stardust']) {
    // eslint-disable-next-line no-console
    console.warn('@nebula.js/stardust should be specified as a peer dependency');
  } else if (external.indexOf('@nebula.js/stardust') === -1) {
    external.push('@nebula.js/stardust'); // <-- This never happen as the first if statement always will be triggered in case stardust is not in the list of deps
  }
```

See code [here](https://github.com/qlik-oss/nebula.js/blob/b9d9038c09082f8737353411af341edadd1ea09d/commands/build/lib/build.js#L98).

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [ ] Add code reviewers, for example @qlik-oss/nebula-core
