### PR TITLE
feat: sdk OAuth support in mashup template

### DIFF
--- a/commands/create/templates/mashup/_package.json
+++ b/commands/create/templates/mashup/_package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@nebula.js/stardust": "<%= nebulaVersion %>",
     "@nebula.js/sn-bar-chart": "^1.x",
-    "@qlik/sdk": "^0.9.1",
+    "@qlik/sdk": "^0.10.2",
     "enigma.js": "^2.6.3",
     "parcel": "^2.3.2"
   }

--- a/commands/create/templates/mashup/src/Authenticator.js
+++ b/commands/create/templates/mashup/src/Authenticator.js
@@ -1,0 +1,87 @@
+import enigma from 'enigma.js';
+import schema from 'enigma.js/schemas/12.936.0.json';
+import { Auth, AuthType } from '@qlik/sdk';
+
+export default class Authenticator {
+  /**
+   *
+   * @param {String} appId  - application id from sense client
+   * @param {Strign} url    - tenant url
+   */
+  constructor({ appId, url }) {
+    this.authInstance = null;
+    this.appId = appId;
+    this.host = url.replace(/^https?:\/\//, '').replace(/\/?/, '');
+  }
+
+  /**
+   * gets you the promise of enigma instance for your app
+   * based on webIntegrationId
+   * @param {Strign} webIntegrationId - your web Integration Id from managment console
+   * @returns {Promise<IEnigmaClass>} enigma app promise
+   */
+  async AuthenticateWithWebIntegrationId({ webIntegrationId }) {
+    this.authInstance = new Auth({
+      authType: AuthType.WebIntegration,
+      autoRedirect: true,
+      host: this.host,
+      webIntegrationId,
+    });
+
+    if (!this.authInstance.isAuthenticated()) {
+      this.authInstance.authenticate();
+    } else return this.getEnigmaApp();
+
+    return null;
+  }
+
+  /**
+   * gets you the promise of enigma instance for your app
+   * based on clientId
+   * @param {Strign} clientId     - your client Id from managment console
+   * @param {Strign} redirectUri  - the redirect url while bringing you the code + state, default is `window.location.origin`
+   * @returns {Promise<IEnigmaClass>} enigma app promise
+   */
+  async AuthenticateWithOAuth({ clientId, redirectUri }) {
+    this.authInstance = new Auth({
+      authType: AuthType.OAuth2,
+      host: this.host,
+      redirectUri: redirectUri || window.location.origin,
+      clientId,
+    });
+
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('code')) {
+      try {
+        await this.authInstance.authorize(window.location.href);
+        const url = new URL(window.location);
+        url.searchParams.delete('code');
+        url.searchParams.delete('state');
+        window.history.replaceState(null, null, url);
+      } catch (error) {
+        console.error({ error });
+      }
+
+      return this.getEnigmaApp();
+    }
+
+    if (!(await this.authInstance.isAuthorized())) {
+      const { url } = await this.authInstance.generateAuthorizationUrl();
+      const protocol = url.includes('https://') ? 'https' : 'http';
+      console.log({ url });
+      window.location = `${protocol}://${url}`;
+    }
+
+    return null;
+  }
+
+  /**
+   * returns a promise of enigma instance
+   * @returns {Promise<IEnigmaClass>} enigma app instance promise
+   */
+  async getEnigmaApp() {
+    const url = await this.authInstance.generateWebsocketUrl(this.appId);
+    const enigmaGlobal = await enigma.create({ schema, url }).open();
+    return enigmaGlobal.openDoc(this.appId);
+  }
+}

--- a/commands/create/templates/mashup/src/connect.js
+++ b/commands/create/templates/mashup/src/connect.js
@@ -1,24 +1,26 @@
-import enigma from 'enigma.js';
-import schema from 'enigma.js/schemas/12.936.0.json';
-import { Auth, AuthType } from '@qlik/sdk';
+import { AuthType } from '@qlik/sdk';
+import Authenticator from './Authenticator';
 
-async function connect({ url, webIntegrationId, appId }) {
-  const authInstance = new Auth({
-    webIntegrationId,
-    autoRedirect: true,
-    authType: AuthType.WebIntegration,
-    host: url.replace(/^https?:\/\//, '').replace(/\/?/, ''),
+async function connect({ connectionType, url, appId, ...rest }) {
+  const AuthenticatorInstance = new Authenticator({
+    url,
+    appId,
   });
 
-  if (!authInstance.isAuthenticated()) {
-    authInstance.authenticate();
-  } else {
-    const wssUrl = await authInstance.generateWebsocketUrl(appId);
-    const enigmaGlobal = await enigma.create({ schema, url: wssUrl }).open();
-    return enigmaGlobal.openDoc(appId);
-  }
+  switch (connectionType) {
+    case AuthType.WebIntegration: {
+      return AuthenticatorInstance.AuthenticateWithWebIntegrationId({
+        ...rest,
+      });
+    }
 
-  return null;
+    case AuthType.OAuth2: {
+      return AuthenticatorInstance.AuthenticateWithOAuth({ ...rest });
+    }
+
+    default:
+      throw new Error('Please Provide a `connectionType` to proceed!');
+  }
 }
 
 export default connect;

--- a/commands/create/templates/mashup/src/index.js
+++ b/commands/create/templates/mashup/src/index.js
@@ -1,12 +1,18 @@
 /* eslint-disable */
+// import { AuthType } from '@qlik/sdk';
 import embed from './configure';
 import connect from './connect';
 
 async function run() {
   const app = await connect({
+    connectionType: '<AuthType.SOME_CONNECTION_TYPE>',
     url: '<URL>',
-    webIntegrationId: '<Qlik web integration id>',
     appId: '<App id>',
+
+    // you should use only one of below keys
+    // based on your `connectionType`
+    clientId: '<Qlik OAuth client id>',
+    webIntegrationId: '<Qlik web integration id>',
   });
 
   const n = embed(app);

--- a/commands/serve/package.json
+++ b/commands/serve/package.json
@@ -54,7 +54,7 @@
     "@nebula.js/snapshooter": "^3.0.3",
     "@nebula.js/stardust": "^3.0.3",
     "@nebula.js/ui": "^3.0.3",
-    "@qlik/sdk": "^0.9.1",
+    "@qlik/sdk": "^0.10.2",
     "autosuggest-highlight": "3.3.4",
     "babel-loader": "8.2.5",
     "d3-require": "1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4913,17 +4913,17 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
-"@qlik/sdk@^0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@qlik/sdk/-/sdk-0.9.1.tgz#b48575756b31b5f65fd1866da596e24db09b3b98"
-  integrity sha512-6gCy9s+GwD+DjPgtapdRXZHEThlKmrxeM1YawkriSKXpElUl1+Wyq4tt5Y9Ijmg9Dmp3t0w8Ftjv0uBnpFPedw==
+"@qlik/sdk@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@qlik/sdk/-/sdk-0.10.2.tgz#24c8e1d864b81e8837744914825f321da01a5895"
+  integrity sha512-cKpWPgDOi4alWwSQ/1DI40Pj+PhL8hMwBSib/tRwwpVn00iVUoFvjG80SUUmYGbeWLeBV38f/W4pqh+5jghHRA==
   dependencies:
-    "@types/jsonwebtoken" "8.5.8"
+    "@types/jsonwebtoken" "8.5.9"
     cross-fetch "3.1.5"
     enigma.js "2.9.0"
-    isomorphic-ws "4.0.1"
+    isomorphic-ws "5.0.0"
     jsonwebtoken "8.5.1"
-    ws "8.8.0"
+    ws "8.8.1"
 
 "@rollup/plugin-commonjs@22.0.2":
   version "22.0.2"
@@ -6290,10 +6290,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/jsonwebtoken@8.5.8":
-  version "8.5.8"
-  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz#01b39711eb844777b7af1d1f2b4cf22fda1c0c44"
-  integrity sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==
+"@types/jsonwebtoken@8.5.9":
+  version "8.5.9"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz#2c064ecb0b3128d837d2764aa0b117b0ff6e4586"
+  integrity sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==
   dependencies:
     "@types/node" "*"
 
@@ -8384,10 +8384,15 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@1.0.30001387, caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001349, caniuse-lite@^1.0.30001400:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001349:
   version "1.0.30001387"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001387.tgz#90d2b9bdfcc3ab9a5b9addee00a25ef86c9e2e1e"
   integrity sha512-fKDH0F1KOJvR+mWSOvhj8lVRr/Q/mc5u5nabU2vi1/sgvlSqEsE8dOq0Hy/BqVbDkCYQPRRHB1WRjW6PGB/7PA==
+
+caniuse-lite@^1.0.30001400:
+  version "1.0.30001415"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001415.tgz#fd7ea96e9e94c181a7f56e7571efb43d92b860cc"
+  integrity sha512-ER+PfgCJUe8BqunLGWd/1EY4g8AzQcsDAVzdtMGKVtQEmKAwaFfU6vb7EAVIqTMYsqxBorYZi2+22Iouj/y7GQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -13301,10 +13306,10 @@ isomorphic-unfetch@^3.1.0:
     node-fetch "^2.6.1"
     unfetch "^4.2.0"
 
-isomorphic-ws@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
-  integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
+isomorphic-ws@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz#e5529148912ecb9b451b46ed44d53dae1ce04bbf"
+  integrity sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==
 
 istanbul-lib-coverage@^2.0.5:
   version "2.0.5"
@@ -17725,7 +17730,17 @@ react-inspector@^5.1.0:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
-react-is@17.0.2, react-is@18.2.0, react-is@^16.12.0, "react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^16.13.1, react-is@^16.7.0, react-is@^17.0.1, react-is@^18.0.0, react-is@^18.2.0:
+react-is@17.0.2, react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
@@ -21064,11 +21079,6 @@ ws@8.7.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.7.0.tgz#eaf9d874b433aa00c0e0d8752532444875db3957"
   integrity sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==
 
-ws@8.8.0, ws@^8.2.3, ws@^8.4.2:
-  version "8.8.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.0.tgz#8e71c75e2f6348dbf8d78005107297056cb77769"
-  integrity sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==
-
 ws@8.8.1, ws@^8.8.0:
   version "8.8.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
@@ -21085,6 +21095,11 @@ ws@^7.2.0:
   version "7.5.8"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.8.tgz#ac2729881ab9e7cbaf8787fe3469a48c5c7f636a"
   integrity sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==
+
+ws@^8.2.3, ws@^8.4.2:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.0.tgz#8e71c75e2f6348dbf8d78005107297056cb77769"
+  integrity sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==
 
 x-default-browser@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## Motivation

<!-- Write your motivation here -->
by release of `@qlik/sdk` version `0.10.x`, there is a requirement to integrate OAuth support for mashup. This PR fixed that. 

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [x] Add code reviewers, for example @qlik-oss/nebula-core
