### PR TITLE
feat(listbox): listbox popover api

### DIFF
--- a/apis/nucleus/src/components/NebulaApp.jsx
+++ b/apis/nucleus/src/components/NebulaApp.jsx
@@ -23,7 +23,8 @@ const NebulaApp = forwardRef(({ initialContext, app }, ref) => {
 
   useImperativeHandle(ref, () => ({
     addComponent(component) {
-      setComponents([...components, component]);
+      const key = component.key || `${new Date().getTime()}_${Math.random().toString(36).substring(2)}`;
+      setComponents([...components, { ...component, key }]);
     },
     removeComponent(component) {
       const ix = components.indexOf(component);

--- a/apis/nucleus/src/components/listbox/ListBoxPopoverWrapper.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopoverWrapper.jsx
@@ -1,16 +1,10 @@
-import React, { useState, forwardRef, useImperativeHandle } from 'react';
+import React, { useState } from 'react';
 import ListBoxPopover from './ListBoxPopover';
 
-const ListBoxPopoverWrapper = forwardRef(({ app, fieldIdentifier, stateName, element, options = {} }, ref) => {
-  const [showState, setShowState] = useState(options.show);
-
-  useImperativeHandle(ref, () => ({
-    setShowState,
-  }));
-
+export default function ListBoxPopoverWrapper({ app, fieldIdentifier, stateName, element, options = {} }) {
+  const [showState, setShowstate] = useState(!!options.show);
   const handleCloseShowState = () => {
-    setShowState(false);
-    options.onPopoverClose && options.onPopoverClose();
+    setShowstate(false);
   };
 
   return (
@@ -23,6 +17,4 @@ const ListBoxPopoverWrapper = forwardRef(({ app, fieldIdentifier, stateName, ele
       stateName={stateName}
     />
   );
-});
-
-export default ListBoxPopoverWrapper;
+}

--- a/apis/nucleus/src/components/listbox/ListBoxPopoverWrapper.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopoverWrapper.jsx
@@ -1,0 +1,28 @@
+import React, { useState, forwardRef, useImperativeHandle } from 'react';
+import ListBoxPopover from './ListBoxPopover';
+
+const ListBoxPopoverWrapper = forwardRef(({ app, fieldIdentifier, stateName, element, options = {} }, ref) => {
+  const [showState, setShowState] = useState(options.show);
+
+  useImperativeHandle(ref, () => ({
+    setShowState,
+  }));
+
+  const handleCloseShowState = () => {
+    setShowState(false);
+    options.onPopoverClose && options.onPopoverClose();
+  };
+
+  return (
+    <ListBoxPopover
+      show={showState}
+      app={app}
+      alignTo={{ current: element }}
+      close={handleCloseShowState}
+      fieldName={fieldIdentifier}
+      stateName={stateName}
+    />
+  );
+});
+
+export default ListBoxPopoverWrapper;

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -8,7 +8,6 @@ import bootNebulaApp from './components/NebulaApp';
 import AppSelectionsPortal from './components/selections/AppSelections';
 import ListBoxPortal from './components/listbox/ListBoxPortal';
 import ListBoxPopoverWrapper from './components/listbox/ListBoxPopoverWrapper';
-import eventmixin from './selections/event-mixin';
 
 import create from './object/create-session-object';
 import get from './object/get-generic-object';
@@ -465,37 +464,7 @@ function nuked(configuration = {}) {
               this._instance = null;
             }
           },
-
-          /*
-               Create a new file for the ListboxPopover Wrapper
-               Make it a forwardRef
-               useImperativeHandle to add a show function to it
-              */
-
-          __DO_NOT_USE__: {
-            popover(anchorElement, options = { show: true }) {
-              if (!fieldSels._popoverInstance) {
-                const onPopoverClose = () => fieldSels.emit('closePopover');
-
-                fieldSels._popoverRef = React.createRef();
-                fieldSels._popoverInstance = React.createElement(ListBoxPopoverWrapper, {
-                  element: anchorElement,
-                  popover: true,
-                  ref: fieldSels._popoverRef,
-                  app,
-                  fieldIdentifier,
-                  qId,
-                  options: getOptions({ ...options, onPopoverClose }),
-                  stateName: options.stateName || '$',
-                });
-                root.add(fieldSels._popoverInstance);
-              } else {
-                fieldSels._popoverRef.current.setShowState(true);
-              }
-            },
-          },
         };
-        eventmixin(fieldSels);
         return fieldSels;
       },
       /**
@@ -515,6 +484,21 @@ function nuked(configuration = {}) {
       getRegisteredTypes: types.getList,
       __DO_NOT_USE__: {
         types,
+        popover(anchorElement, fieldIdentifier, options = { show: true }) {
+          if (api._popoverInstance) {
+            root.remove(api._popoverInstance);
+            api._popoverInstance = null;
+          }
+          api._popoverInstance = React.createElement(ListBoxPopoverWrapper, {
+            element: anchorElement,
+            popover: true,
+            app,
+            fieldIdentifier,
+            options: getOptions({ ...options }),
+            stateName: options.stateName || '$',
+          });
+          root.add(api._popoverInstance);
+        },
       },
     };
 

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -491,7 +491,6 @@ function nuked(configuration = {}) {
           }
           api._popoverInstance = React.createElement(ListBoxPopoverWrapper, {
             element: anchorElement,
-            popover: true,
             app,
             fieldIdentifier,
             options: getOptions({ ...options }),

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -1,4 +1,5 @@
 /* eslint no-underscore-dangle:0 */
+import React from 'react';
 import appLocaleFn from './locale/app-locale';
 import appThemeFn from './app-theme';
 import deviceTypeFn from './device-type';
@@ -6,6 +7,8 @@ import deviceTypeFn from './device-type';
 import bootNebulaApp from './components/NebulaApp';
 import AppSelectionsPortal from './components/selections/AppSelections';
 import ListBoxPortal from './components/listbox/ListBoxPortal';
+import ListBoxPopoverWrapper from './components/listbox/ListBoxPopoverWrapper';
+import eventmixin from './selections/event-mixin';
 
 import create from './object/create-session-object';
 import get from './object/get-generic-object';
@@ -462,7 +465,37 @@ function nuked(configuration = {}) {
               this._instance = null;
             }
           },
+
+          /*
+               Create a new file for the ListboxPopover Wrapper
+               Make it a forwardRef
+               useImperativeHandle to add a show function to it
+              */
+
+          __DO_NOT_USE__: {
+            popover(anchorElement, options = { show: true }) {
+              if (!fieldSels._popoverInstance) {
+                const onPopoverClose = () => fieldSels.emit('closePopover');
+
+                fieldSels._popoverRef = React.createRef();
+                fieldSels._popoverInstance = React.createElement(ListBoxPopoverWrapper, {
+                  element: anchorElement,
+                  popover: true,
+                  ref: fieldSels._popoverRef,
+                  app,
+                  fieldIdentifier,
+                  qId,
+                  options: getOptions({ ...options, onPopoverClose }),
+                  stateName: options.stateName || '$',
+                });
+                root.add(fieldSels._popoverInstance);
+              } else {
+                fieldSels._popoverRef.current.setShowState(true);
+              }
+            },
+          },
         };
+        eventmixin(fieldSels);
         return fieldSels;
       },
       /**


### PR DESCRIPTION
## Motivation
This is a follow up PR based on #1053 and then #1062 (they should be close by now)

@Caele  has come up with a better solution for exposing popover version of Listbox under `__DO_NOT_USE__` key of nebula embed API. 

The reason for putting it behind doNotUse was inconsistency + changes for now, but soon in future versions, it will be reconsidered. 

Also after testing this API in integration with sn-table, we've noticed one extra re-render which the root of that issue was not having a proper key in each component that nebula renders. So that one was also fixed by adding a string combo of `component creation timestamp + random string` and assigning to the components that don't have a key.

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
