### PR TITLE
feat: hide search button on edit mode

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -82,7 +82,7 @@ export default function ListBoxInline({ options = {} }) {
     model.unlock('/qListObjectDef');
   }, [model]);
 
-  const { translator, keyboardNavigation, themeApi } = useContext(InstanceContext);
+  const { translator, keyboardNavigation, themeApi, constraints } = useContext(InstanceContext);
   theme.listBox = addListboxTheme(themeApi);
 
   const moreAlignTo = useRef();
@@ -173,6 +173,8 @@ export default function ListBoxInline({ options = {} }) {
     setShowSearch(newValue);
   };
 
+  const hideSearch = searchEnabled !== false && constraints.passive && constraints.active && !constraints.select;
+
   return (
     <StyledGrid
       className="listbox-container"
@@ -191,7 +193,7 @@ export default function ListBoxInline({ options = {} }) {
                 <Lock title={translator.get('Listbox.Unlock')} style={{ fontSize: '12px' }} />
               </IconButton>
             ) : (
-              searchEnabled !== false && (
+              !hideSearch && (
                 <IconButton onClick={onShowSearch} tabIndex={-1} title={translator.get('Listbox.Search')} size="large">
                   <SearchIcon style={{ fontSize: '12px' }} />
                 </IconButton>

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -173,7 +173,7 @@ export default function ListBoxInline({ options = {} }) {
     setShowSearch(newValue);
   };
 
-  const hideSearch = searchEnabled !== false && constraints.passive && constraints.active && !constraints.select;
+  const allowSearch = searchEnabled !== false && !(constraints.passive && constraints.active && !constraints.select);
 
   return (
     <StyledGrid
@@ -193,7 +193,7 @@ export default function ListBoxInline({ options = {} }) {
                 <Lock title={translator.get('Listbox.Unlock')} style={{ fontSize: '12px' }} />
               </IconButton>
             ) : (
-              !hideSearch && (
+              allowSearch && (
                 <IconButton onClick={onShowSearch} tabIndex={-1} title={translator.get('Listbox.Search')} size="large">
                   <SearchIcon style={{ fontSize: '12px' }} />
                 </IconButton>


### PR DESCRIPTION
## Motivation
Like for the existing filter pane, hide the search button when on edit mode.


<img width="209" alt="Screenshot 2023-03-02 at 16 28 08" src="https://user-images.githubusercontent.com/13185716/222472947-e4990255-0371-4968-a4a9-235ed45b09e4.png">


## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
