### PR TITLE
fix: assign id to all session listboxes

### DIFF
--- a/apis/nucleus/src/components/listbox/hooks/__tests__/useOnTheFlyModel.test.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/__tests__/useOnTheFlyModel.test.jsx
@@ -49,13 +49,22 @@ describe('useExistingModel', () => {
   });
 
   describe('from field name', () => {
-    test('should use provided frequencyMode', async () => {
+    test('should assign qID', async () => {
       const options = {
         frequencyMode: 'value',
       };
       const fieldIdentifier = 'Alpha';
       await render(useOnTheFlyModel, { app, fieldIdentifier, stateName: '$', options });
       expect(useSessionModel.mock.lastCall[0].qListObjectDef.qFrequencyMode).toBe('V');
+    });
+
+    test('should use provided frequencyMode', async () => {
+      const options = {
+        frequencyMode: 'value',
+      };
+      const fieldIdentifier = 'Alpha';
+      await render(useOnTheFlyModel, { app, fieldIdentifier, stateName: '$', options });
+      expect(useSessionModel.mock.lastCall[0].qInfo.qId).toBeDefined();
     });
 
     test('should default to none if provided frequencyMode is invalid', async () => {

--- a/apis/nucleus/src/components/listbox/hooks/__tests__/useOnTheFlyModel.test.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/__tests__/useOnTheFlyModel.test.jsx
@@ -49,7 +49,7 @@ describe('useExistingModel', () => {
   });
 
   describe('from field name', () => {
-    test('should assign qID', async () => {
+    test('should use provided frequencyMode', async () => {
       const options = {
         frequencyMode: 'value',
       };
@@ -58,7 +58,7 @@ describe('useExistingModel', () => {
       expect(useSessionModel.mock.lastCall[0].qListObjectDef.qFrequencyMode).toBe('V');
     });
 
-    test('should use provided frequencyMode', async () => {
+    test('should assign qID', async () => {
       const options = {
         frequencyMode: 'value',
       };

--- a/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import extend from 'extend';
 import useSessionModel from '../../../hooks/useSessionModel';
 import uid from '../../../object/uid';
@@ -59,10 +59,15 @@ export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, opti
 
   const getListdefFrequencyMode = () => (histogram && frequencyMode === 'N' ? 'V' : frequencyMode);
 
+  const id = useRef();
+  if (!id.current) {
+    id.current = uid();
+  }
+
   const listdef = {
     qInfo: {
       qType: 'njsListbox',
-      qId: uid(),
+      qId: id.current,
     },
     qListObjectDef: {
       qStateName: stateName,

--- a/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import extend from 'extend';
 import useSessionModel from '../../../hooks/useSessionModel';
+import uid from '../../../object/uid';
 
 export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, options = {} }) {
   const [fieldDef, setFieldDef] = useState('');
@@ -61,6 +62,7 @@ export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, opti
   const listdef = {
     qInfo: {
       qType: 'njsListbox',
+      qId: uid(),
     },
     qListObjectDef: {
       qStateName: stateName,


### PR DESCRIPTION

## Motivation

When mounting multiple listboxes in the same mashup and using the exact same definition, they will also share a model -> meaning they also share the modal selection state.
They should get unique IDs.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
