### PR TITLE
chore: publish jest coverage to code climate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,8 +109,15 @@ jobs:
       - store_test_results:
           path: coverage/junit
       - run:
-          name: Jest Unit Tests
-          command: yarn run test:jest
+          name: Jest Unit Tests and Upload to code climate
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+            ./cc-test-reporter before-build
+            yarn test:jest:coverage
+            ./cc-test-reporter after-build --coverage-input-type lcov --exit-code $?
+      - store_artifacts:
+          path: coverage
       - run:
           name: Test component
           command: yarn run test:component --chrome.browserWSEndpoint "ws://localhost:3000" --no-launch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
             ./cc-test-reporter before-build
-            yarn test:jest -- --ci --reporters=default --reporters=jest-junit
+            yarn test:jest:coverage -- --maxWorkers=2
             ./cc-test-reporter after-build --coverage-input-type lcov --exit-code $?
           environment:
             JEST_JUNIT_OUTPUT_DIR: ./coverage/junit/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: cimg/node:18.10.0
+      - image: circleci/node:16.12.0-browsers
       - image: browserless/chrome:1-puppeteer-7.1.0
 
     working_directory: ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,27 +102,16 @@ jobs:
           name: Unit tests
           command: |
             yarn run test:unit --mocha.bail false --mocha.reporter mocha-junit-reporter --mocha.reporterOptions.mochaFile ./coverage/junit/junit.xml
+      - store_test_results:
+          path: coverage/junit
+      - run:
+          name: Jest Unit Tests
+          command: |
+            yarn test:jest --coverage --reporters=default --reporters=jest-junit
             if [ ! -z "$COVERALLS_REPO_TOKEN" ]; then
               echo "Uploading coverage results to coveralls.io..."
               cat ./coverage/unit/lcov.info | npx coveralls
             fi
-      - store_test_results:
-          path: coverage/junit
-      - run:
-          name: Setup Code Climate test-reporter
-          command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-            chmod +x ./cc-test-reporter
-      - run:
-          name: Jest Unit Tests and Upload to code climate
-          command: |
-            ./cc-test-reporter before-build
-            yarn test:jest --coverage --reporters=default --reporters=jest-junit
-            ./cc-test-reporter after-build --coverage-input-type lcov --exit-code $?
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./coverage/junit/
-      - store_artifacts:
-          path: coverage
       - run:
           name: Test component
           command: yarn run test:component --chrome.browserWSEndpoint "ws://localhost:3000" --no-launch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
           name: Jest Unit Tests and Upload to code climate
           command: |
             ./cc-test-reporter before-build
-            yarn test:jest:coverage -- --maxWorkers=2
+            yarn jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=2
             ./cc-test-reporter after-build --coverage-input-type lcov --exit-code $?
           environment:
             JEST_JUNIT_OUTPUT_DIR: ./coverage/junit/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: circleci/node:16.12.0-browsers
+      - image: cimg/node:18.10.0
       - image: browserless/chrome:1-puppeteer-7.1.0
 
     working_directory: ~/project
@@ -109,10 +109,13 @@ jobs:
       - store_test_results:
           path: coverage/junit
       - run:
-          name: Jest Unit Tests and Upload to code climate
+          name: Setup Code Climate test-reporter
           command: |
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
+      - run:
+          name: Jest Unit Tests and Upload to code climate
+          command: |
             ./cc-test-reporter before-build
             yarn test:jest:coverage -- --maxWorkers=2
             ./cc-test-reporter after-build --coverage-input-type lcov --exit-code $?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
           name: Jest Unit Tests and Upload to code climate
           command: |
             ./cc-test-reporter before-build
-            yarn jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=2
+            yarn test:jest --coverage --reporters=default --reporters=jest-junit
             ./cc-test-reporter after-build --coverage-input-type lcov --exit-code $?
           environment:
             JEST_JUNIT_OUTPUT_DIR: ./coverage/junit/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,8 +114,10 @@ jobs:
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
             ./cc-test-reporter before-build
-            yarn test:jest:coverage
+            yarn test:jest -- --ci --reporters=default --reporters=jest-junit
             ./cc-test-reporter after-build --coverage-input-type lcov --exit-code $?
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./coverage/junit/
       - store_artifacts:
           path: coverage
       - run:

--- a/jest.config.js
+++ b/jest.config.js
@@ -39,5 +39,6 @@ module.exports = {
     '!**/*.config.js',
     '!**/*.conf.js',
   ],
-  coverageReporters: ['default', 'lcov', 'jest-junit'],
+  coverageReporters: ['json', 'lcov', 'text-summary', 'clover'],
+  reporters: ['default', ['jest-junit', { outputDirectory: 'coverage/junit/' }]],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -39,5 +39,5 @@ module.exports = {
     '!**/*.config.js',
     '!**/*.conf.js',
   ],
-  coverageReporters: ['json', 'lcov', 'text-summary', 'clover'],
+  coverageReporters: ['default', 'lcov', 'jest-junit'],
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "yarn run test:unit",
     "test:jest": "jest --maxWorkers=2",
     "test:jest:watch": "jest --watch",
-    "test:jest:coverage": "jest --coverage --maxWorkers=2",
+    "test:jest:coverage": "jest --coverage",
     "mashup": "node scripts/start-mashup.js",
     "test:mashup": "aw puppet -c aw.config.js --testExt '*.int.js' --glob 'test/mashup/**/*.int.js'",
     "test:integration": "aw puppet -c aw.config.js --testExt '*.int.js' --glob 'test/integration/**/*.int.js'",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "husky": "8.0.1",
     "jest": "^29.1.2",
     "jest-environment-jsdom": "^29.1.2",
+    "jest-junit": "^14.0.1",
     "jest-location-mock": "^1.0.9",
     "jimp": "0.16.2",
     "lerna": "5.5.4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "yarn run test:unit",
     "test:jest": "jest --maxWorkers=2",
     "test:jest:watch": "jest --watch",
-    "test:jest:coverage": "jest --coverage",
+    "test:jest:coverage": "jest --coverage --maxWorkers=2",
     "mashup": "node scripts/start-mashup.js",
     "test:mashup": "aw puppet -c aw.config.js --testExt '*.int.js' --glob 'test/mashup/**/*.int.js'",
     "test:integration": "aw puppet -c aw.config.js --testExt '*.int.js' --glob 'test/integration/**/*.int.js'",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13833,6 +13833,16 @@ jest-haste-map@^29.1.2:
   optionalDependencies:
     fsevents "^2.3.2"
 
+jest-junit@^14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-14.0.1.tgz#5b357d6f5d333459585d628a24cd48b5bbc92ba2"
+  integrity sha512-h7/wwzPbllgpQhhVcRzRC76/cc89GlazThoV1fDxcALkf26IIlRsu/AcTG64f4nR2WPE3Cbd+i/sVf+NCUHrWQ==
+  dependencies:
+    mkdirp "^1.0.4"
+    strip-ansi "^6.0.1"
+    uuid "^8.3.2"
+    xml "^1.0.1"
+
 jest-leak-detector@^29.1.2:
   version "29.1.2"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.1.2.tgz#4c846db14c58219430ccbc4f01a1ec52ebee4fc2"
@@ -21375,7 +21385,7 @@ xml2js@^0.4.5:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
 
-xml@^1.0.0:
+xml@^1.0.0, xml@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==


### PR DESCRIPTION
## Motivation
publishing jest coverage to coveralls.io instead of afterwork

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [ ] Add code reviewers, for example @qlik-oss/nebula-core
