### PR TITLE
test: fixing failing integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,6 +212,11 @@ workflows:
             tags:
               only:
                 - /v.*/
+      - test-rendering:
+          filters:
+            tags:
+              only:
+                - /v.*/
       - api-governance:
           context: api-compliance
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,15 +139,6 @@ jobs:
           path: generated/barchart/screenshots
       - store_artifacts:
           path: test/mashup/__artifacts__
-
-  test-rendering:
-    working_directory: ~/project
-    docker:
-      - image: cimg/node:18.12.1
-      - image: mcr.microsoft.com/playwright:focal
-    steps:
-      - attach_workspace:
-          at: ~/project
       - run:
           name: Test rendering
           command: |
@@ -208,13 +199,6 @@ workflows:
   build-deploy:
     jobs:
       - build:
-          filters:
-            tags:
-              only:
-                - /v.*/
-      - test-rendering:
-          requires:
-            - build
           filters:
             tags:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,14 @@ jobs:
       - store_artifacts:
           path: test/mashup/__artifacts__
 
+  test-rendering:
+    working_directory: ~/project
+    docker:
+      - image: cimg/node:18.12.1
+      - image: mcr.microsoft.com/playwright:focal
+    steps:
+      - attach_workspace:
+          at: ~/project
       - run:
           name: Test rendering
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,8 @@ workflows:
               only:
                 - /v.*/
       - test-rendering:
+          requires:
+            - build
           filters:
             tags:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,6 @@ jobs:
       - run:
           name: Test integration
           command: yarn run test:integration --chrome.browserWSEndpoint "ws://localhost:3000" --no-launch
-
       - nebula_create:
           project_name: 'generated/hello'
           picasso_template: 'none'
@@ -140,6 +139,7 @@ jobs:
           path: generated/barchart/screenshots
       - store_artifacts:
           path: test/mashup/__artifacts__
+
       - run:
           name: Test rendering
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,18 +111,6 @@ jobs:
       - store_test_results:
           path: coverage/junit
       - run:
-          name: Test rendering
-          command: |
-            npx playwright install
-            sudo npx playwright install-deps
-            yarn run test:rendering
-      - store_test_results:
-          path: ./test/rendering/reports/xml/report.xml
-      - store_artifacts:
-          path: ./test/rendering
-      - store_artifacts:
-          path: ./test/rendering/reports/html
-      - run:
           name: Test component
           command: yarn run test:component --chrome.browserWSEndpoint "ws://localhost:3000" --no-launch
       - run:
@@ -152,6 +140,18 @@ jobs:
           path: generated/barchart/screenshots
       - store_artifacts:
           path: test/mashup/__artifacts__
+      - run:
+          name: Test rendering
+          command: |
+            npx playwright install
+            sudo npx playwright install-deps
+            yarn run test:rendering
+      - store_test_results:
+          path: ./test/rendering/reports/xml/report.xml
+      - store_artifacts:
+          path: ./test/rendering
+      - store_artifacts:
+          path: ./test/rendering/reports/html
 
   api-governance:
     machine:

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@babel/preset-react": "7.18.6",
     "@commitlint/cli": "17.3.0",
     "@commitlint/config-conventional": "17.3.0",
-    "@playwright/test": "1.28.1",
     "@rollup/plugin-commonjs": "23.0.3",
     "@rollup/plugin-json": "5.0.2",
     "@rollup/plugin-node-resolve": "15.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5071,14 +5071,6 @@
   dependencies:
     esquery "^1.0.1"
 
-"@playwright/test@1.28.1":
-  version "1.28.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.28.1.tgz#e5be297e024a3256610cac2baaa9347fd57c7860"
-  integrity sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==
-  dependencies:
-    "@types/node" "*"
-    playwright-core "1.28.1"
-
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.7.tgz#58f8217ba70069cc6a73f5d7e05e85b458c150e2"
@@ -17592,11 +17584,6 @@ pkg-dir@^5.0.0:
   integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
   dependencies:
     find-up "^5.0.0"
-
-playwright-core@1.28.1:
-  version "1.28.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.28.1.tgz#8400be9f4a8d1c0489abdb9e75a4cc0ffc3c00cb"
-  integrity sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==
 
 pngjs@^3.0.0, pngjs@^3.3.3:
   version "3.4.0"


### PR DESCRIPTION
## Motivation

Integration tests started to fail after rendering tests for playwright was added. Probably the playwright install part overwrites some part of the integration tests. (this was however not seen on the local CCI branch?). This PR will move the rendering tests to last in the execution order so that it hopefully does not overwrite anything.

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
