### PR TITLE
feat: integrate `@qlik/sdk` into mashup template

### DIFF
--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1213,33 +1213,6 @@
         }
       }
     },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
-      "kind": "interface",
-      "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
-              "type": "string"
-            }
-          }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
-        }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
-    },
     "Field": {
       "kind": "alias",
       "items": {
@@ -1348,6 +1321,33 @@
           ]
         }
       }
+    },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
     },
     "LoadType": {
       "kind": "interface",

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -367,16 +367,6 @@ declare namespace stardust {
 
     }
 
-    /**
-     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
-     */
-    interface Plugin {
-        info: {
-            name: string;
-        };
-        fn: ()=>void;
-    }
-
     type Field = string | EngineAPI.INxDimension | EngineAPI.INxMeasure | stardust.LibraryField;
 
     /**
@@ -408,6 +398,16 @@ declare namespace stardust {
     interface LibraryField {
         qLibraryId: string;
         type: "dimension" | "measure";
+    }
+
+    /**
+     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
+     */
+    interface Plugin {
+        info: {
+            name: string;
+        };
+        fn: ()=>void;
     }
 
     interface LoadType {

--- a/commands/create/templates/mashup/_package.json
+++ b/commands/create/templates/mashup/_package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@nebula.js/stardust": "<%= nebulaVersion %>",
     "@nebula.js/sn-bar-chart": "^0.8.24",
+    "@qlik/sdk": "^0.9.1",
     "enigma.js": "^2.6.3",
     "parcel": "^2.3.2"
   }

--- a/commands/create/templates/mashup/src/connect.js
+++ b/commands/create/templates/mashup/src/connect.js
@@ -1,44 +1,24 @@
 import enigma from 'enigma.js';
 import schema from 'enigma.js/schemas/12.936.0.json';
-
-async function getQCSHeaders({ webIntegrationId, url }) {
-  const response = await fetch(`${url}/api/v1/csrf-token`, {
-    credentials: 'include',
-    headers: { 'qlik-web-integration-id': webIntegrationId },
-  });
-  if (response.status === 401) {
-    const loginUrl = new URL(`${url}/login`);
-    loginUrl.searchParams.append('returnto', window.location.href);
-    loginUrl.searchParams.append('qlik-web-integration-id', webIntegrationId);
-    window.location.href = loginUrl;
-    return undefined;
-  }
-  const csrfToken = new Map(response.headers).get('qlik-csrf-token');
-  return {
-    'qlik-web-integration-id': webIntegrationId,
-    'qlik-csrf-token': csrfToken,
-  };
-}
-
-async function getEnigmaApp({ host, appId, headers }) {
-  const params = Object.keys(headers)
-    .map((key) => `${key}=${headers[key]}`)
-    .join('&');
-
-  const enigmaGlobal = await enigma
-    .create({
-      schema,
-      url: `wss://${host}/app/${appId}?${params}`,
-    })
-    .open();
-
-  return enigmaGlobal.openDoc(appId);
-}
+import { Auth, AuthType } from '@qlik/sdk';
 
 async function connect({ url, webIntegrationId, appId }) {
-  const host = url.replace(/^https?:\/\//, '').replace(/\/?/, '');
-  const headers = await getQCSHeaders({ url, webIntegrationId });
-  return getEnigmaApp({ host, headers, appId });
+  const authInstance = new Auth({
+    webIntegrationId,
+    autoRedirect: true,
+    authType: AuthType.WebIntegration,
+    host: url.replace(/^https?:\/\//, '').replace(/\/?/, ''),
+  });
+
+  if (!authInstance.isAuthenticated()) {
+    authInstance.authenticate();
+  } else {
+    const wssUrl = await authInstance.generateWebsocketUrl(appId);
+    const enigmaGlobal = await enigma.create({ schema, url: wssUrl }).open();
+    return enigmaGlobal.openDoc(appId);
+  }
+
+  return null;
 }
 
 export default connect;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

<!-- Write your motivation here -->
integrating the nebula mashup template to use `@qlik/sdk` pkg instead of old solution(`csrf-token`).

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [ ] No changes
     ***OR***
    - [x] API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [x] Add code reviewers, for example @qlik-oss/nebula-core
