### PR TITLE
feat: add dense as a property

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -77,7 +77,6 @@ export default function ListBox({
   fetchStart = undefined,
   postProcessPages = undefined,
   calculatePagesHeight = false,
-  dense = false,
   keyboard = {},
   showGray = true,
   scrollState,
@@ -245,6 +244,7 @@ export default function ListBox({
 
   const listCount = pages && pages.length && calculatePagesHeight ? getCalculatedHeight(pages) : count;
   onSetListCount?.(listCount);
+  const dense = layout.layoutOptions?.dense ?? false;
   const { itemSize, listHeight } = getSizeInfo({ isVertical, checkboxes, dense, height });
   const isLocked = layout && layout.qListObject.qDimensionInfo.qLocked;
   const { frequencyMax } = layout;

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -56,7 +56,6 @@ export default function ListBoxInline({ options = {} }) {
     selections,
     update = undefined,
     fetchStart = undefined,
-    dense = false,
     selectDisabled = () => false,
     postProcessPages = undefined,
     calculatePagesHeight,
@@ -162,6 +161,7 @@ export default function ListBoxInline({ options = {} }) {
   const showTitle = true;
 
   const searchVisible = (search === true || (search === 'toggle' && showSearch)) && !selectDisabled();
+  const dense = layout.layoutOptions?.dense ?? false;
   const searchHeight = dense ? 27 : 40;
   const extraheight = dense ? 39 : 49;
   const minHeight = 49 + (searchVisible ? searchHeight : 0) + extraheight;
@@ -278,7 +278,6 @@ export default function ListBoxInline({ options = {} }) {
                 fetchStart={fetchStart}
                 postProcessPages={postProcessPages}
                 calculatePagesHeight={calculatePagesHeight}
-                dense={dense}
                 selectDisabled={selectDisabled}
                 keyboard={keyboard}
                 showGray={showGray}

--- a/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
@@ -6,6 +6,16 @@ export default function useExistingModel({ app, qId, options = {} }) {
   const [modelStore] = useModelStore();
   const { sessionModel } = options;
 
+  const validateOptions = (opts) => {
+    if (opts.dense) {
+      throw new Error('Option "dense" is not avaliable when rendering existing model.');
+    }
+  };
+
+  useEffect(() => {
+    validateOptions(options);
+  }, []);
+
   useEffect(() => {
     async function fetchObject() {
       const modelFromStore = modelStore.get(qId);

--- a/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
@@ -6,15 +6,9 @@ export default function useExistingModel({ app, qId, options = {} }) {
   const [modelStore] = useModelStore();
   const { sessionModel } = options;
 
-  const validateOptions = (opts) => {
-    if (opts.dense) {
-      throw new Error('Option "dense" is not avaliable when rendering existing model.');
-    }
-  };
-
-  useEffect(() => {
-    validateOptions(options);
-  }, []);
+  if (options.dense) {
+    throw new Error('Option "dense" is not avaliable when rendering existing model.');
+  }
 
   useEffect(() => {
     async function fetchObject() {

--- a/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
@@ -7,7 +7,7 @@ export default function useExistingModel({ app, qId, options = {} }) {
   const { sessionModel } = options;
 
   if (options.dense) {
-    throw new Error('Option "dense" is not avaliable when rendering existing model.');
+    throw new Error('Option "dense" is not applicable for existing objects.');
   }
 
   useEffect(() => {

--- a/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
@@ -30,7 +30,7 @@ export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, opti
     }
   }, []);
 
-  const { title, properties = {} } = options;
+  const { title, dense, properties = {} } = options;
   let { frequencyMode, histogram = false } = options;
 
   if (fieldDef && fieldDef.failedToFetchFieldDef) {
@@ -84,6 +84,9 @@ export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, opti
           },
         ],
       },
+    },
+    layoutOptions: {
+      dense,
     },
     title,
   };

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -421,7 +421,7 @@ function nuked(configuration = {}) {
            * @param {SearchMode=} [options.search=true] Show the search bar permanently or using the toggle button: false|true|toggle|toggleShow
            * @param {boolean=} [options.toolbar=true] Show the toolbar
            * @param {boolean=} [options.checkboxes=false] Show values as checkboxes instead of as fields
-           * @param {boolean=} [options.dense=false] Reduces padding and text size (not applicable when rendering existing model).
+           * @param {boolean=} [options.dense=false] Reduces padding and text size (not applicable for existing objects).
            * @param {string=} [options.stateName="$"] Sets the state to make selections in
            * @param {object=} [options.properties={}] Properties object to extend default properties with
            *

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -421,7 +421,7 @@ function nuked(configuration = {}) {
            * @param {SearchMode=} [options.search=true] Show the search bar permanently or using the toggle button: false|true|toggle|toggleShow
            * @param {boolean=} [options.toolbar=true] Show the toolbar
            * @param {boolean=} [options.checkboxes=false] Show values as checkboxes instead of as fields
-           * @param {boolean=} [options.dense=false] Reduces padding and text size. (Not applicable when rendering existing model)
+           * @param {boolean=} [options.dense=false] Reduces padding and text size (not applicable when rendering existing model).
            * @param {string=} [options.stateName="$"] Sets the state to make selections in
            * @param {object=} [options.properties={}] Properties object to extend default properties with
            *

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -421,7 +421,7 @@ function nuked(configuration = {}) {
            * @param {SearchMode=} [options.search=true] Show the search bar permanently or using the toggle button: false|true|toggle|toggleShow
            * @param {boolean=} [options.toolbar=true] Show the toolbar
            * @param {boolean=} [options.checkboxes=false] Show values as checkboxes instead of as fields
-           * @param {boolean=} [options.dense=false] Reduces padding and text size
+           * @param {boolean=} [options.dense=false] Reduces padding and text size. (Not applicable when rendering existing model)
            * @param {string=} [options.stateName="$"] Sets the state to make selections in
            * @param {object=} [options.properties={}] Properties object to extend default properties with
            *

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -917,7 +917,7 @@
                   "type": "boolean"
                 },
                 "dense": {
-                  "description": "Reduces padding and text size",
+                  "description": "Reduces padding and text size. (Not applicable when rendering existing model)",
                   "optional": true,
                   "defaultValue": false,
                   "type": "boolean"

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -917,7 +917,7 @@
                   "type": "boolean"
                 },
                 "dense": {
-                  "description": "Reduces padding and text size (not applicable when rendering existing model).",
+                  "description": "Reduces padding and text size (not applicable for existing objects).",
                   "optional": true,
                   "defaultValue": false,
                   "type": "boolean"

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -917,7 +917,7 @@
                   "type": "boolean"
                 },
                 "dense": {
-                  "description": "Reduces padding and text size. (Not applicable when rendering existing model)",
+                  "description": "Reduces padding and text size (not applicable when rendering existing model).",
                   "optional": true,
                   "defaultValue": false,
                   "type": "boolean"


### PR DESCRIPTION
## Motivation

To be able to set the dense mode from the property panel in sense client, a dense property is added.
This way you also avoid re rendering the Listbox when toggling dense mode, compared to passing dense as an option.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
