### PR TITLE
fix: listbox more menu is broken

### DIFF
--- a/apis/nucleus/src/components/ActionsToolbar.jsx
+++ b/apis/nucleus/src/components/ActionsToolbar.jsx
@@ -115,8 +115,7 @@ function ActionsToolbar({
 
   const { translator, keyboardNavigation } = useContext(InstanceContext);
   const [showMoreItems, setShowMoreItems] = useState(false);
-  const [moreEnabled, setMoreEnabled] = useState(more.enabled);
-  const [moreActions, setMoreActions] = useState([]);
+
   const moreRef = useRef();
   const actionsRef = useRef();
   const theme = useTheme();
@@ -130,10 +129,6 @@ function ActionsToolbar({
   };
 
   useEffect(() => () => setShowMoreItems(false), [popover.show]);
-
-  useEffect(() => {
-    setMoreEnabled(more.enabled);
-  }, [more.enabled]);
 
   useEffect(() => {
     if (!focusHandler) return;
@@ -150,18 +145,14 @@ function ActionsToolbar({
     focusHandler.on('focus_toolbar_last', focusLast);
   }, []);
 
-  useEffect(() => {
-    const newActions = actions.filter((a) => !a.hidden);
-    if (newActions.length > maxItems) {
-      const newMoreActions = newActions.splice(-(newActions.length - maxItems) - 1);
-      setMoreEnabled(true);
-      setMoreActions([...newMoreActions, ...more.actions]);
-    } else {
-      setMoreActions(more.actions);
-    }
-  }, [actions, more.actions]);
-
-  const newActions = useMemo(() => actions.filter((a) => !a.hidden), [actions]);
+  let moreEnabled = more.enabled;
+  let moreActions = more.actions;
+  const newActions = actions.filter((a) => !a.hidden);
+  if (newActions.length > maxItems) {
+    const newMoreActions = newActions.splice(-(newActions.length - maxItems) - 1);
+    moreEnabled = true;
+    moreActions = [...newMoreActions, ...more.actions];
+  }
 
   if (!selections.show && newActions.length === 0) return null;
 

--- a/apis/nucleus/src/components/ActionsToolbar.jsx
+++ b/apis/nucleus/src/components/ActionsToolbar.jsx
@@ -116,7 +116,7 @@ function ActionsToolbar({
   const { translator, keyboardNavigation } = useContext(InstanceContext);
   const [showMoreItems, setShowMoreItems] = useState(false);
   const [moreEnabled, setMoreEnabled] = useState(more.enabled);
-  const [moreActions, setMoreActions] = useState(more.actions);
+  const [moreActions, setMoreActions] = useState([]);
   const moreRef = useRef();
   const actionsRef = useRef();
   const theme = useTheme();
@@ -150,6 +150,17 @@ function ActionsToolbar({
     focusHandler.on('focus_toolbar_last', focusLast);
   }, []);
 
+  useEffect(() => {
+    const newActions = actions.filter((a) => !a.hidden);
+    if (newActions.length > maxItems) {
+      const newMoreActions = newActions.splice(-(newActions.length - maxItems) - 1);
+      setMoreEnabled(true);
+      setMoreActions([...newMoreActions, ...more.actions]);
+    } else {
+      setMoreActions(more.actions);
+    }
+  }, [actions, more.actions]);
+
   const newActions = useMemo(() => actions.filter((a) => !a.hidden), [actions]);
 
   if (!selections.show && newActions.length === 0) return null;
@@ -167,12 +178,6 @@ function ActionsToolbar({
     enabled: () => moreEnabled,
     action: () => setShowMoreItems(!showMoreItems),
   };
-
-  if (newActions.length > maxItems) {
-    const newMoreActions = newActions.splice(-(newActions.length - maxItems) - 1);
-    setMoreEnabled(true);
-    setMoreActions([...newMoreActions, ...more.actions]);
-  }
 
   const tabCallback =
     // if keyboardNavigation is true, create a callback to handle tabbing from the first/last button in the toolbar that resets focus on the content

--- a/apis/nucleus/src/components/ActionsToolbarMore.jsx
+++ b/apis/nucleus/src/components/ActionsToolbarMore.jsx
@@ -10,6 +10,10 @@ import useActionState from '../hooks/useActionState';
 
 const PREFIX = 'More';
 
+const ActionsToolbarMoreElement = {
+  className: 'njs-action-toolbar-more',
+};
+
 const classes = {
   icon: `${PREFIX}-icon`,
 };
@@ -51,10 +55,12 @@ const More = React.forwardRef(
           ref={ref}
           open={show}
           anchorEl={alignTo.current}
-          getContentAnchorEl={null}
-          hideBackdrop
-          style={{ pointerEvents: 'none' }}
           transitionDuration={0}
+          slotProps={{
+            root: {
+              className: ActionsToolbarMoreElement.className,
+            },
+          }}
           anchorOrigin={{
             vertical: 'bottom',
             horizontal: 'left',

--- a/apis/nucleus/src/components/listbox/ListBoxPortal.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPortal.jsx
@@ -73,7 +73,7 @@ function ListBoxWrapper({ app, fieldIdentifier, qId, stateName, element, options
 
   const selections = hasExternalSelectionsApi
     ? options.selectionsApi
-    : useObjectSelections(app, model, elementRef, options)[0];
+    : useObjectSelections(app, model, [elementRef, '.njs-action-toolbar-more'], options)[0];
 
   if (!selections || !model) {
     return null;

--- a/apis/nucleus/src/components/listbox/__tests__/list-box-portal.test.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box-portal.test.jsx
@@ -109,7 +109,12 @@ describe('ListBoxPortal', () => {
       };
       const elem = ListBoxPortal({ app, fieldIdentifier, options });
       await render(elem);
-      expect(useObjectSelectionsMock).toHaveBeenCalledWith(app, options.sessionModel, elementRef, options);
+      expect(useObjectSelectionsMock).toHaveBeenCalledWith(
+        app,
+        options.sessionModel,
+        [elementRef, '.njs-action-toolbar-more'],
+        options
+      );
     });
   });
 

--- a/apis/nucleus/src/hooks/useObjectSelections.js
+++ b/apis/nucleus/src/hooks/useObjectSelections.js
@@ -186,11 +186,11 @@ const getClickOutFuncs = ({ elements, objectSelections, options }) => {
   return {
     activateClickOut() {
       document.addEventListener('mousedown', handler);
-      options.onSelectionActivated?.();
+      options?.onSelectionActivated?.();
     },
     deactivateClickOut() {
       document.removeEventListener('mousedown', handler);
-      options.onSelectionDeactivated?.();
+      options?.onSelectionDeactivated?.();
     },
   };
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -129,6 +129,7 @@ const config = ({ format = 'umd', debug = false, file, targetPkg }) => {
       json(),
       commonjs(),
       babel({
+        babelHelpers: 'bundled',
         babelrc: false,
         include: [
           '/**/apis/conversion/**',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

The ... more button in the listbox had broken due to mainly this: https://github.com/qlik-oss/nebula.js/pull/1048/files#diff-bc6a3f095f62f60275871e29a5ac5d22566f2dada32f3e17b897fab53052cdecL56
I also noticed that the contents of it ("select alternatives" etc) wasn't correct, it only used the initial state of the layout. Tried a lot of things to see what was actually wrong, but in the end I just refactored how it sets the actionItems.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
