### PR TITLE
fix: return promise from cli-sense api

### DIFF
--- a/commands/sense/lib/api-entry.js
+++ b/commands/sense/lib/api-entry.js
@@ -7,5 +7,5 @@ module.exports = (argv) => {
   // not runnning via command line, run the config to inject default values
   const defaultBuildConfig = initConfig(yargs([])).argv;
   const senseConfig = extend(true, {}, defaultBuildConfig, argv);
-  sense(senseConfig);
+  return sense(senseConfig);
 };

--- a/commands/sense/lib/sense.js
+++ b/commands/sense/lib/sense.js
@@ -3,9 +3,8 @@ const build = require('./build');
 
 function sense(argv) {
   if (argv.legacy) {
-    buildLegacy(argv);
-  } else {
-    build(argv);
+    return buildLegacy(argv);
   }
+  return build(argv);
 }
 module.exports = sense;


### PR DESCRIPTION
many uses already expect a promise
ex: https://github.com/qlik-oss/sn-scatter-plot/blob/36cf9ce948ac86d9f959f5b9ba62871cf4f065df/scripts/build.js#L39

That use is still OK as the missing promise is only needed when using a external ext file or use a legacy build.

## Motivation

<!-- Write your motivation here -->


## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [ ] Add code reviewers, for example @qlik-oss/nebula-core
