### PR TITLE
feat(serve): pass fullscreen callback to nebbie options

### DIFF
--- a/commands/serve/web/components/Cell.jsx
+++ b/commands/serve/web/components/Cell.jsx
@@ -114,6 +114,19 @@ export default function ({ id, expandable, minHeight }) {
     [model, currentThemeName]
   );
 
+  const singleRenderUrl = (modelId) => {
+    if (model || modelId) {
+      return `${document.location.href.replace(/\/dev\//, '/render/')}${window.location.search ? '&' : '?'}object=${
+        model ? model.id : modelId
+      }&theme=${currentThemeName}&language=${language}`;
+    }
+    return '';
+  };
+
+  const openInSingleRender = (modelId) => {
+    window.open(singleRenderUrl(modelId), '_blank').focus();
+  };
+
   const activeStyle =
     !isExpanded && vizRef.current && activeViz && activeViz === vizRef.current.viz
       ? {
@@ -152,13 +165,7 @@ export default function ({ id, expandable, minHeight }) {
             title="Open in single render view"
             className={classes.secondaryIcon}
             disabled={!model}
-            href={
-              model
-                ? `${document.location.href.replace(/\/dev\//, '/render/')}${
-                    window.location.search ? '&' : '?'
-                  }object=${model.id}&theme=${currentThemeName}&language=${language}`
-                : ''
-            }
+            href={singleRenderUrl()}
             target="_blank"
             size="large"
           >
@@ -269,7 +276,7 @@ export default function ({ id, expandable, minHeight }) {
         </Toolbar>
       </Grid>
       <Grid item xs style={{ ...activeStyle }} className={classes.drop}>
-        <Chart id={id} onLoad={onLoad} toggleExpand={toggleExpand} />
+        <Chart id={id} onLoad={onLoad} onFullscreen={openInSingleRender} />
       </Grid>
     </StyledGrid>
   );

--- a/commands/serve/web/components/Cell.jsx
+++ b/commands/serve/web/components/Cell.jsx
@@ -269,7 +269,7 @@ export default function ({ id, expandable, minHeight }) {
         </Toolbar>
       </Grid>
       <Grid item xs style={{ ...activeStyle }} className={classes.drop}>
-        <Chart id={id} onLoad={onLoad} />
+        <Chart id={id} onLoad={onLoad} toggleExpand={toggleExpand} />
       </Grid>
     </StyledGrid>
   );

--- a/commands/serve/web/components/Chart.jsx
+++ b/commands/serve/web/components/Chart.jsx
@@ -7,13 +7,16 @@ import React, {
 
 import NebulaContext from '../contexts/NebulaContext';
 
-export default function Chart({ id, onLoad }) {
+export default function Chart({ id, onLoad, toggleExpand }) {
   const nebbie = useContext(NebulaContext);
   const el = useRef();
   useEffect(() => {
     const n = nebbie.render({
       id,
       element: el.current,
+      options: {
+        toggleExpand,
+      },
     });
     n.then((viz) => {
       onLoad(viz, el.current);

--- a/commands/serve/web/components/Chart.jsx
+++ b/commands/serve/web/components/Chart.jsx
@@ -7,7 +7,7 @@ import React, {
 
 import NebulaContext from '../contexts/NebulaContext';
 
-export default function Chart({ id, onLoad, toggleExpand }) {
+export default function Chart({ id, onLoad, onFullscreen }) {
   const nebbie = useContext(NebulaContext);
   const el = useRef();
   useEffect(() => {
@@ -15,7 +15,7 @@ export default function Chart({ id, onLoad, toggleExpand }) {
       id,
       element: el.current,
       options: {
-        toggleExpand,
+        onFullscreen,
       },
     });
     n.then((viz) => {

--- a/commands/serve/web/components/property-panel/DataCube.jsx
+++ b/commands/serve/web/components/property-panel/DataCube.jsx
@@ -32,7 +32,7 @@ export default function DataCube({ setProperties, target, properties }) {
     () =>
       createHandler({
         def: target,
-        dc: getValue(properties, target.propertyPath),
+        dc: getValue(properties, target.propertyPath, {}),
         properties,
       }),
     [properties]

--- a/commands/serve/web/components/property-panel/DataCube.jsx
+++ b/commands/serve/web/components/property-panel/DataCube.jsx
@@ -32,7 +32,7 @@ export default function DataCube({ setProperties, target, properties }) {
     () =>
       createHandler({
         def: target,
-        dc: getValue(properties, target.propertyPath, {}),
+        dc: getValue(properties, target.propertyPath),
         properties,
       }),
     [properties]


### PR DESCRIPTION
## Motivation
While using sn-filter-pane in nebula-serve,
the expand-button shown in sn-filter-pane when all Listboxes are collapsed needs a callback function that trigger expand.
![fs](https://user-images.githubusercontent.com/99665802/192298476-4db83cde-6079-481c-adcb-068483493571.gif)

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [ ] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [x] Add code reviewers, for example @qlik-oss/nebula-core
