### PR TITLE
feat: add checkboxes, histogram as properties

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -72,8 +72,6 @@ export default function ListBox({
   width,
   listLayout = 'vertical',
   frequencyMode,
-  histogram = false,
-  checkboxes = false,
   update = undefined,
   fetchStart = undefined,
   postProcessPages = undefined,
@@ -89,6 +87,7 @@ export default function ListBox({
   const isSingleSelect = !!(layout && layout.qListObject.qDimensionInfo.qIsOneAndOnlyOne);
   const [pages, setPages] = useState(null);
   const [isLoadingData, setIsLoadingData] = useState(false);
+  const { checkboxes, histogram } = layout ?? {};
 
   const {
     instantPages = [],

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -53,13 +53,11 @@ export default function ListBoxInline({ options = {} }) {
   const {
     direction,
     frequencyMode,
-    histogram = false,
     listLayout,
     search = true,
     focusSearch = false,
     toolbar = true,
     rangeSelect = true,
-    checkboxes = false,
     model,
     selections,
     update = undefined,
@@ -279,9 +277,7 @@ export default function ListBoxInline({ options = {} }) {
                 listLayout={listLayout}
                 onSetListCount={(c) => setListCount(c)}
                 frequencyMode={frequencyMode}
-                histogram={histogram}
                 rangeSelect={rangeSelect}
-                checkboxes={checkboxes}
                 height={height}
                 width={width}
                 update={update}

--- a/apis/nucleus/src/components/listbox/__tests__/list-box.test.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box.test.jsx
@@ -135,7 +135,6 @@ describe('<Listbox />', () => {
               width={mergedArgs.width}
               listLayout={mergedArgs.listLayout}
               update={mergedArgs.update}
-              checkboxes={mergedArgs.checkboxes}
               selectDisabled={mergedArgs.selectDisabled}
               fetchStart={mergedArgs.fetchStart}
             />
@@ -158,7 +157,6 @@ describe('<Listbox />', () => {
       expect(rows.length).toBe(1);
       expect(columns.length).toBe(0);
       expect(useSelectionsInteractions.mock.lastCall[0]).toMatchObject({
-        checkboxes: false,
         layout,
         selections,
         pages: [],
@@ -168,7 +166,6 @@ describe('<Listbox />', () => {
       expect(useSelectionsInteractions.mock.calls[1][0].selectDisabled instanceof Function).toBe(true);
       const { itemData } = FixedSizeList.mock.lastCall[0];
       expect(itemData).toMatchObject({
-        checkboxes: false,
         column: false,
         pages: [],
         isLocked: false,
@@ -184,7 +181,6 @@ describe('<Listbox />', () => {
       await render();
 
       expect(useSelectionsInteractions.mock.lastCall[0]).toMatchObject({
-        checkboxes: false,
         layout,
         selections,
         pages: [],
@@ -217,7 +213,6 @@ describe('<Listbox />', () => {
       await render();
 
       expect(useSelectionsInteractions.mock.lastCall[0]).toMatchObject({
-        checkboxes: true,
         layout,
         selections,
         pages: [],
@@ -226,7 +221,6 @@ describe('<Listbox />', () => {
 
       const { itemData } = FixedSizeList.mock.lastCall[0];
       expect(itemData).toMatchObject({
-        checkboxes: true,
         column: false,
         pages: [],
       });
@@ -237,7 +231,6 @@ describe('<Listbox />', () => {
       await render();
       const { itemData } = FixedSizeList.mock.lastCall[0];
       expect(itemData).toMatchObject({
-        checkboxes: false,
         column: true,
         pages: [],
       });

--- a/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
@@ -11,6 +11,9 @@ export default function useExistingModel({ app, qId, options = {} }) {
     frequencyMode: options.frequencyMode,
     checkboxes: options.checkboxes,
     histogram: options.histogram,
+    title: options.title,
+    stateName: options.stateName,
+    listLayout: options.listLayout,
   };
 
   let usedInvalidOption = null;

--- a/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
@@ -6,12 +6,22 @@ export default function useExistingModel({ app, qId, options = {} }) {
   const [modelStore] = useModelStore();
   const { sessionModel } = options;
 
-  if (options.dense) {
-    throw new Error('Option "dense" is not applicable for existing objects.');
-  }
+  const invalidOptions = {
+    dense: options.dense,
+    frequencyMode: options.frequencyMode,
+    checkboxes: options.checkboxes,
+    histogram: options.histogram,
+  };
 
-  if (options.frequencyMode) {
-    throw new Error('Option "frequencyMode" is not applicable for existing objects.');
+  let usedInvalidOption = null;
+  Object.entries(invalidOptions).forEach(([key, value]) => {
+    if (value) {
+      usedInvalidOption = key;
+    }
+  });
+
+  if (usedInvalidOption) {
+    throw new Error(`Option "${usedInvalidOption}" is not applicable for existing objects.`);
   }
 
   useEffect(() => {

--- a/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
@@ -8,7 +8,7 @@ export default function useExistingModel({ app, qId, options = {} }) {
 
   const forbiddenOptions = ['dense', 'frequencyMode', 'checkboxes', 'histogram', 'title', 'stateName', 'listLayout'];
   const usedOptions = Object.keys(options);
-  const usedForbiddenOptions = usedOptions.filter(Set.prototype.has, new Set(forbiddenOptions));
+  const usedForbiddenOptions = usedOptions.filter((usedOption) => forbiddenOptions.includes(usedOption));
 
   if (usedForbiddenOptions.length) {
     throw new Error(`Option "${usedForbiddenOptions.join(', ')}" is not applicable for existing objects.`);

--- a/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
@@ -6,25 +6,12 @@ export default function useExistingModel({ app, qId, options = {} }) {
   const [modelStore] = useModelStore();
   const { sessionModel } = options;
 
-  const invalidOptions = {
-    dense: options.dense,
-    frequencyMode: options.frequencyMode,
-    checkboxes: options.checkboxes,
-    histogram: options.histogram,
-    title: options.title,
-    stateName: options.stateName,
-    listLayout: options.listLayout,
-  };
+  const forbiddenOptions = ['dense', 'frequencyMode', 'checkboxes', 'histogram', 'title', 'stateName', 'listLayout'];
+  const usedOptions = Object.keys(options);
+  const usedForbiddenOptions = usedOptions.filter(Set.prototype.has, new Set(forbiddenOptions));
 
-  let usedInvalidOption = null;
-  Object.entries(invalidOptions).forEach(([key, value]) => {
-    if (value) {
-      usedInvalidOption = key;
-    }
-  });
-
-  if (usedInvalidOption) {
-    throw new Error(`Option "${usedInvalidOption}" is not applicable for existing objects.`);
+  if (usedForbiddenOptions.length) {
+    throw new Error(`Option "${usedForbiddenOptions.join(', ')}" is not applicable for existing objects.`);
   }
 
   useEffect(() => {

--- a/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
@@ -30,7 +30,7 @@ export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, opti
     }
   }, []);
 
-  const { title, dense, properties = {} } = options;
+  const { title, dense, checkboxes, properties = {} } = options;
   let { frequencyMode, histogram = false } = options;
 
   if (fieldDef && fieldDef.failedToFetchFieldDef) {
@@ -85,6 +85,8 @@ export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, opti
         ],
       },
     },
+    histogram,
+    checkboxes,
     layoutOptions: {
       dense,
     },

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -418,11 +418,11 @@ function nuked(configuration = {}) {
            * @param {Direction=} [options.direction=ltr] Direction setting ltr|rtl.
            * @param {ListLayout=} [options.listLayout=vertical] Layout direction vertical|horizontal
            * @param {FrequencyMode=} [options.frequencyMode=none] Show frequency none|value|percent|relative
-           * @param {boolean=} [options.histogram=false] Show histogram bar
+           * @param {boolean=} [options.histogram=false] Show histogram bar (not applicable for existing objects)
            * @param {SearchMode=} [options.search=true] Show the search bar permanently or using the toggle button: false|true|toggle|toggleShow
            * @param {boolean=} [options.toolbar=true] Show the toolbar
-           * @param {boolean=} [options.checkboxes=false] Show values as checkboxes instead of as fields
-           * @param {boolean=} [options.dense=false] Reduces padding and text size (not applicable for existing objects).
+           * @param {boolean=} [options.checkboxes=false] Show values as checkboxes instead of as fields (not applicable for existing objects)
+           * @param {boolean=} [options.dense=false] Reduces padding and text size (not applicable for existing objects)
            * @param {string=} [options.stateName="$"] Sets the state to make selections in
            * @param {object=} [options.properties={}] Properties object to extend default properties with
            *

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -414,16 +414,16 @@ function nuked(configuration = {}) {
            * Mounts the field as a listbox into the provided HTMLElement.
            * @param {HTMLElement} element
            * @param {object=} options Settings for the embedded listbox
-           * @param {string=} options.title Custom title, defaults to fieldname
+           * @param {string=} options.title Custom title, defaults to fieldname (not applicable for existing objects)
            * @param {Direction=} [options.direction=ltr] Direction setting ltr|rtl.
-           * @param {ListLayout=} [options.listLayout=vertical] Layout direction vertical|horizontal
+           * @param {ListLayout=} [options.listLayout=vertical] Layout direction vertical|horizontal (not applicable for existing objects)
            * @param {FrequencyMode=} [options.frequencyMode=none] Show frequency none|value|percent|relative
            * @param {boolean=} [options.histogram=false] Show histogram bar (not applicable for existing objects)
            * @param {SearchMode=} [options.search=true] Show the search bar permanently or using the toggle button: false|true|toggle|toggleShow
            * @param {boolean=} [options.toolbar=true] Show the toolbar
            * @param {boolean=} [options.checkboxes=false] Show values as checkboxes instead of as fields (not applicable for existing objects)
            * @param {boolean=} [options.dense=false] Reduces padding and text size (not applicable for existing objects)
-           * @param {string=} [options.stateName="$"] Sets the state to make selections in
+           * @param {string=} [options.stateName="$"] Sets the state to make selections in (not applicable for existing objects)
            * @param {object=} [options.properties={}] Properties object to extend default properties with
            *
            * @since 1.1.0

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -870,7 +870,7 @@
               "kind": "object",
               "entries": {
                 "title": {
-                  "description": "Custom title, defaults to fieldname",
+                  "description": "Custom title, defaults to fieldname (not applicable for existing objects)",
                   "optional": true,
                   "type": "string"
                 },
@@ -881,7 +881,7 @@
                   "type": "#/definitions/Direction"
                 },
                 "listLayout": {
-                  "description": "Layout direction vertical|horizontal",
+                  "description": "Layout direction vertical|horizontal (not applicable for existing objects)",
                   "optional": true,
                   "defaultValue": "vertical",
                   "type": "#/definitions/ListLayout"
@@ -893,7 +893,7 @@
                   "type": "#/definitions/FrequencyMode"
                 },
                 "histogram": {
-                  "description": "Show histogram bar",
+                  "description": "Show histogram bar (not applicable for existing objects)",
                   "optional": true,
                   "defaultValue": false,
                   "type": "boolean"
@@ -911,19 +911,19 @@
                   "type": "boolean"
                 },
                 "checkboxes": {
-                  "description": "Show values as checkboxes instead of as fields",
+                  "description": "Show values as checkboxes instead of as fields (not applicable for existing objects)",
                   "optional": true,
                   "defaultValue": false,
                   "type": "boolean"
                 },
                 "dense": {
-                  "description": "Reduces padding and text size (not applicable for existing objects).",
+                  "description": "Reduces padding and text size (not applicable for existing objects)",
                   "optional": true,
                   "defaultValue": false,
                   "type": "boolean"
                 },
                 "stateName": {
-                  "description": "Sets the state to make selections in",
+                  "description": "Sets the state to make selections in (not applicable for existing objects)",
                   "optional": true,
                   "defaultValue": "\"$\"",
                   "type": "string"


### PR DESCRIPTION
## Motivation
To be able to set the checkboxes and histogram from the property panel in sense client.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
