### PR TITLE
fix: include webpack-cli

### DIFF
--- a/commands/serve/package.json
+++ b/commands/serve/package.json
@@ -43,6 +43,7 @@
     "regenerator-runtime": "0.13.10",
     "source-map-loader": "4.0.1",
     "webpack": "5.74.0",
+    "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.11.1",
     "ws": "8.10.0",
     "yargs": "17.6.0"
@@ -70,7 +71,6 @@
     "monaco-editor-webpack-plugin": "7.0.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-router-dom": "6.4.2",
-    "webpack-cli": "4.10.0"
+    "react-router-dom": "6.4.2"
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Prevent this error for missing webpack-cli by including it in dependencies along with the existing `webpack` dep (apparently `webpack-cli` is already included in `yarn.lock` but not in `package.json` since installing it did not result in any changes in `yarn.lock`):
```
webpack-cli (https://github.com/webpack/webpack-cli)

We will use "npm" to install the CLI via "npm install -D webpack-cli".
Do you want to install 'webpack-cli' (yes/no):
```

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
