### PR TITLE
fix: remove broken unused parts of appSelections

### DIFF
--- a/apis/nucleus/src/hooks/__tests__/use-app-selections.test.jsx
+++ b/apis/nucleus/src/hooks/__tests__/use-app-selections.test.jsx
@@ -106,13 +106,6 @@ describe('useAppSelections', () => {
     jest.resetAllMocks();
   });
 
-  test('returns current selections layout', async () => {
-    await render();
-
-    const res = await ref.current.result[0].layout();
-    expect(res).toEqual(currentSelectionsLayout);
-  });
-
   test('should create app selections', async () => {
     await render();
     expect(ref.current.result[0]).toEqual(appSel);
@@ -155,26 +148,6 @@ describe('useAppSelections', () => {
     expect(ref.current.result[0].isModal(obj)).toBe(true);
     expect(ref.current.result[0].isModal({})).toBe(false);
     expect(ref.current.result[0].isModal()).toBe(true);
-  });
-
-  test('can go forward', async () => {
-    await render();
-
-    const res = await ref.current.result[0].canGoForward();
-    expect(res).toBe(true);
-  });
-
-  test('can go back', async () => {
-    await render();
-    const res = await ref.current.result[0].canGoBack();
-    expect(res).toBe(true);
-  });
-
-  test('can clear', async () => {
-    await render();
-
-    const res = await ref.current.result[0].canClear();
-    expect(res).toBe(true);
   });
 
   test('forward', async () => {

--- a/apis/nucleus/src/hooks/useAppSelections.js
+++ b/apis/nucleus/src/hooks/useAppSelections.js
@@ -1,6 +1,5 @@
 /* eslint no-underscore-dangle: 0 */
 import { useEffect } from 'react';
-import useAppSelectionsNavigation from './useAppSelectionsNavigation';
 import {
   useAppSelectionsStore,
   objectSelectionsStore,
@@ -8,7 +7,7 @@ import {
   appModalStore,
 } from '../stores/selections-store';
 
-function createAppSelections({ app, currentSelectionsLayout, navState }) {
+function createAppSelections({ app }) {
   const key = `${app.id}`;
 
   const end = async (accept = true) => {
@@ -70,18 +69,6 @@ function createAppSelections({ app, currentSelectionsLayout, navState }) {
       // TODO check model state
       return object ? modalObjectStore.get(key) === object : !!modalObjectStore.get(key);
     },
-    canGoForward() {
-      return navState.canGoForward;
-    },
-    canGoBack() {
-      return navState.canGoBack;
-    },
-    canClear() {
-      return navState.canClear;
-    },
-    layout() {
-      return currentSelectionsLayout;
-    },
     forward() {
       return appModal.end().then(() => app.forward());
     },
@@ -102,17 +89,16 @@ export default function useAppSelections(app) {
     // assume the app is mocked if session is undefined
     return [];
   }
-  const [navState, currentSelectionsModel, currentSelectionsLayout] = useAppSelectionsNavigation(app);
   const [appSelectionsStore] = useAppSelectionsStore();
   const key = app ? app.id : null;
   let appSelections = appSelectionsStore.get(key);
 
   useEffect(() => {
-    if (!app || !currentSelectionsModel || !currentSelectionsLayout || !navState || appSelections) return;
-    appSelections = createAppSelections({ app, currentSelectionsLayout, navState });
+    if (!app || appSelections) return;
+    appSelections = createAppSelections({ app });
     appSelectionsStore.set(key, appSelections);
     appSelectionsStore.dispatch(true);
-  }, [app, currentSelectionsModel, currentSelectionsLayout, navState]);
+  }, [app]);
 
-  return [appSelections, navState];
+  return [appSelections];
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

removed to not have react compoents using useAppSelections update on any change in selection
to get the extra information use useAppSelectionsNavigation instead of useAppSelections

from what I can see not be a part of the exposed api
https://github.com/qlik-oss/nebula.js/blob/02441143b8a16475009eabd7f496163042ca98dc/apis/nucleus/src/index.js#L330

found when investigated listbox performance.
see qlik-oss/sn-list-objects#105
fix one source of extra updates but do not have any impact by itself

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
