### PR TITLE
fix(nucleus): apply styles on header element

### DIFF
--- a/apis/nucleus/src/components/Header.jsx
+++ b/apis/nucleus/src/components/Header.jsx
@@ -14,11 +14,11 @@ const classes = {
 };
 
 const StyledGrid = styled(Grid)(({ theme }) => ({
-  [`& .${classes.containerStyle}`]: {
+  [`&.${classes.containerStyle}`]: {
     flexGrow: 0,
   },
 
-  [`& .${classes.containerTitleStyle}`]: {
+  [`&.${classes.containerTitleStyle}`]: {
     paddingBottom: theme.spacing(1),
   },
 }));


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Modify container styles to apply directly on container element (instead of being applied to sub elements of the container).

Example **without** the fix. Note that there is no padding below the header:

![December 2018](https://user-images.githubusercontent.com/7684435/191289723-032cf92a-e02a-415e-9486-8b6f8d6e44fa.png)

Example **with** the fix. Note the 8px padding below the header:

![December 2019](https://user-images.githubusercontent.com/7684435/191289953-d467a7a4-3c99-4ae5-bfa9-8e9355dab4fd.png)

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [ ] Add code reviewers, for example @qlik-oss/nebula-core
