### PR TITLE
ci: misleading error message

### DIFF
--- a/commands/build/lib/build.js
+++ b/commands/build/lib/build.js
@@ -110,7 +110,7 @@ const config = ({
     try {
       typescriptPlugin = require('@rollup/plugin-typescript'); // eslint-disable-line
     } catch (e) {
-      throw new Error(`Please install '@rollup/plugin-typescript' to build using typescript.`);
+      throw new Error(`${e}\n '@rollup/plugin-typescript' is required to build using typescript.`);
     }
   }
 


### PR DESCRIPTION
## Motivation

When you build with `nebula build` and your peer dependency typescript is missing this error message is shown:
`Please install '@rollup/plugin-typescript' to build using typescript.` even though it's installed.
With this change you get the actual error first which is `Cannot find module 'typescript'`

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes
     ***OR***
    - [ ] API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:
- [ ] Add code reviewers, for example @qlik-oss/nebula-core
