### PR TITLE
fix(serve): add cors headers to `/info` and `/pkg/<name>`

### DIFF
--- a/commands/serve/lib/serve.js
+++ b/commands/serve/lib/serve.js
@@ -47,7 +47,7 @@ const initiateWatch = async ({ snPath, snName, host }) => {
   const cache = {};
 
   return {
-    addRoutes(app) {
+    addRoutes(app, options) {
       app.get('/pkg/:name', async (req, res) => {
         const { name } = req.params;
         await done;
@@ -77,10 +77,7 @@ const initiateWatch = async ({ snPath, snName, host }) => {
 
         if (fs.existsSync(file)) {
           const f = fs.readFileSync(file);
-          res.set('Access-Control-Allow-Credentials', 'true');
-          res.set('Access-Control-Allow-Origin', '*');
-          res.set('Access-Control-Allow-Headers', 'x-qlik-xrfkey,qlik-csrf-token');
-
+          res.set(options.headers);
           res.send(f);
         } else {
           res.sendStatus('404');

--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -108,7 +108,7 @@ module.exports = async ({
       app.use(snapshotRoute, snapRouter);
 
       if (entryWatcher) {
-        entryWatcher.addRoutes(app);
+        entryWatcher.addRoutes(app, devServer.options);
       }
 
       app.get('/themes', (req, res) => {
@@ -139,6 +139,7 @@ module.exports = async ({
       });
 
       app.get('/info', (req, res) => {
+        res.set(devServer.options.headers);
         res.json({
           enigma: enigmaConfig,
           webIntegrationId,
@@ -185,6 +186,11 @@ module.exports = async ({
           },
         }
       : {},
+    headers: {
+      'Access-Control-Allow-Credentials': 'true',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Headers': 'x-qlik-xrfkey,qlik-csrf-token',
+    },
   };
 
   const compiler = webpack(config);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

CORS headers needed when serving visualisation artifacts to a MFE environment.

The headers are configured in the options for webpack devserver. These headers are added to responses for requests to `/info` and `/pkg/<name>`.

Question: Would it be useful to allow the headers to be configurable in nebula.config.js?

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [X] Ran `yarn spec`
    - [ ] No changes
     ***OR***
    - [x] API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [ ] Add code reviewers, for example @qlik-oss/nebula-core
