### PR TITLE
fix: do not show Search box on selection when there is no title

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -159,7 +159,8 @@ export default function ListBoxInline({ options = {} }) {
     : [];
 
   const showTitle = true;
-  const shouldShowSearch = ((search === 'toggle' || (search === 'inSelection' && (!layout.title || !toolbar))) && showSearch);
+  const shouldShowSearch =
+    (search === 'toggle' || (search === 'inSelection' && (!layout.title || !toolbar))) && showSearch;
   const searchVisible = (search === true || shouldShowSearch) && !selectDisabled();
   const dense = layout.layoutOptions?.dense ?? false;
   const searchHeight = dense ? 27 : 40;

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -159,9 +159,8 @@ export default function ListBoxInline({ options = {} }) {
     : [];
 
   const showTitle = true;
-
-  const searchVisible =
-    (search === true || ((search === 'toggle' || (search === 'inSelection' && !layout.title)) && showSearch)) && !selectDisabled();
+  const shouldShowSearch = ((search === 'toggle' || (search === 'inSelection' && !layout.title)) && showSearch);
+  const searchVisible = (search === true || shouldShowSearch) && !selectDisabled();
   const dense = layout.layoutOptions?.dense ?? false;
   const searchHeight = dense ? 27 : 40;
   const extraheight = dense ? 39 : 49;

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -161,7 +161,7 @@ export default function ListBoxInline({ options = {} }) {
   const showTitle = true;
 
   const searchVisible =
-    (search === true || ((search === 'toggle' || search === 'inSelection') && showSearch)) && !selectDisabled();
+    (search === true || ((search === 'toggle' || (search === 'inSelection' && !layout.title)) && showSearch)) && !selectDisabled();
   const dense = layout.layoutOptions?.dense ?? false;
   const searchHeight = dense ? 27 : 40;
   const extraheight = dense ? 39 : 49;

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -159,7 +159,7 @@ export default function ListBoxInline({ options = {} }) {
     : [];
 
   const showTitle = true;
-  const shouldShowSearch = ((search === 'toggle' || (search === 'inSelection' && !layout.title)) && showSearch);
+  const shouldShowSearch = ((search === 'toggle' || (search === 'inSelection' && (!layout.title || !toolbar))) && showSearch);
   const searchVisible = (search === true || shouldShowSearch) && !selectDisabled();
   const dense = layout.layoutOptions?.dense ?? false;
   const searchHeight = dense ? 27 : 40;


### PR DESCRIPTION
To fix https://github.com/qlik-oss/sn-list-objects/issues/103 by checking selection state and layout.title.