### PR TITLE
fix(Listbox): use fallback title

### DIFF
--- a/apis/nucleus/src/components/listbox/hooks/__tests__/useOnTheFlyModel.test.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/__tests__/useOnTheFlyModel.test.jsx
@@ -76,6 +76,17 @@ describe('useExistingModel', () => {
       await render(useOnTheFlyModel, { app, fieldIdentifier, stateName: '$', options });
       expect(useSessionModel.mock.lastCall[0].qListObjectDef.qFrequencyMode).toBe('V');
     });
+    test('should use title from fieldIdentifier', async () => {
+      const fieldIdentifier = 'Alpha';
+      await render(useOnTheFlyModel, { app, fieldIdentifier, stateName: '$' });
+      expect(useSessionModel.mock.lastCall[0].title).toBe('Alpha');
+    });
+    test('should use title from options if provided', async () => {
+      const options = { title: 'Options title' };
+      const fieldIdentifier = 'Alpha';
+      await render(useOnTheFlyModel, { app, fieldIdentifier, stateName: '$', options });
+      expect(useSessionModel.mock.lastCall[0].title).toBe('Options title');
+    });
   });
 
   describe('on the fly library dimension', () => {
@@ -90,6 +101,23 @@ describe('useExistingModel', () => {
       await render(useOnTheFlyModel, { app, fieldIdentifier, stateName: '$', options });
       expect(app.getDimension).toHaveBeenCalledTimes(1);
       expect(useSessionModel.mock.lastCall[0].frequencyMax.qValueExpression.includes('Volume')).toBe(true);
+    });
+    test('should use title from qDim', async () => {
+      const fieldIdentifier = { qLibraryId: '123' };
+      const fakeDimLayout = { qDim: { qFieldDefs: ['Volume'], title: 'Volume title' } };
+      app.getDimension = jest.fn().mockReturnValue({ getLayout: async () => fakeDimLayout });
+
+      await render(useOnTheFlyModel, { app, fieldIdentifier, stateName: '$' });
+      expect(useSessionModel.mock.lastCall[0].title).toBe('Volume title');
+    });
+    test('should use title from options if provided', async () => {
+      const options = { title: 'Options title' };
+      const fieldIdentifier = { qLibraryId: '123' };
+      const fakeDimLayout = { qDim: { qFieldDefs: ['Volume'], title: 'Volume title' } };
+      app.getDimension = jest.fn().mockReturnValue({ getLayout: async () => fakeDimLayout });
+
+      await render(useOnTheFlyModel, { app, fieldIdentifier, stateName: '$', options });
+      expect(useSessionModel.mock.lastCall[0].title).toBe('Options title');
     });
   });
 });

--- a/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
@@ -6,12 +6,17 @@ export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, opti
   const [fieldDef, setFieldDef] = useState('');
   const [isFetching, setIsFetching] = useState(true);
   const [model, setModel] = useState();
+  const [title, setTitle] = useState(options.title);
+  const setFallbackTitle = (fallbackTitle) => {
+    setTitle((currentTitle) => currentTitle ?? fallbackTitle);
+  };
 
   useEffect(() => {
     async function fetchMasterItem() {
       try {
         const dim = await app.getDimension(fieldIdentifier.qLibraryId);
         const dimLayout = await dim.getLayout();
+        setFallbackTitle(dimLayout.qDim.title);
         setFieldDef(dimLayout.qDim.qFieldDefs ? dimLayout.qDim.qFieldDefs[0] : '');
         setIsFetching(false);
       } catch (e) {
@@ -27,10 +32,11 @@ export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, opti
       fetchMasterItem();
     } else {
       setIsFetching(false);
+      setFallbackTitle(fieldIdentifier);
     }
   }, []);
 
-  const { title, dense, checkboxes, properties = {} } = options;
+  const { dense, checkboxes, properties = {} } = options;
   let { frequencyMode, histogram = false } = options;
 
   if (fieldDef && fieldDef.failedToFetchFieldDef) {

--- a/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
@@ -6,10 +6,8 @@ export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, opti
   const [fieldDef, setFieldDef] = useState('');
   const [isFetching, setIsFetching] = useState(true);
   const [model, setModel] = useState();
-  const [title, setTitle] = useState(options.title);
-  const setFallbackTitle = (fallbackTitle) => {
-    setTitle((currentTitle) => currentTitle ?? fallbackTitle);
-  };
+  const [fallbackTitle, setFallbackTitle] = useState();
+  const title = options.title ?? fallbackTitle;
 
   useEffect(() => {
     async function fetchMasterItem() {


### PR DESCRIPTION
## Motivation

When rendering a Listbox on the fly (`embed.field(…).mount()`) and no title is provided in options.
Set a default title.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
