### PR TITLE
refactor: avoid setPreselected many times

### DIFF
--- a/apis/nucleus/src/components/listbox/hooks/selections/useSelectionsInteractions.js
+++ b/apis/nucleus/src/components/listbox/hooks/selections/useSelectionsInteractions.js
@@ -79,7 +79,9 @@ export default function useSelectionsInteractions({
         return;
       }
       const elemNumber = +event.currentTarget.getAttribute('data-n');
-      setPreSelected([elemNumber]);
+      if (!(preSelected.length === 1 && preSelected[0] === elemNumber)) {
+        setPreSelected([elemNumber]);
+      }
       handleSingleSelectKey(event);
     },
     [selectingValues, selectDisabled]
@@ -94,7 +96,9 @@ export default function useSelectionsInteractions({
       setMouseDown(true);
 
       const elemNumber = +event.currentTarget.getAttribute('data-n');
-      setPreSelected([elemNumber]);
+      if (!(preSelected.length === 1 && preSelected[0] === elemNumber)) {
+        setPreSelected([elemNumber]);
+      }
       handleSingleSelectKey(event);
     },
     [selectingValues, selectDisabled]


### PR DESCRIPTION
On click an item, useSelectionsInteractions is run too many times because of some state change.
This PR is to reduce partly this problem by checking the value before setting a state.