### PR TITLE
fix: harmonise styles

### DIFF
--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/ListBoxRowColumn.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/ListBoxRowColumn.jsx
@@ -119,7 +119,9 @@ function RowColumn({ index, rowIndex, columnIndex, style, data }) {
     setSelected(selected);
 
     const clazzArr = [column ? classes.column : classes.row];
-    if (!(histogram && (dense || checkboxes))) clazzArr.push(classes.rowBorderBottom);
+    if (!histogram) {
+      clazzArr.push(classes.rowBorderBottom);
+    }
     if (!checkboxes) {
       if (cell.qState === 'XS') {
         clazzArr.push(showGray ? classes.XS : classes.S);

--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
@@ -110,9 +110,9 @@ const RowColRoot = styled('div', {
   [`& .${classes.icon}`]: {
     display: 'flex',
     justifyContent: 'center',
-    width: 22,
-    minWidth: 22,
-    maxWidth: 22,
+    width: 24,
+    minWidth: 24,
+    maxWidth: 24,
   },
 
   // Selection styles (S=Selected, XS=ExcludedSelected, A=Available, X=Excluded).

--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
@@ -54,7 +54,7 @@ const RowColRoot = styled('div', {
     minWidth: 0,
     flexGrow: 1,
     // Note that this padding is overridden when using checkboxes.
-    paddingLeft: '8px',
+    paddingLeft: '9px',
     paddingRight: 0,
   },
 

--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
@@ -18,6 +18,7 @@ const ellipsis = {
   width: '100%',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
 };
 
 const RowColRoot = styled('div', {
@@ -53,8 +54,8 @@ const RowColRoot = styled('div', {
     minWidth: 0,
     flexGrow: 1,
     // Note that this padding is overridden when using checkboxes.
-    paddingLeft: '9px',
-    paddingRight: '9px',
+    paddingLeft: '8px',
+    paddingRight: 0,
   },
 
   // The leaf node, containing the label text.
@@ -62,9 +63,9 @@ const RowColRoot = styled('div', {
     flexBasis: flexBasisProp,
     lineHeight: '16px',
     userSelect: 'none',
-    whiteSpace: 'pre', // to keep white-space on highlight
-    paddingRight: '9px',
+    paddingRight: 0,
     ...ellipsis,
+    whiteSpace: 'pre', // to keep white-space on highlight
     fontSize: theme.listBox?.content?.fontSize,
     fontFamily: theme.listBox?.content?.fontFamily,
   },
@@ -108,7 +109,10 @@ const RowColRoot = styled('div', {
   // The icons container holding tick and lock, shown inside fields.
   [`& .${classes.icon}`]: {
     display: 'flex',
-    padding: theme.spacing(1, 1, 1, 0),
+    justifyContent: 'center',
+    width: 22,
+    minWidth: 22,
+    maxWidth: 22,
   },
 
   // Selection styles (S=Selected, XS=ExcludedSelected, A=Available, X=Excluded).
@@ -137,8 +141,13 @@ const RowColRoot = styled('div', {
   },
 
   [`& .${classes.frequencyCount}`]: {
-    width: '66px',
     justifyContent: 'flex-end',
+    ...ellipsis,
+    width: 'auto',
+    maxWidth: 'fit-content',
+    minWidth: 'fit-content',
+    textAlign: 'right',
+    padding: '2px',
   },
 
   [`&.${classes.barContainer}`]: {

--- a/apis/nucleus/src/components/listbox/components/grid-list-components/item-sizes.js
+++ b/apis/nucleus/src/components/listbox/components/grid-list-components/item-sizes.js
@@ -12,11 +12,15 @@ export default function getGridItemSizes({ dataLayout, layoutOrder, itemPadding 
       return {
         height: `calc(100% - ${itemPadding}px)`,
         width: `calc(100% - ${2 * itemPadding}px)`,
+        position: 'absolute',
+        left: 4,
       };
     case 'column':
       return {
         height: `calc(100% - ${itemPadding}px)`,
         width: `calc(100% - ${2 * itemPadding}px)`,
+        position: 'absolute',
+        left: 4,
       };
     default:
       return {};

--- a/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
@@ -76,6 +76,7 @@ export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, opti
     qListObjectDef: {
       qStateName: stateName,
       qShowAlternatives: true,
+      frequencyEnabled: false,
       qFrequencyMode: getListdefFrequencyMode(),
       qInitialDataFetch: [
         {


### PR DESCRIPTION
## Motivation

- fixes(https://github.com/qlik-oss/sn-list-objects/issues/121)
- fixes(https://github.com/qlik-oss/sn-list-objects/issues/117)
- fixes "remove borders in histogram mode" (no issue)
- fixes "Leftmost column doesnt have enough padding on the left so the 3 indicators meant to show if it is ordered by row or column (vertical or horizontal) are barely visible here…"
- fixes(https://github.com/qlik-oss/sn-list-objects/issues/90)

Fixes a lot of issues with CSS and gives a much better use of the space, especially in frequency mode (much better than in the existing Filter pane in sense-client).

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
