### PR TITLE
feat(serve): add mfe mode

### DIFF
--- a/commands/serve/README.md
+++ b/commands/serve/README.md
@@ -112,7 +112,7 @@ The regular dev environment in nebula serve is disabled when running in this mod
 There are a few ways to install local trusted certificates on your machine, The important
 end result is that there are two files `~/.certs/cert.pem` (the certificate) and
 `~/.certs/key.pem` (the public key). Read about how certificates work
-[here](http://www.steves-internet-guide.com/ssl-certificates-explained/) if you already
+[here](http://www.steves-internet-guide.com/ssl-certificates-explained/). If you already
 have a self-signed and trusted certificate in this location, then skip this guide.
 
 ##### Easy step-by-step guide to install and generate certificates locally

--- a/commands/serve/README.md
+++ b/commands/serve/README.md
@@ -37,6 +37,7 @@ Options:
   --webIntegrationId                                                    [string]
   --fixturePath       Path to a folder that will be used as basis when locating
                       fixtures              [string] [default: "test/component"]
+  --mfe               Serves bundle to use in micro frontend           [boolean]
   -h, --help          Show help                                        [boolean]
 ```
 
@@ -88,3 +89,49 @@ serve({
   s.close(); // close the server
 });
 ```
+
+### Micro Frontend (MFE) Mode
+
+The MFE mode, activated with the `--mfe` option, builds a visualisation bundle which is
+used in a micro frontend environemnt. The bundle is served at:
+
+```
+https://<host>:<port>/pkg/<module name>
+```
+
+The module name is by default the name in `package.json` but may be overriden using the
+`--type` option.
+
+The MFE mode requires HTTPS which requires certificates to be installed in the
+environment running nebula serve.
+
+The regular dev environment in nebula serve is disabled when running in this mode.
+
+#### How to install trusted certificates locally
+
+There are a few ways to install local trusted certificates on your machine, The important
+end result is that there are two files `~/.certs/cert.pem` (the certificate) and
+`~/.certs/key.pem` (the public key). Read about how certificates work
+[here](http://www.steves-internet-guide.com/ssl-certificates-explained/) if you already
+have a self-signed and trusted certificate in this location, then skip this guide.
+
+##### Easy step-by-step guide to install and generate certificates locally
+
+Install mkcert - [documentation](https://github.com/FiloSottile/mkcert)
+
+```sh
+brew install mkcert
+```
+
+Make sure the active directory is user folder and run the following:
+
+```sh
+$ mkdir ~/.certs
+
+$ mkcert -install
+
+$ mkcert -key-file ~/.certs/key.pem -cert-file ~/.certs/cert.pem localhost 127.0.0.1 ::1
+
+```
+
+Verify that two new files have appeared in the certs/ - folder

--- a/commands/serve/README.md
+++ b/commands/serve/README.md
@@ -92,8 +92,8 @@ serve({
 
 ### Micro Frontend (MFE) Mode
 
-The MFE mode, activated with the `--mfe` option, builds a visualisation bundle which is
-used in a micro frontend environemnt. The bundle is served at:
+The MFE mode, activated with the `--mfe` option, builds a visualisation which is
+used in a micro frontend environemnt. The visualisation is served at:
 
 ```
 https://<host>:<port>/pkg/<module name>

--- a/commands/serve/README.md
+++ b/commands/serve/README.md
@@ -102,7 +102,7 @@ https://<host>:<port>/pkg/<module name>
 The module name is by default the name in `package.json` but may be overriden using the
 `--type` option.
 
-The MFE mode requires HTTPS which requires certificates to be installed in the
+The MFE mode runs in HTTPS which requires certificates to be installed in the
 environment running nebula serve.
 
 The regular dev environment in nebula serve is disabled when running in this mode.

--- a/commands/serve/lib/init-config.js
+++ b/commands/serve/lib/init-config.js
@@ -67,6 +67,11 @@ const options = {
     default: 'test/component',
     description: 'Path to a folder that will be used as basis when locating fixtures',
   },
+  mfe: {
+    type: 'boolean',
+    default: false,
+    describe: 'Serves bundle to use in micro frontend',
+  },
 };
 
 module.exports = (yargs) =>


### PR DESCRIPTION
## Motivation

Serve visualisation bundle to use in microfront end (MFE) environment. The MFE mode is activated with the option `--mfe`.

Example starting Nebula serve in MFE mode:

```sh
nebula serve --mfe
```

This allows visualisation developers to spin up nebula serve, override the import map in the MFE environment (for example QCS) and do development against it. When the source code is changed the bundle is automatically rebuilt.

The MFE mode requires the server to run with HTTPS. This in turn requires certificates to be installed on environment spinning up nebula serve.

**Use option `--systemjs` instead of `--mfe`?**

`--mfe` is intended to describe the purpose for the developer while `--systemjs` is how its technically achieved. For the time being systemjs is the format for the bundle. Later on it might change to ESM.

When using `--mfe` some other aspects of nebula serve changes. For example,  the normal nebula serve dev env is disabled and the server requires certificates to be installed. Is this what the user expects when starting with the flag `--systemjs`?

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [ ] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [x] Add code reviewers, for example @qlik-oss/nebula-core
