### PR TITLE
fix: correctly check qId in mocker

### DIFF
--- a/apis/enigma-mocker/src/__tests__/from-generic-objects.inspect.js
+++ b/apis/enigma-mocker/src/__tests__/from-generic-objects.inspect.js
@@ -74,6 +74,16 @@ describe('enigma-mocker', () => {
       expect(await app.getObject('aabbcc')).not.toBe(undefined);
     });
 
+    test('error for unmatched IDs', async () => {
+      const genericObjectA = {
+        id: 'AABBCC',
+        getLayout: { qInfo: { qId: '112233' } },
+      };
+      await expect(async () => {
+        await createEnigmaMocker([genericObjectA]);
+      }).rejects.toThrow();
+    });
+
     describe('getLayout', () => {
       test('shoud support fixed value', async () => {
         const app = await createEnigmaMocker(genericObjects);

--- a/apis/enigma-mocker/src/mocks/get-object-mock.js
+++ b/apis/enigma-mocker/src/mocks/get-object-mock.js
@@ -45,11 +45,18 @@ function getQId(genericObject) {
  * @returns The mocked object
  */
 function createMock(genericObject, options) {
-  const qId = getQId(genericObject);
+  let qId = getQId(genericObject);
   const { delay } = options;
   const { id, session, ...props } = genericObject;
+
+  if (id && qId && id !== qId) {
+    throw new Error(`Generic object has multiple IDs, qInfo.qId: ${qId}, id: ${id}`);
+  }
+
+  qId = qId || id || `object - ${+Date.now()}`;
+
   const mock = {
-    id: getPropValue(id, { defaultValue: `object - ${+Date.now()}` }),
+    id: qId,
     session: getPropValue(session, { defaultValue: true }),
     on: () => {},
     once: () => {},


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Make sure ID and qID are matching when generating generic object mocks.


## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [x] Add code reviewers, for example @qlik-oss/nebula-core
