### PR TITLE
feat(Listbox): remove inSelection search option

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -122,7 +122,7 @@ export default function ListBoxInline({ options = {} }) {
   };
 
   if (layout?.toolbar !== undefined) {
-    toolbar = layout?.toolbar;
+    toolbar = layout.toolbar;
   }
   toolbar = toolbar && layout?.title !== '';
 

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -122,19 +122,20 @@ export default function ListBoxInline({ options = {} }) {
   };
 
   if (layout?.toolbar !== undefined) {
-    toolbar = layout.toolbar;
+    toolbar = layout?.toolbar;
   }
+  toolbar = toolbar && layout?.title !== '';
 
   useEffect(() => {
     const show = () => {
       setShowToolbar(true);
-      if (search === 'inSelection') {
+      if (search === 'toggle' && toolbar === false) {
         setShowSearch(true);
       }
     };
     const hide = () => {
       setShowToolbar(false);
-      if (search === 'toggle' || search === 'inSelection') {
+      if (search === 'toggle') {
         setShowSearch(false);
       }
     };
@@ -151,7 +152,7 @@ export default function ListBoxInline({ options = {} }) {
         selections.removeListener('activated', hide);
       }
     };
-  }, [selections]);
+  }, [selections, toolbar]);
 
   useEffect(() => {
     if (!searchContainer || !searchContainer.current) {
@@ -179,9 +180,8 @@ export default function ListBoxInline({ options = {} }) {
     : [];
 
   const showTitle = true;
-  const shouldShowSearch =
-    (search === 'toggle' || (search === 'inSelection' && (!layout.title || !toolbar))) && showSearch;
-  const searchVisible = (search === true || shouldShowSearch) && !selectDisabled();
+  const showSearchToggle = search === 'toggle' && showSearch;
+  const searchVisible = (search === true || showSearchToggle) && !selectDisabled();
   const dense = layout.layoutOptions?.dense ?? false;
   const searchHeight = dense ? 27 : 40;
   const extraheight = dense ? 39 : 49;
@@ -206,7 +206,7 @@ export default function ListBoxInline({ options = {} }) {
       onMouseLeave={handleOnMouseLeave}
       ref={containerRef}
     >
-      {toolbar && layout.title && (
+      {toolbar && (
         <Grid item container style={{ padding: theme.spacing(1) }} wrap="nowrap">
           <Grid item container wrap="nowrap">
             <Grid item sx={{ display: 'flex', alignItems: 'center', width: searchIconWidth }}>

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -394,7 +394,7 @@ function nuked(configuration = {}) {
          */
 
         /**
-         * @typedef { boolean | 'toggle' | 'inSelection' } SearchMode
+         * @typedef { boolean | 'toggle' } SearchMode
          */
 
         /**
@@ -440,7 +440,7 @@ function nuked(configuration = {}) {
            * @param {ListLayout=} [options.listLayout=vertical] Layout direction vertical|horizontal (not applicable for existing objects)
            * @param {FrequencyMode=} [options.frequencyMode=none] Show frequency none|value|percent|relative
            * @param {boolean=} [options.histogram=false] Show histogram bar (not applicable for existing objects)
-           * @param {SearchMode=} [options.search=true] Show the search bar permanently, using the toggle button or when in selection: false|true|toggle|inSelection
+           * @param {SearchMode=} [options.search=true] Show the search bar permanently, using the toggle button or when in selection: false|true|toggle
            * @param {boolean=} [options.toolbar=true] Show the toolbar
            * @param {boolean=} [options.checkboxes=false] Show values as checkboxes instead of as fields (not applicable for existing objects)
            * @param {boolean=} [options.dense=false] Reduces padding and text size (not applicable for existing objects)

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -877,10 +877,6 @@
           {
             "kind": "literal",
             "value": "'toggle'"
-          },
-          {
-            "kind": "literal",
-            "value": "'inSelection'"
           }
         ]
       }
@@ -995,7 +991,7 @@
                   "type": "boolean"
                 },
                 "search": {
-                  "description": "Show the search bar permanently, using the toggle button or when in selection: false|true|toggle|inSelection",
+                  "description": "Show the search bar permanently, using the toggle button or when in selection: false|true|toggle",
                   "optional": true,
                   "defaultValue": true,
                   "type": "#/definitions/SearchMode"

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -266,7 +266,7 @@ declare namespace stardust {
 
     type FrequencyMode = "none" | "value" | "percent" | "relative";
 
-    type SearchMode = boolean | "toggle" | "inSelection";
+    type SearchMode = boolean | "toggle";
 
     type FieldEventTypes = "selectionActivated" | "selectionDeactivated";
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

When using search option toggle and the toolbar is hidden, show the search input when entering selection.
This will make the search option `'inSelection'` obsolete.

![Kapture 2023-03-06 at 15 25 19](https://user-images.githubusercontent.com/99665802/223140836-35e3552d-a8ee-40af-9aa7-1c49b55cd0f0.gif)


## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
