### PR TITLE
feat: `clientId` from `nebula.config.js` support

### DIFF
--- a/commands/serve/README.md
+++ b/commands/serve/README.md
@@ -34,6 +34,7 @@ Options:
   --stylesheets       Array of stylesheets to inject                     [array]
   --enigma.host                                  [string] [default: "localhost"]
   --enigma.port                                         [number] [default: 9076]
+  --clientId                                                            [string]
   --webIntegrationId                                                    [string]
   --fixturePath       Path to a folder that will be used as basis when locating
                       fixtures              [string] [default: "test/component"]

--- a/commands/serve/README.md
+++ b/commands/serve/README.md
@@ -34,8 +34,8 @@ Options:
   --stylesheets       Array of stylesheets to inject                     [array]
   --enigma.host                                  [string] [default: "localhost"]
   --enigma.port                                         [number] [default: 9076]
-  --clientId          Your Apps clientId for OAuth connection           [string]
-  --webIntegrationId  Your Apps webIntegrationId for OAuth connection   [string]
+  --clientId          Your tenant's clientId for OAuth connection       [string]
+  --webIntegrationId  Your tenant's webIntegrationId for connection     [string]
   --fixturePath       Path to a folder that will be used as basis when locating
                       fixtures              [string] [default: "test/component"]
   --mfe               Serves bundle to use in micro frontend           [boolean]

--- a/commands/serve/README.md
+++ b/commands/serve/README.md
@@ -35,7 +35,7 @@ Options:
   --enigma.host                                  [string] [default: "localhost"]
   --enigma.port                                         [number] [default: 9076]
   --clientId          Your Apps clientId for OAuth connection           [string]
-  --webIntegrationId                                                    [string]
+  --webIntegrationId  Your Apps webIntegrationId for OAuth connection   [string]
   --fixturePath       Path to a folder that will be used as basis when locating
                       fixtures              [string] [default: "test/component"]
   --mfe               Serves bundle to use in micro frontend           [boolean]

--- a/commands/serve/README.md
+++ b/commands/serve/README.md
@@ -34,7 +34,7 @@ Options:
   --stylesheets       Array of stylesheets to inject                     [array]
   --enigma.host                                  [string] [default: "localhost"]
   --enigma.port                                         [number] [default: 9076]
-  --clientId                                                            [string]
+  --clientId          Your Apps clientId for OAuth connection           [string]
   --webIntegrationId                                                    [string]
   --fixturePath       Path to a folder that will be used as basis when locating
                       fixtures              [string] [default: "test/component"]

--- a/commands/serve/lib/serve.js
+++ b/commands/serve/lib/serve.js
@@ -153,6 +153,7 @@ module.exports = async (argv) => {
     port,
     disableHostCheck: serveConfig.disableHostCheck,
     enigmaConfig,
+    clientId: serveConfig.clientId,
     webIntegrationId: serveConfig.webIntegrationId,
     snName: serveConfig.type || snName,
     snUrl,

--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -19,6 +19,7 @@ module.exports = async ({
   port,
   disableHostCheck,
   enigmaConfig,
+  clientId,
   webIntegrationId,
   snName,
   snUrl,
@@ -142,6 +143,7 @@ module.exports = async ({
         res.set(devServer.options.headers);
         res.json({
           enigma: enigmaConfig,
+          clientId,
           webIntegrationId,
           supernova: {
             name: snName,


### PR DESCRIPTION
## Motivation
support for: 
- nebula.config.js file -> `serve: { clientId: <SOME_ID_HERE> }`
- passing `clientId` directly while running `nebula serve  --clientId="<SOME_ID_HERE>"`

This PR depends on: #962 
===

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [x] Add code reviewers, for example @qlik-oss/nebula-core
