### PR TITLE
fix: no re-render of inline listbox from extra useLayout updates

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -1,7 +1,6 @@
 /* eslint no-underscore-dangle:0 */
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import InfiniteLoader from 'react-window-infinite-loader';
-import useLayout from '../../hooks/useLayout';
 import useSelectionsInteractions from './hooks/selections/useSelectionsInteractions';
 import getListBoxComponents from './components/grid-list-components/grid-list-components';
 import getListSizes from './assets/get-list-sizes';
@@ -19,6 +18,7 @@ const DEFAULT_MIN_BATCH_SIZE = 100;
 
 export default function ListBox({
   model,
+  layout,
   selections,
   direction,
   checkboxes: checkboxOption,
@@ -38,7 +38,6 @@ export default function ListBox({
   currentScrollIndex = { set: () => {} },
 }) {
   const [initScrollPosIsSet, setInitScrollPosIsSet] = useState(false);
-  const [layout] = useLayout(model);
   const isSingleSelect = !!(layout && layout.qListObject.qDimensionInfo.qIsOneAndOnlyOne);
   const { checkboxes = checkboxOption, histogram } = layout ?? {};
 

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -44,7 +44,7 @@ const Title = styled(Typography)(({ theme }) => ({
   fontFamily: theme.listBox?.title?.main?.fontFamily,
 }));
 
-export default function ListBoxInline({ options = {} }) {
+function ListBoxInline({ options, layout }) {
   const {
     app,
     direction,
@@ -93,7 +93,6 @@ export default function ListBoxInline({ options = {} }) {
   const containerRef = useRef();
   const [searchContainer, searchContainerRef] = useRefWithCallback();
 
-  const [layout] = useLayout(model);
   const [showToolbar, setShowToolbar] = useState(false);
   const [showSearch, setShowSearch] = useState(false);
   const [keyboardActive, setKeyboardActive] = useState(false);
@@ -292,6 +291,7 @@ export default function ListBoxInline({ options = {} }) {
             {({ height, width }) => (
               <ListBox
                 model={model}
+                layout={layout}
                 selections={selections}
                 direction={direction}
                 listLayout={listLayout}
@@ -324,3 +324,13 @@ export default function ListBoxInline({ options = {} }) {
     </StyledGrid>
   );
 }
+
+const ListBoxInlineMemoed = React.memo(ListBoxInline);
+
+function IsolateUseLayoutWrapper({ options = {} }) {
+  const { model } = options;
+  const [layout] = useLayout(model);
+  return <ListBoxInlineMemoed options={options} layout={layout} />;
+}
+
+export default IsolateUseLayoutWrapper;

--- a/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -176,7 +176,13 @@ export default function ListBoxPopover({
             keyboard={{ enabled: false }}
             autoFocus={autoFocus ?? true}
           />
-          <ListBox model={model} selections={selections} direction="ltr" onSetListCount={(c) => setListCount(c)} />
+          <ListBox
+            model={model}
+            layout={layout}
+            selections={selections}
+            direction="ltr"
+            onSetListCount={(c) => setListCount(c)}
+          />
         </Grid>
       </Grid>
     </Popover>

--- a/apis/nucleus/src/components/listbox/ListBoxPortal.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPortal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import ListBoxInline from './ListBoxInline';
 import useObjectSelections from '../../hooks/useObjectSelections';
@@ -75,16 +75,19 @@ function ListBoxWrapper({ app, fieldIdentifier, qId, stateName, element, options
     ? options.selectionsApi
     : useObjectSelections(app, model, [elementRef, '.njs-action-toolbar-more'], options)[0];
 
+  const opts = useMemo(
+    () => ({
+      ...options,
+      selections,
+      model,
+      app,
+    }),
+    [options, selections, model, app]
+  );
+
   if (!selections || !model) {
     return null;
   }
-
-  const opts = {
-    ...options,
-    selections,
-    model,
-    app,
-  };
 
   return <ListBoxInline options={opts} />;
 }

--- a/apis/nucleus/src/components/listbox/__tests__/list-box.test.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { create, act } from 'react-test-renderer';
 import * as reactWindowInfiniteLoaderModule from 'react-window-infinite-loader';
-import * as useLayoutModule from '../../../hooks/useLayout';
 import * as useSelectionsInteractionsModule from '../hooks/selections/useSelectionsInteractions';
 import * as useTextWidth from '../hooks/useTextWidth';
 import * as getListSizes from '../assets/get-list-sizes';
@@ -74,7 +73,6 @@ describe('<Listbox />', () => {
     // eslint-disable-next-line react/jsx-props-no-spreading
     FixedSizeGrid = jest.fn().mockImplementation((props) => <div className="a-column-row" {...props} />);
 
-    jest.spyOn(useLayoutModule, 'default').mockImplementation(() => [layout]);
     jest.spyOn(React, 'useCallback').mockImplementation(useCallbackMock);
     jest.spyOn(useSelectionsInteractionsModule, 'default').mockImplementation(useSelectionsInteractions);
     jest.spyOn(useTextWidth, 'default').mockImplementation(() => 50);
@@ -150,6 +148,7 @@ describe('<Listbox />', () => {
             <InstanceContext.Provider value={{ translator: { get: (s) => s, language: () => 'sv' } }}>
               <ListBox
                 model={mergedArgs.model}
+                layout={layout}
                 frequencyMode={mergedArgs.frequencyMode}
                 histogram={mergedArgs.histogram}
                 keyboard={mergedArgs.keyboard}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

the internal logic in useLayout (in useRpc) causes a lot of extra re-rendering of the component using it
(some of the updates are relevant if the request status in the second retrun value is used)

this isolates ListBoxInline and prevent the extra updates from re-rendering it

together with #1117 and #1118 this fixes most (but not all) of the performance problem in qlik-oss/sn-list-objects#105

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
