### PR TITLE
feat!: move enigma mocker to public api

### DIFF
--- a/apis/enigma-mocker/src/from-generic-objects.js
+++ b/apis/enigma-mocker/src/from-generic-objects.js
@@ -3,39 +3,7 @@ import CreateSessionObjectMock from './mocks/create-session-object-mock';
 import GetObjectMock from './mocks/get-object-mock';
 import GetAppLayoutMock from './mocks/get-app-layout-mock';
 
-/**
- * @interface EnigmaMockerOptions
- * @property {number} delay Simulate delay (in ms) for calls in enigma-mocker.
- */
-
-/**
- * Mocks Engima app functionality. It accepts one / many generic objects as input argument and returns the mocked Enigma app. Each generic object represents one visulization and specifies how it behaves. For example, what layout to use the data to present.
- *
- * The generic object is represented with a Javascript object with a number of properties. The name of the property correlates to the name in the Enigma model for `app.getObject(id)`. For example, the property `getLayout` in the generic object is used to define `app.getObject(id).getLayout()`. Any property can be added to the fixture (just make sure it exists and behaves as in the Enigma model!).
- *
- * The value for each property is either fixed (string / boolean / number / object) or a function. Arguments are forwarded to the function to allow for greater flexibility. For example, this can be used to return different hypercube data when scrolling in the chart.
- *
- * @param {Array<object>} genericObjects Generic objects controling behaviour of visualizations.
- * @param {EnigmaMockerOptions} options Options
- * @returns {Promise<enigma.Doc>}
- * @example
- * const genericObject = {
- *   getLayout() {
- *     return {
- *       qInfo: {
- *         qId: 'qqj4zx',
- *         qType: 'sn-grid-chart'
- *       },
- *       ...
- *     }
- *   },
- *   getHyperCubeData(path, page) {
- *     return [ ... ];
- *   }
- * };
- * const app = await EnigmaMocker.fromGenericObjects([genericObject]);
- */
-export default (genericObjects, options = {}) => {
+export default function fromGenericObjects(genericObjects, options = {}) {
   const session = new SessionMock();
   const createSessionObject = new CreateSessionObjectMock();
   const getObject = new GetObjectMock(genericObjects, options);
@@ -50,4 +18,4 @@ export default (genericObjects, options = {}) => {
   };
 
   return Promise.resolve(app);
-};
+}

--- a/apis/enigma-mocker/src/index.js
+++ b/apis/enigma-mocker/src/index.js
@@ -1,5 +1,50 @@
-import fromGenericObjects from './from-generic-objects';
+import fGO from './from-generic-objects';
 
-export default {
-  fromGenericObjects,
+/**
+ * @interface EnigmaMockerOptions
+ * @property {number} delay Simulate delay (in ms) for calls in enigma-mocker.
+ * @description Mocks Engima app functionality for demo and testing purposes.
+ * @experimental
+ * @since 3.0.0
+ */
+
+/**
+ * @entry
+ * @alias EnigmaMocker
+ */
+const api = /** @lends EnigmaMocker# */ {
+  /**
+   * Mocks Engima app functionality. It accepts one / many generic objects as input argument and returns the mocked Enigma app. Each generic object represents one visulization and specifies how it behaves. For example, what layout to use the data to present.
+   *
+   * The generic object is represented with a Javascript object with a number of properties. The name of the property correlates to the name in the Enigma model for `app.getObject(id)`. For example, the property `getLayout` in the generic object is used to define `app.getObject(id).getLayout()`. Any property can be added to the fixture (just make sure it exists and behaves as in the Enigma model!).
+   *
+   * The value for each property is either fixed (string / boolean / number / object) or a function. Arguments are forwarded to the function to allow for greater flexibility. For example, this can be used to return different hypercube data when scrolling in the chart.
+   * @type function
+   * @experimental
+   * @since 3.0.0
+   * @param {Array<object>} genericObjects Generic objects controling behaviour of visualizations.
+   * @param {EnigmaMockerOptions} options Options
+   * @returns {Promise<EngineAPI.IApp>}
+   * @example
+   * const genericObject = {
+   *   getLayout() {
+   *     return {
+   *       qInfo: {
+   *         qId: 'qqj4zx',
+   *         qType: 'sn-grid-chart'
+   *       },
+   *       ...
+   *     }
+   *   },
+   *   getHyperCubeData(path, page) {
+   *     return [ ... ];
+   *   }
+   * };
+   * const app = await EnigmaMocker.fromGenericObjects([genericObject]);
+   */
+  fromGenericObjects(genericObjects, options = {}) {
+    fGO(genericObjects, options);
+  },
 };
+
+export default api;

--- a/apis/enigma-mocker/src/index.js
+++ b/apis/enigma-mocker/src/index.js
@@ -43,7 +43,7 @@ const api = /** @lends EnigmaMocker# */ {
    * const app = await EnigmaMocker.fromGenericObjects([genericObject]);
    */
   fromGenericObjects(genericObjects, options = {}) {
-    fGO(genericObjects, options);
+    return fGO(genericObjects, options);
   },
 };
 

--- a/apis/enigma-mocker/src/index.js
+++ b/apis/enigma-mocker/src/index.js
@@ -3,7 +3,7 @@ import fGO from './from-generic-objects';
 /**
  * @interface EnigmaMockerOptions
  * @property {number} delay Simulate delay (in ms) for calls in enigma-mocker.
- * @description Mocks Engima app functionality for demo and testing purposes.
+ * @description Options for Enigma Mocker
  * @experimental
  * @since 3.0.0
  */

--- a/apis/enigma-mocker/src/mocks/get-object-mock.js
+++ b/apis/enigma-mocker/src/mocks/get-object-mock.js
@@ -2,6 +2,8 @@ import { getPropValue, getPropFn } from '../prop';
 
 /**
  * Properties on `getObject()` operating synchronously.
+ * @ignore
+ * @type Array
  */
 const PROPS_SYNC = [
   'addListener',
@@ -17,6 +19,7 @@ const PROPS_SYNC = [
 /**
  * Is property operating asynchrously.
  * @param {string} name Property name.
+ * @ignore
  * @returns `true` if property is operating asynchrously, otherwise `false`.
  */
 function isPropAsync(name) {
@@ -26,6 +29,7 @@ function isPropAsync(name) {
 /**
  * Get `qId` for visualization.
  * @param {object} genericObject Generic object describing behaviour of mock
+ * @ignore
  * @returns The `qId`, undefined if not present
  */
 function getQId(genericObject) {
@@ -37,6 +41,7 @@ function getQId(genericObject) {
  * Create a mock of a generic object. Mandatory properties are added, functions returns async values where applicable etc.
  * @param {object} genericObject Generic object describing behaviour of mock
  * @param {EnigmaMockerOptions} options Options.
+ * @ignore
  * @returns The mocked object
  */
 function createMock(genericObject, options) {
@@ -63,6 +68,7 @@ function createMock(genericObject, options) {
  * Create mocked objects from list of generic objects.
  * @param {Array<object>} genericObjects Generic objects describing behaviour of mock
  * @param {EnigmaMockerOptions} options options
+ * @ignore
  * @returns Object with mocks where key is `qId` and value is the mocked object.
  */
 function createMocks(genericObjects, options) {
@@ -78,6 +84,7 @@ function createMocks(genericObjects, options) {
 /**
  * Validates if mandatory information is available.
  * @param {object} genericObject Generic object to validate
+ * @ignore
  * @throws {}
  * <ul>
  *   <li>{Error} If getLayout is missing</li>
@@ -98,6 +105,7 @@ function validate(genericObject) {
  * Creates mock of `getObject(id)` based on an array of generic objects.
  * @param {Array<object>} genericObjects Generic objects.
  * @param {EnigmaMockerOptions} options Options.
+ * @ignore
  * @returns Function to retrieve the mocked generic object with the corresponding id.
  */
 function GetObjectMock(genericObjects = [], options = {}) {

--- a/apis/enigma-mocker/src/prop.js
+++ b/apis/enigma-mocker/src/prop.js
@@ -14,12 +14,13 @@
  *   id: getValue(fixture.id, { defaultValue: 'object-id-${+Date.now()}'}),
  * }
  * ```
- *
+ * @type function
+ * @ignore
  * @param {any} prop Fixture property. Either a fixed value (string / object / boolean / ...) or a function invoked when the value is needed.
  * @param {object} options Options.
  * @param {Array<any>} options.args Arguments used to evaluate the property value.
  * @param {any} options.defaultValue Default value in case not value is defined in fixture.
- * @returns The property value.
+ * @returns {any} The property value.
  */
 export const getPropValue = (prop, { args = [], defaultValue } = {}) => {
   if (typeof prop === 'function') {
@@ -47,13 +48,14 @@ export const getPropValue = (prop, { args = [], defaultValue } = {}) => {
  *   getHyperCubeData: getPropFn(fixture.getHyperCubeData, { defaultValue: [], usePromise: true })
  * };
  * ```
- *
+ * @type function
+ * @ignore
  * @param {any} prop Fixture property. Either a fixed value (string / object / boolean / ...) or a function invoked when the value is needed.
  * @param {object} options Options.
  * @param {any} options.defaultValue Default value in case not value is defined in fixture.
  * @param {boolean} options.async When `true` the returns value is wrapped in a promise, otherwise the value is directly returned.
  * @param {number} options.number Delay before value is returned.
- * @returns A fixture property function
+ * @returns {function} A fixture property function
  */
 export const getPropFn =
   (prop, { defaultValue, async = true, delay = 0 } = {}) =>

--- a/apis/nucleus/src/components/listbox/useConfirmUnfocus.jsx
+++ b/apis/nucleus/src/components/listbox/useConfirmUnfocus.jsx
@@ -3,6 +3,7 @@ import { useRef, useEffect, useState } from 'react';
 /**
  * Hook that confirms selection when
  * user interact outside of passed element ref.
+ * @ignore
  */
 
 export default function useConfirmUnfocus(ref, selections, shouldConfirmOnBlur) {

--- a/apis/stardust/api-spec/spec.conf.js
+++ b/apis/stardust/api-spec/spec.conf.js
@@ -8,6 +8,7 @@ module.exports = {
       '../locale/src/translator.js',
       '../theme/src/**/*.js',
       '../conversion/src/**/*.js',
+      '../enigma-mocker/src/**/*.js',
     ],
     api: {
       stability: 'stable',

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -511,6 +511,45 @@
         "// configure nebula to enable navigation between charts\nembed(app, {\n  context: {\n    keyboardNavigation: true, // tell Nebula to handle navigation\n  }\n}).render({ element, id: 'sdfsdf' });",
         "import { useKeyboard } from '@nebula.js/stardust';\n// ...\nconst keyboard = useKeyboard();\nuseEffect(() => {\n // Set a tab stop on our button if in focus or if Nebulas navigation is disabled\n button.setAttribute('tabIndex', keyboard.active || !keyboard.enabled ? 0 : -1);\n // If navigation is enabled and focus has shifted, lets focus the button\n keyboard.enabled && keyboard.active && button.focus();\n}, [keyboard])"
       ]
+    },
+    "EnigmaMocker": {
+      "kind": "object",
+      "entries": {
+        "fromGenericObjects": {
+          "description": "Mocks Engima app functionality. It accepts one / many generic objects as input argument and returns the mocked Enigma app. Each generic object represents one visulization and specifies how it behaves. For example, what layout to use the data to present.\n\nThe generic object is represented with a Javascript object with a number of properties. The name of the property correlates to the name in the Enigma model for `app.getObject(id)`. For example, the property `getLayout` in the generic object is used to define `app.getObject(id).getLayout()`. Any property can be added to the fixture (just make sure it exists and behaves as in the Enigma model!).\n\nThe value for each property is either fixed (string / boolean / number / object) or a function. Arguments are forwarded to the function to allow for greater flexibility. For example, this can be used to return different hypercube data when scrolling in the chart.",
+          "stability": "experimental",
+          "availability": {
+            "since": "3.0.0"
+          },
+          "kind": "function",
+          "params": [
+            {
+              "name": "genericObjects",
+              "description": "Generic objects controling behaviour of visualizations.",
+              "kind": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            {
+              "name": "options",
+              "description": "Options",
+              "type": "#/definitions/EnigmaMockerOptions"
+            }
+          ],
+          "returns": {
+            "type": "Promise",
+            "generics": [
+              {
+                "type": "EngineAPI.IApp"
+              }
+            ]
+          },
+          "examples": [
+            "const genericObject = {\n  getLayout() {\n    return {\n      qInfo: {\n        qId: 'qqj4zx',\n        qType: 'sn-grid-chart'\n      },\n      ...\n    }\n  },\n  getHyperCubeData(path, page) {\n    return [ ... ];\n  }\n};\nconst app = await EnigmaMocker.fromGenericObjects([genericObject]);"
+          ]
+        }
+      }
     }
   },
   "definitions": {
@@ -1213,33 +1252,6 @@
         }
       }
     },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
-      "kind": "interface",
-      "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
-              "type": "string"
-            }
-          }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
-        }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
-    },
     "Field": {
       "kind": "alias",
       "items": {
@@ -1393,6 +1405,33 @@
           "type": "object"
         }
       }
+    },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
     },
     "ActionToolbarElement": {
       "availability": {
@@ -2350,6 +2389,20 @@
       ],
       "kind": "interface",
       "entries": {}
+    },
+    "EnigmaMockerOptions": {
+      "description": "Mocks Engima app functionality for demo and testing purposes.",
+      "stability": "experimental",
+      "availability": {
+        "since": "3.0.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "delay": {
+          "description": "Simulate delay (in ms) for calls in enigma-mocker.",
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/apis/stardust/src/index.js
+++ b/apis/stardust/src/index.js
@@ -8,7 +8,7 @@ import conversion from '@nebula.js/conversion';
 import EnigmaMocker from '@nebula.js/enigma-mocker';
 
 // mashup api
-export { embed, conversion };
+export { embed, conversion, EnigmaMocker };
 
 // component api
 export {
@@ -40,5 +40,5 @@ export {
 } from '@nebula.js/supernova';
 
 // component internals
-const __DO_NOT_USE__ = { generator, hook, theme, locale, EnigmaMocker };
+const __DO_NOT_USE__ = { generator, hook, theme, locale };
 export { __DO_NOT_USE__ };

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -169,6 +169,19 @@ export function useRenderState(): stardust.RenderState;
  */
 export function useKeyboard(): stardust.Keyboard;
 
+declare type EnigmaMocker = {
+    /**
+     * Mocks Engima app functionality. It accepts one / many generic objects as input argument and returns the mocked Enigma app. Each generic object represents one visulization and specifies how it behaves. For example, what layout to use the data to present.
+     * 
+     * The generic object is represented with a Javascript object with a number of properties. The name of the property correlates to the name in the Enigma model for `app.getObject(id)`. For example, the property `getLayout` in the generic object is used to define `app.getObject(id).getLayout()`. Any property can be added to the fixture (just make sure it exists and behaves as in the Enigma model!).
+     * 
+     * The value for each property is either fixed (string / boolean / number / object) or a function. Arguments are forwarded to the function to allow for greater flexibility. For example, this can be used to return different hypercube data when scrolling in the chart.
+     * @param genericObjects Generic objects controling behaviour of visualizations.
+     * @param options Options
+     */
+    fromGenericObjects(genericObjects: object[], options: stardust.EnigmaMockerOptions): Promise<EngineAPI.IApp>;
+};
+
 declare namespace stardust {
     interface Context {
         keyboardNavigation?: boolean;
@@ -367,16 +380,6 @@ declare namespace stardust {
 
     }
 
-    /**
-     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
-     */
-    interface Plugin {
-        info: {
-            name: string;
-        };
-        fn: ()=>void;
-    }
-
     type Field = string | EngineAPI.INxDimension | EngineAPI.INxMeasure | stardust.LibraryField;
 
     /**
@@ -422,6 +425,16 @@ declare namespace stardust {
         version?: string;
         load: stardust.LoadType;
         meta?: object;
+    }
+
+    /**
+     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
+     */
+    interface Plugin {
+        info: {
+            name: string;
+        };
+        fn: ()=>void;
     }
 
     interface ActionToolbarElement extends HTMLElement{
@@ -691,6 +704,13 @@ declare namespace stardust {
     }
 
     interface hyperCubeConversion {
+    }
+
+    /**
+     * Mocks Engima app functionality for demo and testing purposes.
+     */
+    interface EnigmaMockerOptions {
+        delay: number;
     }
 
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

To allow us to start using the enigma mocker in examples I've moved it to the public API as experimental.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [ ] No changes
     ***OR***
    - [x] API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [ ] Add code reviewers, for example @qlik-oss/nebula-core
