### PR TITLE
chore: move more popover back into container

### DIFF
--- a/apis/nucleus/src/components/ActionsToolbar.jsx
+++ b/apis/nucleus/src/components/ActionsToolbar.jsx
@@ -128,7 +128,12 @@ function ActionsToolbar({
     return buttons[last ? buttons.length - 1 : 0];
   };
 
-  useEffect(() => () => setShowMoreItems(false), [popover.show]);
+  useEffect(
+    () => () => {
+      setShowMoreItems(false);
+    },
+    [popover.show, show, selections.show]
+  );
 
   useEffect(() => {
     if (!focusHandler) return;
@@ -147,7 +152,7 @@ function ActionsToolbar({
 
   let moreEnabled = more.enabled;
   let moreActions = more.actions;
-  const moreAlignTo = more.alignTo;
+  const moreAlignTo = more.alignTo || moreRef;
   const newActions = actions.filter((a) => !a.hidden);
   if (newActions.length > maxItems) {
     const newMoreActions = newActions.splice(-(newActions.length - maxItems) - 1);

--- a/apis/nucleus/src/components/ActionsToolbar.jsx
+++ b/apis/nucleus/src/components/ActionsToolbar.jsx
@@ -147,6 +147,7 @@ function ActionsToolbar({
 
   let moreEnabled = more.enabled;
   let moreActions = more.actions;
+  const moreAlignTo = more.alignTo;
   const newActions = actions.filter((a) => !a.hidden);
   if (newActions.length > maxItems) {
     const newMoreActions = newActions.splice(-(newActions.length - maxItems) - 1);
@@ -212,7 +213,7 @@ function ActionsToolbar({
         <More
           show={showMoreItems}
           actions={moreActions}
-          alignTo={moreRef}
+          alignTo={moreAlignTo}
           popoverProps={more.popoverProps}
           popoverPaperStyle={more.popoverPaperStyle}
           onCloseOrActionClick={handleCloseShowMoreItems}

--- a/apis/nucleus/src/components/ActionsToolbarMore.jsx
+++ b/apis/nucleus/src/components/ActionsToolbarMore.jsx
@@ -55,6 +55,11 @@ const More = React.forwardRef(
           ref={ref}
           open={show}
           anchorEl={alignTo.current}
+          getContentAnchorEl={null}
+          container={alignTo.current}
+          disablePortal
+          hideBackdrop
+          style={{ pointerEvents: 'none' }}
           transitionDuration={0}
           slotProps={{
             root: {
@@ -63,11 +68,11 @@ const More = React.forwardRef(
           }}
           anchorOrigin={{
             vertical: 'bottom',
-            horizontal: 'left',
+            horizontal: 'right',
           }}
           transformOrigin={{
             vertical: 'top',
-            horizontal: 'left',
+            horizontal: 'right',
           }}
           PaperProps={{
             style: {

--- a/apis/nucleus/src/components/ActionsToolbarMore.jsx
+++ b/apis/nucleus/src/components/ActionsToolbarMore.jsx
@@ -19,6 +19,8 @@ const classes = {
 };
 
 const StyledPopover = styled(Popover)(({ theme }) => ({
+  // Set here to allow clicking through the modals container
+  pointerEvents: 'none',
   [`& .${classes.icon}`]: {
     color: theme.palette.text.primary,
   },
@@ -59,7 +61,6 @@ const More = React.forwardRef(
           container={alignTo.current}
           disablePortal
           hideBackdrop
-          style={{ pointerEvents: 'none' }}
           transitionDuration={0}
           slotProps={{
             root: {

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -238,6 +238,7 @@ export default function ListBoxInline({ options = {} }) {
         role="region"
         aria-label={translator.get('Listbox.ResultFilterLabel')}
       >
+        <div ref={moreAlignTo} />
         <Grid item ref={searchContainerRef}>
           <div className={classes.screenReaderOnly}>{translator.get('Listbox.Search.ScreenReaderInstructions')}</div>
           <ListBoxSearch
@@ -252,7 +253,6 @@ export default function ListBoxInline({ options = {} }) {
           />
         </Grid>
         <Grid item xs>
-          <div ref={moreAlignTo} />
           <div className={classes.screenReaderOnly}>{translator.get('Listbox.ScreenReaderInstructions')}</div>
           <AutoSizer>
             {({ height, width }) => (


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

To get the look'n'feel back to previous iteration and tidy up the code.
Looks like this now:
<img width="311" alt="image" src="https://user-images.githubusercontent.com/6318307/221904541-3040f068-47d1-4ba8-b30d-5647e5d70465.png">
<img width="383" alt="image" src="https://user-images.githubusercontent.com/6318307/221904606-3b127181-08cf-44b1-900b-8cd80c81f7d3.png">
<img width="435" alt="image" src="https://user-images.githubusercontent.com/6318307/221906527-3464612f-2a68-4a0b-8930-79b024e7d644.png">

 Previously:
<img width="454" alt="image" src="https://user-images.githubusercontent.com/6318307/221908231-9fbcc42c-a6af-4841-94e8-ea87730f3bae.png">

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
