### PR TITLE
fix(ListBox): accept search results only if there are hits 

### DIFF
--- a/apis/nucleus/src/components/ActionsToolbarItem.jsx
+++ b/apis/nucleus/src/components/ActionsToolbarItem.jsx
@@ -22,6 +22,8 @@ const Item = React.forwardRef(({ ariaExpanded = false, item, addAnchor = false }
   const { hidden, disabled, style, hasSvgIconShape } = useActionState(item);
   if (hidden) return null;
 
+  const spacing = Number.parseInt(theme.spacing(0.5), 10);
+
   const handleKeyDown = item.keyboardAction
     ? (e) => ['Enter', ' ', 'Spacebar'].includes(e.key) && item.keyboardAction()
     : null;
@@ -43,7 +45,13 @@ const Item = React.forwardRef(({ ariaExpanded = false, item, addAnchor = false }
       {addAnchor && (
         <div
           ref={ref}
-          style={{ bottom: -theme.spacing(0.5), right: 0, position: 'absolute', width: '100%', height: 0 }}
+          style={{
+            bottom: -spacing,
+            right: 0,
+            position: 'absolute',
+            width: '100%',
+            height: 0,
+          }}
         />
       )}
     </IconButton>

--- a/apis/nucleus/src/components/ActionsToolbarMore.jsx
+++ b/apis/nucleus/src/components/ActionsToolbarMore.jsx
@@ -51,6 +51,7 @@ const More = React.forwardRef(
           ref={ref}
           open={show}
           anchorEl={alignTo.current}
+          getContentAnchorEl={null}
           container={alignTo.current}
           disablePortal
           hideBackdrop

--- a/apis/nucleus/src/components/ActionsToolbarMore.jsx
+++ b/apis/nucleus/src/components/ActionsToolbarMore.jsx
@@ -51,7 +51,6 @@ const More = React.forwardRef(
           ref={ref}
           open={show}
           anchorEl={alignTo.current}
-          getContentAnchorEl={null}
           container={alignTo.current}
           disablePortal
           hideBackdrop

--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -82,6 +82,7 @@ export default function ListBox({
   showGray = true,
   scrollState,
   selectDisabled = () => false,
+  onSetListCount = () => {},
   setCount,
 }) {
   const [layout] = useLayout(model);
@@ -243,6 +244,7 @@ export default function ListBox({
   };
 
   const listCount = pages && pages.length && calculatePagesHeight ? getCalculatedHeight(pages) : count;
+  onSetListCount?.(listCount);
   const { itemSize, listHeight } = getSizeInfo({ isVertical, checkboxes, dense, height });
   const isLocked = layout && layout.qListObject.qDimensionInfo.qLocked;
   const { frequencyMax } = layout;

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -97,6 +97,7 @@ export default function ListBoxInline({ options = {} }) {
   const [showToolbar, setShowToolbar] = useState(false);
   const [showSearch, setShowSearch] = useState(false);
   const [keyboardActive, setKeyboardActive] = useState(false);
+  const [listCount, setListCount] = useState(0);
 
   const handleKeyDown = getListboxInlineKeyboardNavigation({ setKeyboardActive });
 
@@ -170,8 +171,9 @@ export default function ListBoxInline({ options = {} }) {
     setShowSearch(newValue);
   };
 
-  const getSearchOrUnlock = () =>
-    search === 'toggle' && !hasSelections ? (
+  const getSearchOrUnlock = () => {
+    const showSearchIcon = search === 'toggle' && !hasSelections;
+    return showSearchIcon ? (
       <IconButton onClick={onShowSearch} tabIndex={-1} title={translator.get('Listbox.Search')} size="large">
         <SearchIcon />
       </IconButton>
@@ -180,6 +182,7 @@ export default function ListBoxInline({ options = {} }) {
         <Unlock />
       </IconButton>
     );
+  };
 
   return (
     <StyledGrid
@@ -248,6 +251,7 @@ export default function ListBoxInline({ options = {} }) {
             selections={selections}
             model={model}
             dense={dense}
+            listCount={listCount}
             keyboard={keyboard}
             visible={searchVisible}
             searchContainerRef={searchContainerRef}
@@ -263,6 +267,7 @@ export default function ListBoxInline({ options = {} }) {
                 selections={selections}
                 direction={direction}
                 listLayout={listLayout}
+                onSetListCount={(c) => setListCount(c)}
                 frequencyMode={frequencyMode}
                 histogram={histogram}
                 rangeSelect={rangeSelect}

--- a/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useCallback, useRef, useEffect } from 'react';
+import React, { useContext, useCallback, useRef, useEffect, useState } from 'react';
 
 import Lock from '@nebula.js/ui/icons/lock';
 import Unlock from '@nebula.js/ui/icons/unlock';
@@ -22,6 +22,7 @@ import getHasSelections from './assets/has-selections';
 
 export default function ListBoxPopover({ alignTo, show, close, app, fieldName, stateName = '$' }) {
   const open = show && Boolean(alignTo.current);
+  const [listCount, setListCount] = useState(0);
   const theme = useTheme();
   const [model] = useSessionModel(
     {
@@ -155,8 +156,8 @@ export default function ListBoxPopover({ alignTo, show, close, app, fieldName, s
         </Grid>
         <Grid item xs>
           <div ref={moreAlignTo} />
-          <ListBoxSearch selections={selections} model={model} visible />
-          <ListBox model={model} selections={selections} direction="ltr" />
+          <ListBoxSearch selections={selections} model={model} layout={layout} listCount={listCount} visible />
+          <ListBox model={model} selections={selections} direction="ltr" onSetListCount={(c) => setListCount(c)} />
         </Grid>
       </Grid>
     </Popover>

--- a/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -156,7 +156,7 @@ export default function ListBoxPopover({ alignTo, show, close, app, fieldName, s
         </Grid>
         <Grid item xs>
           <div ref={moreAlignTo} />
-          <ListBoxSearch selections={selections} model={model} layout={layout} listCount={listCount} visible />
+          <ListBoxSearch selections={selections} model={model} listCount={listCount} visible />
           <ListBox model={model} selections={selections} direction="ltr" onSetListCount={(c) => setListCount(c)} />
         </Grid>
       </Grid>

--- a/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
@@ -2,12 +2,11 @@ import React, { useContext, useState, useEffect } from 'react';
 import { useTheme } from '@nebula.js/ui/theme';
 import { InputAdornment, OutlinedInput } from '@mui/material';
 import Search from '@nebula.js/ui/icons/search';
-
 import InstanceContext from '../../../contexts/InstanceContext';
 
 const TREE_PATH = '/qListObjectDef';
 
-export default function ListBoxSearch({ selections, model, keyboard, dense = false, visible = true }) {
+export default function ListBoxSearch({ selections, model, keyboard, listCount, dense = false, visible = true }) {
   const { translator } = useContext(InstanceContext);
   const [value, setValue] = useState('');
   const theme = useTheme();
@@ -52,13 +51,25 @@ export default function ListBoxSearch({ selections, model, keyboard, dense = fal
     }
   };
 
-  const onKeyDown = (e) => {
+  const hasHits = () => listCount > 0;
+
+  const performSearch = async () => {
+    let response;
+    const success = await model.searchListObjectFor(TREE_PATH, value);
+    if (success && value.length && hasHits()) {
+      response = model.acceptListObjectSearch(TREE_PATH, true);
+      // eslint-disable-next-line no-param-reassign
+      selections.selectionsMade = true;
+      setValue('');
+    }
+    return response;
+  };
+
+  const onKeyDown = async (e) => {
     let response;
     switch (e.key) {
       case 'Enter':
-        // Maybe we only want to accept if isSearching is true
-        response = model.acceptListObjectSearch(TREE_PATH, true);
-        setValue('');
+        response = await performSearch();
         break;
       case 'Escape':
         response = cancel();

--- a/apis/nucleus/src/components/listbox/components/__tests__/list-box-search.inspect.jsx
+++ b/apis/nucleus/src/components/listbox/components/__tests__/list-box-search.inspect.jsx
@@ -20,7 +20,7 @@ const keyboard = { enabled: false, active: true };
 const testRender = (model) =>
   create(
     <InstanceContext.Provider value={{ translator: { get: () => 'Search' } }}>
-      <ListBoxSearch selections={selections} model={model} keyboard={keyboard} />
+      <ListBoxSearch selections={selections} model={model} listCount={10} keyboard={keyboard} />
     </InstanceContext.Provider>
   );
 
@@ -35,7 +35,7 @@ describe('<ListBoxSearch />', () => {
     keyboard.active = true;
 
     model = {
-      searchListObjectFor: jest.fn(),
+      searchListObjectFor: jest.fn().mockResolvedValue(true),
       acceptListObjectSearch: jest.fn(),
       abortListObjectSearch: jest.fn().mockResolvedValue(),
     };
@@ -64,7 +64,7 @@ describe('<ListBoxSearch />', () => {
     const testRenderer = testRender(model);
     const testInstance = testRenderer.root;
     const types = testInstance.findAllByType(OutlinedInput);
-    expect(types.length).toBe(1);
+    expect(types).toHaveLength(1);
     expect(types[0].props.fullWidth).toBe(true);
     expect(types[0].props.autoFocus).toBe(undefined);
     expect(types[0].props.placeholder).toBe('Search');
@@ -95,7 +95,7 @@ describe('<ListBoxSearch />', () => {
     testRenderer.update(
       <ThemeProvider theme={theme}>
         <InstanceContext.Provider value={{ translator: { get: () => 'Search' } }}>
-          <ListBoxSearch selections={selections} model={model} keyboard={keyboard} />
+          <ListBoxSearch selections={selections} model={model} keyboard={keyboard} listCount={1} />
         </InstanceContext.Provider>
       </ThemeProvider>
     );
@@ -104,19 +104,23 @@ describe('<ListBoxSearch />', () => {
     expect(type.props.value).toBe('foo');
   });
 
-  test('should reset `OutlinedInput` and `acceptListObjectSearch` on `Enter`', () => {
+  test('should reset `OutlinedInput` and `acceptListObjectSearch` on `Enter`', async () => {
     const testRenderer = create(
       <InstanceContext.Provider value={{ translator: { get: () => 'Search' } }}>
-        <ListBoxSearch selections={selections} model={model} keyboard={keyboard} />
+        <ListBoxSearch selections={selections} model={model} keyboard={keyboard} listCount={1} />
       </InstanceContext.Provider>
     );
     const testInstance = testRenderer.root;
     const type = testInstance.findByType(OutlinedInput);
 
-    type.props.onChange({ target: { value: 'foo' } });
+    await act(async () => {
+      await type.props.onChange({ target: { value: 'foo' } });
+    });
     expect(type.props.value).toBe('foo');
 
-    type.props.onKeyDown({ ...keyEventDefaults, key: 'Enter' });
+    await act(async () => {
+      await type.props.onKeyDown({ ...keyEventDefaults, key: 'Enter' });
+    });
     expect(model.acceptListObjectSearch).toHaveBeenCalledWith('/qListObjectDef', true);
     expect(type.props.value).toBe('');
   });
@@ -154,11 +158,11 @@ describe('<ListBoxSearch />', () => {
   test('should not render if visible is false', () => {
     const testRenderer = create(
       <InstanceContext.Provider value={{ translator: { get: () => 'Search' } }}>
-        <ListBoxSearch selections={selections} model={model} keyboard={keyboard} visible={false} />
+        <ListBoxSearch selections={selections} model={model} keyboard={keyboard} visible={false} listCount={1} />
       </InstanceContext.Provider>
     );
     const testInstance = testRenderer.root;
     const inputBoxes = testInstance.findAllByType(OutlinedInput);
-    expect(inputBoxes.length).toBe(0);
+    expect(inputBoxes).toHaveLength(0);
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Issue fixed by this PR:
- Pressing Enter in the search field when there are no matches resets the search and all values, which is not as it should work
Solution:
- Check whether there are hits before accepting them and resetting search

Also fixes a console.error due to `NaN` values in ActionsToolbar.

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
