### PR TITLE
fix: fix filter pane header change the height on selection

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -209,7 +209,7 @@ function ListBoxInline({ options, layout }) {
     >
       {toolbar && (
         <Grid item container style={{ padding: theme.spacing(1) }} wrap="nowrap">
-          <Grid item container wrap="nowrap">
+          <Grid item container style={{ height: '32px' }} wrap="nowrap">
             <Grid item sx={{ display: 'flex', alignItems: 'center', width: searchIconWidth }}>
               {isLocked ? (
                 <IconButton tabIndex={-1} onClick={unlock} disabled={!isLocked} size="large">

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -185,6 +185,7 @@ function ListBoxInline({ options, layout }) {
   const searchHeight = dense ? 27 : 40;
   const extraheight = dense ? 39 : 49;
   const minHeight = 49 + (searchVisible ? searchHeight : 0) + extraheight;
+  const headerHeight = 32;
   const { wildCardSearch, searchEnabled } = layout;
 
   const onShowSearch = () => {
@@ -209,7 +210,7 @@ function ListBoxInline({ options, layout }) {
     >
       {toolbar && (
         <Grid item container style={{ padding: theme.spacing(1) }} wrap="nowrap">
-          <Grid item container style={{ height: '32px' }} wrap="nowrap">
+          <Grid item container style={{ height: `${headerHeight}px` }} wrap="nowrap">
             <Grid item sx={{ display: 'flex', alignItems: 'center', width: searchIconWidth }}>
               {isLocked ? (
                 <IconButton tabIndex={-1} onClick={unlock} disabled={!isLocked} size="large">

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -210,7 +210,7 @@ function ListBoxInline({ options, layout }) {
     >
       {toolbar && (
         <Grid item container style={{ padding: theme.spacing(1) }} wrap="nowrap">
-          <Grid item container style={{ height: `${headerHeight}px` }} wrap="nowrap">
+          <Grid item container height={headerHeight} wrap="nowrap">
             <Grid item sx={{ display: 'flex', alignItems: 'center', width: searchIconWidth }}>
               {isLocked ? (
                 <IconButton tabIndex={-1} onClick={unlock} disabled={!isLocked} size="large">


### PR DESCRIPTION
In a filter pane, the action toolbar items (to the right of the header) has 32px height, while the title has 28px height.
This causes the problem reported here https://github.com/qlik-oss/sn-list-objects/issues/119.
To avoid the header height being changed on selection, we set its height to the same height of the action toolbar items.
This PR is to fix https://github.com/qlik-oss/sn-list-objects/issues/119.