### PR TITLE
fix: prevent flickering from engine update during selection

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -13,7 +13,6 @@ import useDataStore from './hooks/useDataStore';
 import ListBoxDisclaimer from './components/ListBoxDisclaimer';
 import ListBoxFooter from './components/ListBoxFooter';
 import getScrollIndex from './interactions/listbox-get-scroll-index';
-import createSelectionState from './hooks/selections/selectionState';
 import getFrequencyAllowed from './components/grid-list-components/frequency-allowed';
 
 const DEFAULT_MIN_BATCH_SIZE = 100;
@@ -23,6 +22,7 @@ export default function ListBox({
   constraints,
   layout,
   selections,
+  selectionState,
   direction,
   checkboxes: checkboxOption,
   height,
@@ -73,10 +73,10 @@ export default function ListBox({
   const showOverflowDisclaimer = (show) => setOverflowDisclaimer((state) => ({ ...state, show }));
 
   const [pages, setPages] = useState([]);
-  const [selectionState] = useState(() => createSelectionState(setPages));
 
   if (itemsLoader?.pages) {
     selectionState.update({
+      setPages,
       pages: itemsLoader?.pages,
       isSingleSelect,
       selectDisabled,

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -15,6 +15,7 @@ import ListBoxSearch from './components/ListBoxSearch';
 import { getListboxInlineKeyboardNavigation } from './interactions/listbox-keyboard-navigation';
 import addListboxTheme from './assets/addListboxTheme';
 import useAppSelections from '../../hooks/useAppSelections';
+import createSelectionState from './hooks/selections/selectionState';
 import { CELL_PADDING_LEFT, ICON_PADDING } from './constants';
 
 const PREFIX = 'ListBoxInline';
@@ -102,6 +103,7 @@ function ListBoxInline({ options, layout }) {
   const updateKeyScroll = (newState) => setKeyScroll((current) => ({ ...current, ...newState }));
   const [currentScrollIndex, setCurrentScrollIndex] = useState({ start: 0, stop: 0 });
   const [appSelections] = useAppSelections(app);
+  const [selectionState] = useState(() => createSelectionState());
 
   const { handleKeyDown, handleOnMouseEnter, handleOnMouseLeave } = getListboxInlineKeyboardNavigation({
     setKeyboardActive,
@@ -176,6 +178,7 @@ function ListBoxInline({ options, layout }) {
         layout,
         model,
         translator,
+        selectionState,
       })
     : [];
 
@@ -294,6 +297,7 @@ function ListBoxInline({ options, layout }) {
           <div className={classes.screenReaderOnly}>{translator.get('Listbox.Search.ScreenReaderInstructions')}</div>
           <ListBoxSearch
             selections={selections}
+            selectionState={selectionState}
             model={model}
             dense={dense}
             keyboard={keyboard}
@@ -314,6 +318,7 @@ function ListBoxInline({ options, layout }) {
                 constraints={constraints}
                 layout={layout}
                 selections={selections}
+                selectionState={selectionState}
                 direction={direction}
                 frequencyMode={frequencyMode}
                 rangeSelect={rangeSelect}

--- a/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -18,6 +18,7 @@ import InstanceContext from '../../contexts/InstanceContext';
 
 import ListBoxSearch from './components/ListBoxSearch';
 import useObjectSelections from '../../hooks/useObjectSelections';
+import createSelectionState from './hooks/selections/selectionState';
 import getHasSelections from './assets/has-selections';
 
 export default function ListBoxPopover({
@@ -89,6 +90,7 @@ export default function ListBoxPopover({
   const containerRef = useRef();
   const [selections] = useObjectSelections(app, model, containerRef);
   const [layout] = useLayout(model);
+  const [selectionState] = useState(() => createSelectionState());
 
   useEffect(() => {
     if (selections && open) {
@@ -114,6 +116,7 @@ export default function ListBoxPopover({
     layout,
     model,
     translator,
+    selectionState,
   });
 
   const hasSelections = getHasSelections(layout);
@@ -173,6 +176,7 @@ export default function ListBoxPopover({
             model={model}
             listCount={listCount}
             selections={selections}
+            selectionState={selectionState}
             keyboard={{ enabled: false }}
             autoFocus={autoFocus ?? true}
           />
@@ -180,6 +184,7 @@ export default function ListBoxPopover({
             model={model}
             layout={layout}
             selections={selections}
+            selectionState={selectionState}
             direction="ltr"
             onSetListCount={(c) => setListCount(c)}
           />

--- a/apis/nucleus/src/components/listbox/__tests__/list-box.test.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box.test.jsx
@@ -55,7 +55,6 @@ describe('<Listbox />', () => {
     };
 
     useSelectionsInteractions = jest.fn().mockReturnValue({
-      instantPages: [],
       interactionEvents: {
         onMouseDown: () => {},
         onMouseUp: () => {},
@@ -183,13 +182,10 @@ describe('<Listbox />', () => {
       expect(rows).toHaveLength(1);
       expect(columns).toHaveLength(0);
       expect(useSelectionsInteractions.mock.lastCall[0]).toMatchObject({
-        layout,
         selections,
-        pages: [],
         doc: expect.any(Object),
       });
 
-      expect(useSelectionsInteractions.mock.calls[1][0].selectDisabled instanceof Function).toBe(true);
       expect(FixedSizeList.mock.calls.length).toBeGreaterThan(0);
     });
 
@@ -197,9 +193,7 @@ describe('<Listbox />', () => {
       await render();
 
       expect(useSelectionsInteractions.mock.lastCall[0]).toMatchObject({
-        layout,
         selections,
-        pages: [],
         doc: expect.any(Object),
       });
     });
@@ -229,9 +223,7 @@ describe('<Listbox />', () => {
       await render();
 
       expect(useSelectionsInteractions.mock.lastCall[0]).toMatchObject({
-        layout,
         selections,
-        pages: [],
         doc: expect.any(Object),
       });
 

--- a/apis/nucleus/src/components/listbox/__tests__/list-box.test.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box.test.jsx
@@ -29,6 +29,7 @@ describe('<Listbox />', () => {
   let args;
   let layout;
   let selections;
+  let selectionState;
   let renderer;
   let render;
   let pages;
@@ -103,6 +104,7 @@ describe('<Listbox />', () => {
     global.window = { setTimeout: setTimeoutStub };
     selectDisabled = () => false;
     selections = { key: 'selections' };
+    selectionState = { update: jest.fn() };
 
     args = {
       model: {
@@ -112,6 +114,7 @@ describe('<Listbox />', () => {
       frequencyMode: 'N',
       histogram: false,
       selections,
+      selectionState,
       postProcessPages: undefined,
       calculatePagesHeight: false,
       keyboard: undefined,
@@ -153,6 +156,7 @@ describe('<Listbox />', () => {
                 keyboard={mergedArgs.keyboard}
                 showGray={mergedArgs.showGray}
                 selections={mergedArgs.selections}
+                selectionState={mergedArgs.selectionState}
                 direction={mergedArgs.direction}
                 height={mergedArgs.height}
                 width={mergedArgs.width}

--- a/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
@@ -20,6 +20,7 @@ const StyledOutlinedInput = styled(OutlinedInput)(({ theme }) => ({
 
 export default function ListBoxSearch({
   selections,
+  selectionState,
   model,
   keyboard,
   dense = false,
@@ -101,6 +102,7 @@ export default function ListBoxSearch({
       response = model.acceptListObjectSearch(TREE_PATH, true);
       // eslint-disable-next-line no-param-reassign
       selections.selectionsMade = true;
+      selectionState.clearItemStates(false);
       setValue('');
     }
     return response;

--- a/apis/nucleus/src/components/listbox/components/__tests__/list-box-search.test.jsx
+++ b/apis/nucleus/src/components/listbox/components/__tests__/list-box-search.test.jsx
@@ -118,9 +118,12 @@ describe('<ListBoxSearch />', () => {
   });
 
   test('should reset `OutlinedInput` and `acceptListObjectSearch` on `Enter`', async () => {
+    const selectionState = {
+      clearItemStates: jest.fn(),
+    };
     const testRenderer = create(
       <InstanceContext.Provider value={{ translator: { get: () => 'Search' } }}>
-        <ListBoxSearch selections={selections} model={model} keyboard={keyboard} />
+        <ListBoxSearch selections={selections} selectionState={selectionState} model={model} keyboard={keyboard} />
       </InstanceContext.Provider>
     );
     const testInstance = testRenderer.root;
@@ -136,6 +139,8 @@ describe('<ListBoxSearch />', () => {
     });
     expect(model.acceptListObjectSearch).toHaveBeenCalledWith('/qListObjectDef', true);
     expect(type.props.value).toBe('');
+    expect(selectionState.clearItemStates).toBeCalledTimes(1);
+    expect(selectionState.clearItemStates).toBeCalledWith(false);
   });
 
   test('should not accept search result if no hits', async () => {

--- a/apis/nucleus/src/components/listbox/hooks/selections/__tests__/listbox-selections.test.js
+++ b/apis/nucleus/src/components/listbox/hooks/selections/__tests__/listbox-selections.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import * as listboxSelections from '../listbox-selections';
 
 describe('use-listbox-interactions', () => {
@@ -29,101 +30,14 @@ describe('use-listbox-interactions', () => {
     expect(listboxSelections.getSelectedValues(pages)).toEqual([0, 1, 5]);
   });
 
-  describe('applySelectionsOnPages should modify pages so that selections are applied', () => {
-    let pages;
-
-    beforeEach(() => {
-      pages = [
-        {
-          qMatrix: [
-            [{ qState: 'S', qElemNumber: 0 }],
-            [{ qState: 'XS', qElemNumber: 1 }],
-            [{ qState: 'L', qElemNumber: 2 }],
-            [{ qState: 'A', qElemNumber: 3 }],
-            [{ qState: 'XL', qElemNumber: 4 }],
-            [{ qState: 'XS', qElemNumber: 5 }],
-            [{ qState: 'A', qElemNumber: 6 }],
-          ],
-        },
-      ];
-    });
-
-    test('should add selection for element number 2', () => {
-      const selectedPages = listboxSelections.applySelectionsOnPages(pages, [2]);
-      expect(selectedPages).toEqual([
-        {
-          qMatrix: [
-            [{ qState: 'S', qElemNumber: 0 }, []],
-            [{ qState: 'XS', qElemNumber: 1 }, []],
-            [{ qState: 'S', qElemNumber: 2 }, []],
-            [{ qState: 'A', qElemNumber: 3 }, []],
-            [{ qState: 'XL', qElemNumber: 4 }, []],
-            [{ qState: 'XS', qElemNumber: 5 }, []],
-            [{ qState: 'A', qElemNumber: 6 }, []],
-          ],
-        },
-      ]);
-    });
-
-    test('should toggle selection (turn it off)', () => {
-      const selectedPages = listboxSelections.applySelectionsOnPages(pages, [0]);
-      expect(selectedPages).toEqual([
-        {
-          qMatrix: [
-            [{ qState: 'A', qElemNumber: 0 }, []],
-            [{ qState: 'XS', qElemNumber: 1 }, []],
-            [{ qState: 'L', qElemNumber: 2 }, []],
-            [{ qState: 'A', qElemNumber: 3 }, []],
-            [{ qState: 'XL', qElemNumber: 4 }, []],
-            [{ qState: 'XS', qElemNumber: 5 }, []],
-            [{ qState: 'A', qElemNumber: 6 }, []],
-          ],
-        },
-      ]);
-    });
-
-    test('should select a range without toggling any already selected values', () => {
-      const selectedPages = listboxSelections.applySelectionsOnPages(pages, [0, 1, 2, 3, 4, 5]);
-      expect(selectedPages).toEqual([
-        {
-          qMatrix: [
-            [{ qState: 'S', qElemNumber: 0 }, []],
-            [{ qState: 'S', qElemNumber: 1 }, []],
-            [{ qState: 'S', qElemNumber: 2 }, []],
-            [{ qState: 'S', qElemNumber: 3 }, []],
-            [{ qState: 'S', qElemNumber: 4 }, []],
-            [{ qState: 'S', qElemNumber: 5 }, []],
-            [{ qState: 'A', qElemNumber: 6 }, []],
-          ],
-        },
-      ]);
-    });
-
-    test('should deselect all exept the new selection', () => {
-      const clearAllButElmNumbers = true;
-      const selectedPages = listboxSelections.applySelectionsOnPages(pages, [3], clearAllButElmNumbers);
-      expect(selectedPages).toEqual([
-        {
-          qMatrix: [
-            [{ qState: 'A', qElemNumber: 0 }, []],
-            [{ qState: 'A', qElemNumber: 1 }, []],
-            [{ qState: 'A', qElemNumber: 2 }, []],
-            [{ qState: 'S', qElemNumber: 3 }, []],
-            [{ qState: 'A', qElemNumber: 4 }, []],
-            [{ qState: 'A', qElemNumber: 5 }, []],
-            [{ qState: 'A', qElemNumber: 6 }, []],
-          ],
-        },
-      ]);
-    });
-  });
-
   describe('selectValues should call the select method', () => {
     let selections;
 
     beforeEach(() => {
       const SUCCESS = true;
       selections = {
+        cancel: jest.fn(),
+        clear: jest.fn(),
         select: jest.fn().mockResolvedValue(SUCCESS),
       };
     });
@@ -140,37 +54,9 @@ describe('use-listbox-interactions', () => {
       expect(selections.select).not.toHaveBeenCalled();
     });
 
-    test('should call select', async () => {
-      const resp = await listboxSelections.selectValues({
-        selections,
-        elemNumbers: [1, 2, 3, 4],
-        isSingleSelect: false,
-      });
-      expect(resp).toBe(true);
-      expect(selections.select).toHaveBeenCalledTimes(1);
-      expect(selections.select).toHaveBeenCalledWith({
-        method: 'selectListObjectValues',
-        params: ['/qListObjectDef', [1, 2, 3, 4], true],
-      });
-    });
-
-    test('single select true should translate to toggle false', async () => {
-      const resp = await listboxSelections.selectValues({
-        selections,
-        elemNumbers: [4],
-        isSingleSelect: true,
-      });
-      expect(resp).toBe(true);
-      expect(selections.select).toHaveBeenCalledTimes(1);
-      expect(selections.select).toHaveBeenCalledWith({
-        method: 'selectListObjectValues',
-        params: ['/qListObjectDef', [4], false],
-      });
-    });
-
     test('should catch errors in backend call', async () => {
       selections.select.mockRejectedValue('error');
-      expect(async () => {
+      await expect(async () => {
         await listboxSelections.selectValues({
           selections,
           elemNumbers: [4],
@@ -179,12 +65,9 @@ describe('use-listbox-interactions', () => {
       }).not.toThrow();
     });
 
-    test('should call select', () => {
-      listboxSelections
-        .selectValues({ selections, elemNumbers: [1, 2, 4], isSingleSelect: false })
-        .then((successStory) => {
-          expect(successStory).toBe(true);
-        });
+    test('should call select', async () => {
+      const successStory = await listboxSelections.selectValues({ selections, elemNumbers: [1, 2, 4], toggle: true });
+      expect(successStory).toBe(true);
       expect(selections.select).toHaveBeenCalledTimes(1);
       expect(selections.select).toHaveBeenCalledWith({
         method: 'selectListObjectValues',
@@ -192,10 +75,9 @@ describe('use-listbox-interactions', () => {
       });
     });
 
-    test('should call select with toggle false when single select', () => {
-      listboxSelections.selectValues({ selections, elemNumbers: [2], isSingleSelect: true }).then((successStory) => {
-        expect(successStory).toBe(true);
-      });
+    test('should call select with toggle', async () => {
+      const successStory = await listboxSelections.selectValues({ selections, elemNumbers: [2], toggle: false });
+      expect(successStory).toBe(true);
       expect(selections.select).toHaveBeenCalledTimes(1);
       expect(selections.select).toHaveBeenCalledWith({
         method: 'selectListObjectValues',
@@ -203,23 +85,41 @@ describe('use-listbox-interactions', () => {
       });
     });
 
-    test('should not call select when NaN values exist', () => {
-      listboxSelections
-        .selectValues({ selections, elemNumbers: [1, NaN, 4], isSingleSelect: false })
-        .then((successStory) => {
-          expect(successStory).toBe(false);
-        });
+    test('should not call select when NaN values exist', async () => {
+      const successStory = await listboxSelections.selectValues({ selections, elemNumbers: [1, NaN, 4], toggle: true });
+      expect(successStory).toBe(false);
       expect(selections.select).not.toHaveBeenCalled();
     });
 
-    test('should handle select failure and then resolve false', () => {
+    test('should handle select failure and then resolve false', async () => {
       selections.select.mockRejectedValue(false);
-      listboxSelections
-        .selectValues({ selections, elemNumbers: [1, 2, 4], isSingleSelect: false })
-        .then((successStory) => {
-          expect(successStory).toBe(false);
-        });
+      const successStory = await listboxSelections.selectValues({ selections, elemNumbers: [1, 2, 4], toggle: true });
+      expect(successStory).toBe(false);
       expect(selections.select).toHaveBeenCalledTimes(1);
+    });
+
+    test('should call clear on failed select', async () => {
+      selections.select.mockResolvedValue(false);
+      const successStory = await listboxSelections.selectValues({
+        selections,
+        elemNumbers: [1, 2, 4],
+        toggle: true,
+        isSingleSelect: false,
+      });
+      expect(successStory).toBe(false);
+      expect(selections.clear).toHaveBeenCalledTimes(1);
+    });
+
+    test('should call cancel on failed select when isSingleSelect is true', async () => {
+      selections.select.mockResolvedValue(false);
+      const successStory = await listboxSelections.selectValues({
+        selections,
+        elemNumbers: [1, 2, 4],
+        toggle: true,
+        isSingleSelect: true,
+      });
+      expect(successStory).toBe(false);
+      expect(selections.cancel).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apis/nucleus/src/components/listbox/hooks/selections/__tests__/use-selections-interactions.test.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/selections/__tests__/use-selections-interactions.test.jsx
@@ -24,6 +24,7 @@ describe('use-listbox-interactions', () => {
   let selectionState;
   let setPages;
   let layout;
+  let updateSelectionState;
 
   beforeEach(() => {
     jest.spyOn(global.document, 'addEventListener').mockImplementation(jest.fn());
@@ -40,15 +41,27 @@ describe('use-listbox-interactions', () => {
       removeEventListener: jest.fn(),
       key: 'selections',
     };
-    layout = { qListObject: { qDimensionInfo: { qIsOneAndOnlyOne: false } } };
+    layout = { qListObject: { qDimensionInfo: { qIsOneAndOnlyOne: false, qApprMaxGlyphCount: 3 }, qSize: { qcy: 3 } } };
     setPages = jest.fn();
     selectionState = createSelectionState(setPages);
     selectionState.update({
+      setPages,
       pages: [],
       isSingleSelect: false,
       layout,
       selectDisabled: () => false,
     });
+    updateSelectionState = (override) => {
+      selectionState.update({
+        setPages,
+        pages: [],
+        isSingleSelect: false,
+        layout,
+        selectDisabled: () => false,
+        ...override,
+      });
+    };
+
     selections = {
       key: 'selections',
       on: jest.fn(),
@@ -111,11 +124,8 @@ describe('use-listbox-interactions', () => {
       await render();
       const arg0 = ref.current.result;
 
-      selectionState.update({
+      updateSelectionState({
         pages: createPageWithSingle(23, 'O'),
-        isSingleSelect: false,
-        layout,
-        selectDisabled: () => false,
       });
 
       const [eventName, docMouseUpListener] = global.document.addEventListener.mock.lastCall;
@@ -155,11 +165,8 @@ describe('use-listbox-interactions', () => {
     });
 
     test('should unselect a value', async () => {
-      selectionState.update({
+      updateSelectionState({
         pages: createPageWithSingle(24, 'S'),
-        isSingleSelect: false,
-        layout,
-        selectDisabled: () => false,
       });
 
       await render();
@@ -217,11 +224,8 @@ describe('use-listbox-interactions', () => {
           { qElemNumber: 31, qState: s31 }
         );
 
-      selectionState.update({
+      updateSelectionState({
         pages: createPage('O', 'O', 'O', 'O', 'O', 'O', 'O', 'O'),
-        isSingleSelect: false,
-        layout,
-        selectDisabled: () => false,
       });
 
       await render();
@@ -279,13 +283,10 @@ describe('use-listbox-interactions', () => {
         toggle: true,
       });
     });
-    // TODO: MUIv5 Should be enabled and fixed
+
     test('Should "toggle" checkboxes', async () => {
-      selectionState.update({
+      updateSelectionState({
         pages: createPageWithSingle(24, 'O'),
-        isSingleSelect: false,
-        layout,
-        selectDisabled: () => false,
       });
       await render({ checkboxes: true });
       const startCallCount = setPages.mock.calls.length;

--- a/apis/nucleus/src/components/listbox/hooks/selections/__tests__/use-selections-interactions.test.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/selections/__tests__/use-selections-interactions.test.jsx
@@ -3,6 +3,10 @@ import { create, act } from 'react-test-renderer';
 import * as listboxSelections from '../listbox-selections';
 
 import useSelectionsInteractions from '../useSelectionsInteractions';
+import createSelectionState from '../selectionState';
+
+const createPageWithSingle = (qElemNumber, qState = 'O') => [{ qMatrix: [[{ qElemNumber, qState }]] }];
+const createPageWithRange = (...items) => [{ qMatrix: items.map((item) => [item]) }];
 
 const TestHook = React.forwardRef(({ hook, hookProps = [] }, ref) => {
   const result = hook(...hookProps);
@@ -13,18 +17,13 @@ const TestHook = React.forwardRef(({ hook, hookProps = [] }, ref) => {
 });
 
 describe('use-listbox-interactions', () => {
-  let layout;
   let selections;
-  let pages;
-  let selectDisabled;
   let ref;
   let render;
-  let getUniques;
   let selectValues;
-  let applySelectionsOnPages;
-  let fillRange;
-  let getSelectedValues;
-  let getElemNumbersFromPages;
+  let selectionState;
+  let setPages;
+  let layout;
 
   beforeEach(() => {
     jest.spyOn(global.document, 'addEventListener').mockImplementation(jest.fn());
@@ -32,26 +31,29 @@ describe('use-listbox-interactions', () => {
 
     jest.useFakeTimers();
 
-    getUniques = jest.fn().mockImplementation((input) => input);
     selectValues = jest.fn().mockResolvedValue();
-    applySelectionsOnPages = jest.fn().mockReturnValue([]);
-    fillRange = jest.fn().mockImplementation((arr) => arr);
-    getSelectedValues = jest.fn().mockReturnValue([]);
-    getElemNumbersFromPages = jest.fn().mockReturnValue([]);
 
-    jest.spyOn(listboxSelections, 'getUniques').mockImplementation(getUniques);
     jest.spyOn(listboxSelections, 'selectValues').mockImplementation(selectValues);
-    jest.spyOn(listboxSelections, 'applySelectionsOnPages').mockImplementation(applySelectionsOnPages);
-    jest.spyOn(listboxSelections, 'fillRange').mockImplementation(fillRange);
-    jest.spyOn(listboxSelections, 'getSelectedValues').mockImplementation(getSelectedValues);
-    jest.spyOn(listboxSelections, 'getElemNumbersFromPages').mockImplementation(getElemNumbersFromPages);
 
-    layout = {
-      qListObject: { qDimensionInfo: { qIsOneAndOnlyOne: false } },
+    selections = {
+      on: jest.fn(),
+      removeEventListener: jest.fn(),
+      key: 'selections',
     };
-    selections = { key: 'selections' };
-    pages = [];
-    selectDisabled = () => false;
+    layout = { qListObject: { qDimensionInfo: { qIsOneAndOnlyOne: false } } };
+    setPages = jest.fn();
+    selectionState = createSelectionState(setPages);
+    selectionState.update({
+      pages: [],
+      isSingleSelect: false,
+      layout,
+      selectDisabled: () => false,
+    });
+    selections = {
+      key: 'selections',
+      on: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
 
     ref = React.createRef();
     render = async (overrides = {}) => {
@@ -60,7 +62,7 @@ describe('use-listbox-interactions', () => {
           <TestHook
             ref={ref}
             hook={useSelectionsInteractions}
-            hookProps={[{ layout, selections, pages, selectDisabled, doc: global.document, ...overrides }]}
+            hookProps={[{ selectionState, selections, doc: global.document, ...overrides }]}
           />
         );
       });
@@ -78,15 +80,13 @@ describe('use-listbox-interactions', () => {
       test('With range', async () => {
         await render();
         const arg0 = ref.current.result;
-        expect(Object.keys(arg0).sort()).toEqual(['instantPages', 'interactionEvents', 'select']);
-        expect(arg0.instantPages).toEqual([]);
+        expect(Object.keys(arg0).sort()).toEqual(['interactionEvents', 'select']);
         expect(Object.keys(arg0.interactionEvents).sort()).toEqual(['onMouseDown', 'onMouseEnter', 'onMouseUp']);
       });
       test('With checkboxes', async () => {
         await render({ checkboxes: true });
         const arg0 = ref.current.result;
-        expect(Object.keys(arg0).sort()).toEqual(['instantPages', 'interactionEvents', 'select']);
-        expect(arg0.instantPages).toEqual([]);
+        expect(Object.keys(arg0).sort()).toEqual(['interactionEvents', 'select']);
         expect(Object.keys(arg0.interactionEvents).sort()).toEqual(['onChange']);
       });
     });
@@ -102,7 +102,8 @@ describe('use-listbox-interactions', () => {
       expect(listboxSelections.selectValues.mock.lastCall[0]).toEqual({
         elemNumbers: [1],
         isSingleSelect: false,
-        selections: { key: 'selections' },
+        toggle: true,
+        selections,
       });
     });
 
@@ -110,12 +111,20 @@ describe('use-listbox-interactions', () => {
       await render();
       const arg0 = ref.current.result;
 
-      expect(applySelectionsOnPages).not.toHaveBeenCalled();
+      selectionState.update({
+        pages: createPageWithSingle(23, 'O'),
+        isSingleSelect: false,
+        layout,
+        selectDisabled: () => false,
+      });
+
       const [eventName, docMouseUpListener] = global.document.addEventListener.mock.lastCall;
       expect(eventName).toBe('mouseup');
       expect(global.document.removeEventListener).not.toHaveBeenCalled();
 
       expect(listboxSelections.selectValues).toHaveBeenCalledTimes(0);
+
+      const callCount = setPages.mock.calls.length;
 
       await act(() => {
         arg0.interactionEvents.onMouseDown({
@@ -125,33 +134,37 @@ describe('use-listbox-interactions', () => {
         });
       });
 
-      const arg1 = ref.current.result;
-
       expect(listboxSelections.selectValues).not.toHaveBeenCalled();
-      expect(arg1.instantPages).toEqual([]);
+      expect(setPages).toHaveBeenCalledTimes(callCount + 1);
+      expect(setPages).toHaveBeenLastCalledWith(createPageWithSingle(23, 'S'));
 
       await act(() => {
         docMouseUpListener(); // trigger doc mouseup listener to set mouseDown => false
       });
 
-      const arg2 = ref.current.result;
-
       expect(listboxSelections.selectValues).toHaveBeenCalledTimes(1);
 
       expect(listboxSelections.selectValues).toHaveBeenCalledWith({
-        selections: { key: 'selections' },
+        selections,
         elemNumbers: [23],
+        toggle: true,
         isSingleSelect: false,
       });
-      expect(applySelectionsOnPages).toHaveBeenCalledTimes(1);
-      expect(applySelectionsOnPages.mock.lastCall).toEqual([[], [23], false]);
-      expect(arg2.instantPages).toEqual([]);
+      // no update of pages on mouse up
+      expect(setPages).toHaveBeenCalledTimes(callCount + 1);
     });
 
     test('should unselect a value', async () => {
-      getSelectedValues.mockReturnValue([24]); // mock element nbr 24 as already selected
+      selectionState.update({
+        pages: createPageWithSingle(24, 'S'),
+        isSingleSelect: false,
+        layout,
+        selectDisabled: () => false,
+      });
+
       await render();
       const arg0 = ref.current.result;
+      const callCount = setPages.mock.calls.length;
 
       await act(() => {
         arg0.interactionEvents.onMouseDown({
@@ -161,9 +174,9 @@ describe('use-listbox-interactions', () => {
         });
       });
 
-      expect(applySelectionsOnPages).toHaveBeenCalledTimes(1);
+      expect(setPages).toHaveBeenCalledTimes(callCount + 1);
+      expect(setPages).toHaveBeenLastCalledWith(createPageWithSingle(24, 'A'));
 
-      expect(applySelectionsOnPages.mock.lastCall).toEqual([[], [24], false]);
       expect(listboxSelections.selectValues).not.toHaveBeenCalled();
       const [, docMouseUpListener] = global.document.addEventListener.mock.lastCall;
 
@@ -173,12 +186,13 @@ describe('use-listbox-interactions', () => {
 
       expect(listboxSelections.selectValues).toHaveBeenCalledTimes(1);
       expect(listboxSelections.selectValues).toHaveBeenCalledWith({
-        selections: { key: 'selections' },
+        selections,
         elemNumbers: [24],
         isSingleSelect: false,
+        toggle: true,
       });
 
-      expect(applySelectionsOnPages).toHaveBeenCalledTimes(1);
+      expect(setPages).toHaveBeenCalledTimes(callCount + 1);
     });
   });
 
@@ -186,17 +200,33 @@ describe('use-listbox-interactions', () => {
     test('should return expected stuff', async () => {
       await render();
       const arg0 = ref.current.result;
-      expect(Object.keys(arg0)).toEqual(['instantPages', 'interactionEvents', 'select']);
-      expect(arg0.instantPages).toEqual([]);
+      expect(Object.keys(arg0)).toEqual(['interactionEvents', 'select']);
       expect(Object.keys(arg0.interactionEvents).sort()).toEqual(['onMouseDown', 'onMouseEnter', 'onMouseUp']);
     });
 
     test('should select a range (in theory)', async () => {
-      getElemNumbersFromPages.mockReturnValue([24, 25, 26, 27, 28, 29, 30, 31]);
+      const createPage = (s24, s25, s26, s27, s28, s29, s30, s31) =>
+        createPageWithRange(
+          { qElemNumber: 24, qState: s24 },
+          { qElemNumber: 25, qState: s25 },
+          { qElemNumber: 26, qState: s26 },
+          { qElemNumber: 27, qState: s27 },
+          { qElemNumber: 28, qState: s28 },
+          { qElemNumber: 29, qState: s29 },
+          { qElemNumber: 30, qState: s30 },
+          { qElemNumber: 31, qState: s31 }
+        );
+
+      selectionState.update({
+        pages: createPage('O', 'O', 'O', 'O', 'O', 'O', 'O', 'O'),
+        isSingleSelect: false,
+        layout,
+        selectDisabled: () => false,
+      });
 
       await render();
 
-      expect(applySelectionsOnPages).toHaveBeenCalledTimes(0);
+      const callCount = setPages.mock.calls.length;
 
       // Simulate a typical select range scenario.
       await act(() => {
@@ -206,7 +236,8 @@ describe('use-listbox-interactions', () => {
           },
         });
       });
-      expect(applySelectionsOnPages).toHaveBeenCalledTimes(1);
+      expect(setPages).toHaveBeenCalledTimes(callCount + 1);
+      expect(setPages).toHaveBeenLastCalledWith(createPage('S', 'O', 'O', 'O', 'O', 'O', 'O', 'O'));
       await act(() => {
         ref.current.result.interactionEvents.onMouseEnter({
           currentTarget: {
@@ -214,7 +245,8 @@ describe('use-listbox-interactions', () => {
           },
         });
       });
-      expect(applySelectionsOnPages).toHaveBeenCalledTimes(2);
+      expect(setPages).toHaveBeenCalledTimes(callCount + 2);
+      expect(setPages).toHaveBeenLastCalledWith(createPage('S', 'S', 'O', 'O', 'O', 'O', 'O', 'O'));
       await act(() => {
         ref.current.result.interactionEvents.onMouseEnter({
           currentTarget: {
@@ -222,6 +254,8 @@ describe('use-listbox-interactions', () => {
           },
         });
       });
+      expect(setPages).toHaveBeenCalledTimes(callCount + 3);
+      expect(setPages).toHaveBeenLastCalledWith(createPage('S', 'S', 'S', 'S', 'S', 'O', 'O', 'O'));
       await act(() => {
         ref.current.result.interactionEvents.onMouseUp({
           currentTarget: {
@@ -229,66 +263,75 @@ describe('use-listbox-interactions', () => {
           },
         });
       });
+      expect(setPages).toHaveBeenCalledTimes(callCount + 4);
+      expect(setPages).toHaveBeenLastCalledWith(createPage('S', 'S', 'S', 'S', 'S', 'S', 'S', 'O'));
       await act(() => {
         const [, docMouseUpListener] = global.document.addEventListener.mock.lastCall;
         docMouseUpListener();
       });
 
-      expect(applySelectionsOnPages).toHaveBeenCalledTimes(4);
+      expect(setPages).toHaveBeenCalledTimes(callCount + 4);
       expect(listboxSelections.selectValues).toHaveBeenCalledTimes(1);
       expect(listboxSelections.selectValues).toHaveBeenCalledWith({
-        selections: { key: 'selections' },
-        elemNumbers: [24, 25, 28, 30], // without mocking fillRange this range would be filled
+        selections,
+        elemNumbers: [24, 25, 26, 27, 28, 29, 30],
         isSingleSelect: false,
+        toggle: true,
       });
-
-      // Should pre-select "cumulative", once for each new value
-      expect(applySelectionsOnPages.mock.calls[0]).toEqual([[], [24], false]);
-      expect(applySelectionsOnPages.mock.calls[1]).toEqual([[], [24, 25], false]);
-      expect(applySelectionsOnPages.mock.calls[2]).toEqual([[], [24, 25, 28], false]);
-      expect(applySelectionsOnPages.mock.calls[3]).toEqual([[], [24, 25, 28, 30], false]);
     });
     // TODO: MUIv5 Should be enabled and fixed
     test('Should "toggle" checkboxes', async () => {
+      selectionState.update({
+        pages: createPageWithSingle(24, 'O'),
+        isSingleSelect: false,
+        layout,
+        selectDisabled: () => false,
+      });
       await render({ checkboxes: true });
-      const startCallCount = applySelectionsOnPages.mock.calls.length;
+      const startCallCount = setPages.mock.calls.length;
       await act(() => {
         ref.current.result.interactionEvents.onChange({
+          nativeEvent: {},
           target: {
             getAttribute: jest.fn().mockReturnValue(24),
           },
         });
       });
 
-      expect(applySelectionsOnPages.mock.calls).toHaveLength(startCallCount + 2);
-      expect(applySelectionsOnPages.mock.calls[1]).toEqual([[], [24], false]);
+      expect(setPages).toHaveBeenCalledTimes(startCallCount + 1);
+      expect(setPages).toHaveBeenLastCalledWith(createPageWithSingle(24, 'S'));
+
       await act(() => {
         ref.current.result.interactionEvents.onChange({
+          nativeEvent: {},
           target: {
             getAttribute: jest.fn().mockReturnValue(24),
           },
         });
       });
-      expect(applySelectionsOnPages.mock.calls[2]).toEqual([[], [], false]);
+      expect(setPages).toHaveBeenCalledTimes(startCallCount + 2);
+      expect(setPages).toHaveBeenLastCalledWith(createPageWithSingle(24, 'O'));
     });
 
-    test('Ctrl or cmd button with click should result in single select behaviour', async () => {
-      await render({ checkboxes: true });
-      const preventDefault = jest.fn();
-      const focus = jest.fn();
-      await act(() => {
-        ref.current.result.interactionEvents.onChange({
-          target: {
-            focus,
-            getAttribute: jest.fn().mockReturnValue(24),
-          },
-          ctrlKey: true,
-          preventDefault,
-        });
-      });
-      expect(focus).toHaveBeenCalledTimes(1);
-      expect(preventDefault).toHaveBeenCalledTimes(1);
-    });
+    // test('Ctrl or cmd button with click should result in single select behaviour', async () => {
+    //   await render({ checkboxes: true });
+    //   const preventDefault = jest.fn();
+    //   const focus = jest.fn();
+    //   await act(() => {
+    //     ref.current.result.interactionEvents.onChange({
+    //       target: {
+    //         focus,
+    //         getAttribute: jest.fn().mockReturnValue(24),
+    //       },
+    //       nativeEvent: {
+    //         ctrlKey: true,
+    //       },
+    //       preventDefault,
+    //     });
+    //   });
+    //   expect(focus).toHaveBeenCalledTimes(1);
+    //   expect(preventDefault).toHaveBeenCalledTimes(1);
+    // });
 
     test('Ctrl or cmd button with mousedown should result in single select behaviour', async () => {
       await render({ checkboxes: false });

--- a/apis/nucleus/src/components/listbox/hooks/selections/listbox-selections.js
+++ b/apis/nucleus/src/components/listbox/hooks/selections/listbox-selections.js
@@ -24,39 +24,32 @@ export function getSelectedValues(pages) {
   return flatten(elementNbrs);
 }
 
-export function applySelectionsOnPages(pages, elmNumbers, clearAllButElmNumbers = false) {
-  const getNewSelectionState = (qState) => (elmNumbers.length <= 1 && isStateSelected(qState) ? 'A' : 'S');
-  const matrices = pages.map((page) => {
-    const qMatrix = page.qMatrix.map((p) => {
-      const [p0] = p;
-      const selectionMatchesElement = elmNumbers.includes(p0.qElemNumber);
-      let qState;
-      if (clearAllButElmNumbers) {
-        qState = selectionMatchesElement ? 'S' : 'A';
-      } else {
-        qState = selectionMatchesElement ? getNewSelectionState(p0.qState) : p0.qState;
-      }
-      return [{ ...p0, qState }, p.slice(1)];
-    });
-    return { ...page, qMatrix };
-  });
-  return matrices;
-}
-
-export async function selectValues({ selections, elemNumbers, isSingleSelect = false }) {
-  let resolved = Promise.resolve(false);
+export async function selectValues({ selections, elemNumbers, toggle, isSingleSelect }) {
+  if (elemNumbers.length === 0) {
+    return false;
+  }
   const hasNanValues = elemNumbers.some((elemNumber) => Number.isNaN(elemNumber));
+  let success = false;
   if (!hasNanValues) {
     const elemNumbersToSelect = elemNumbers;
-    resolved = selections
-      .select({
+    try {
+      const response = await selections.select({
         method: 'selectListObjectValues',
-        params: ['/qListObjectDef', elemNumbersToSelect, !isSingleSelect],
-      })
-      .then((success) => success !== false)
-      .catch(() => false);
+        params: ['/qListObjectDef', elemNumbersToSelect, toggle],
+      });
+      success = response !== false;
+    } catch {
+      success = false;
+    }
+    if (!success) {
+      if (isSingleSelect) {
+        selections.cancel(); // revert selection
+      } else {
+        selections.clear();
+      }
+    }
   }
-  return resolved;
+  return success;
 }
 
 export function getElemNumbersFromPages(pages) {

--- a/apis/nucleus/src/components/listbox/hooks/selections/selectionState.js
+++ b/apis/nucleus/src/components/listbox/hooks/selections/selectionState.js
@@ -1,0 +1,103 @@
+import { getSelectedValues } from './listbox-selections';
+
+export default function selectionState(setPages) {
+  const state = {
+    itemStates: {},
+    ignoreSelectionState: false,
+    selectedInEngine: [],
+    enginePages: [],
+    layout: undefined,
+
+    update({ pages, isSingleSelect, selectDisabled, layout }) {
+      if (state.enginePages !== pages && pages !== undefined) {
+        state.enginePages = pages ?? [];
+        state.selectedInEngine = getSelectedValues(pages);
+        state.selectableValuesUpdating = false;
+        state.triggerStateChanged();
+      }
+      state.isSingleSelect = isSingleSelect;
+      state.selectDisabled = selectDisabled;
+      state.isDimCalculated = layout?.qListObject?.qDimensionInfo?.qIsCalculated ?? false;
+    },
+
+    allowedToSelect() {
+      if (state.selectDisabled()) {
+        return false;
+      }
+      // When a dim is calculated, the rows must be done updating after previeous selection
+      return !(state.isDimCalculated && state.selectableValuesUpdating);
+    },
+
+    setSelectableValuesUpdating() {
+      state.selectableValuesUpdating = true;
+    },
+
+    useClientItemState(elementNumber) {
+      return state.ignoreSelectionState || elementNumber in state.itemStates;
+    },
+
+    isSelected(elementNumber) {
+      if (state.useClientItemState(elementNumber)) {
+        return !!state.itemStates[elementNumber];
+      }
+      return state.selectedInEngine.includes(elementNumber);
+    },
+
+    getState(item) {
+      const { qElemNumber, qState } = item;
+      if (!state.useClientItemState(qElemNumber)) {
+        return qState;
+      }
+      if (state.itemStates[qElemNumber]) {
+        return qState === 'XS' ? 'XS' : 'S';
+      }
+      return qState === 'S' || qState === 'XS' ? 'A' : qState;
+    },
+
+    updateItemNoEvents(elementNumber, additive, selectedValues) {
+      const selected = state.isSelected(elementNumber);
+
+      if (selected && !additive) {
+        state.itemStates[elementNumber] = false;
+      } else if (!selected) {
+        selectedValues?.push(elementNumber);
+        state.itemStates[elementNumber] = true;
+      }
+    },
+
+    triggerStateChanged() {
+      const pages = state.applySelectionsOnPages(state.enginePages);
+      setPages(pages);
+    },
+
+    applySelectionsOnPages(pages) {
+      const matrices = pages.map((page) => {
+        const qMatrix = page.qMatrix.map((p) => {
+          const [p0] = p;
+          const qState = state.getState(p0);
+          return [{ ...p0, qState }, ...p.slice(1)];
+        });
+        return { ...page, qMatrix };
+      });
+      return matrices;
+    },
+
+    updateItem(elementNumber, additive, selectedValues) {
+      state.updateItemNoEvents(elementNumber, additive, selectedValues);
+      state.triggerStateChanged();
+    },
+
+    updateItems(elementNumbers, additive, selectedValues) {
+      elementNumbers.forEach((elementNumber) => {
+        state.updateItemNoEvents(elementNumber, additive, selectedValues);
+      });
+      state.triggerStateChanged();
+    },
+
+    clearItemStates(ignoreSelectionState) {
+      state.itemStates = {};
+      state.ignoreSelectionState = ignoreSelectionState;
+    },
+  };
+  return state;
+}

--- a/apis/nucleus/src/components/listbox/hooks/selections/selectionState.js
+++ b/apis/nucleus/src/components/listbox/hooks/selections/selectionState.js
@@ -6,17 +6,19 @@ export default function selectionState() {
     ignoreSelectionState: false,
     selectedInEngine: [],
     enginePages: [],
-    layout: undefined,
     setPages: undefined,
+    lastRowCount: undefined,
+    lastApprMaxGlyphCount: undefined,
 
     update({ setPages, pages, isSingleSelect, selectDisabled, layout }) {
       this.setPages = setPages;
-      const isSameRowCount = this.layout?.qListObject?.qSize?.qcy === layout.qListObject.qSize.qcy;
-      const isSameMaxGlyphCnt =
-        this.layout?.qListObject?.qDimensionInfo?.qApprMaxGlyphCount ===
-        layout.qListObject.qDimensionInfo.qApprMaxGlyphCount;
+      const isSameRowCount = this.lastRowCount === layout.qListObject.qSize.qcy;
+      const isSameMaxGlyphCnt = this.lastApprMaxGlyphCount === layout.qListObject.qDimensionInfo.qApprMaxGlyphCount;
 
       if (!isSameRowCount || !isSameMaxGlyphCnt) {
+        this.lastRowCount = layout.qListObject.qSize.qcy;
+        this.lastApprMaxGlyphCount = layout.qListObject.qDimensionInfo.qApprMaxGlyphCount;
+
         // The field have probably changed (drill up/down)
         // need to clear the client side item states since the field values have changed
         this.clearItemStates(false);
@@ -28,7 +30,6 @@ export default function selectionState() {
         state.selectableValuesUpdating = false;
         state.triggerStateChanged();
       }
-      state.layout = layout;
       state.isSingleSelect = isSingleSelect;
       state.selectDisabled = selectDisabled;
       state.isDimCalculated = layout?.qListObject?.qDimensionInfo?.qIsCalculated ?? false;

--- a/apis/nucleus/src/components/listbox/interactions/listbox-selection-toolbar.js
+++ b/apis/nucleus/src/components/listbox/interactions/listbox-selection-toolbar.js
@@ -3,7 +3,7 @@ import { selectAlternative } from '@nebula.js/ui/icons/select-alternative';
 import { selectPossible } from '@nebula.js/ui/icons/select-possible';
 import { selectExcluded } from '@nebula.js/ui/icons/select-excluded';
 
-export default ({ layout, model, translator }) => {
+export default ({ layout, model, translator, selectionState }) => {
   if (layout.qListObject.qDimensionInfo.qIsOneAndOnlyOne) {
     return [];
   }
@@ -26,6 +26,7 @@ export default ({ layout, model, translator }) => {
       getSvgIconShape: selectAll,
       enabled: canSelectAll,
       action: () => {
+        selectionState.clearItemStates(false);
         model.selectListObjectAll('/qListObjectDef');
       },
     },
@@ -36,6 +37,7 @@ export default ({ layout, model, translator }) => {
       getSvgIconShape: selectPossible,
       enabled: canSelectPossible,
       action: () => {
+        selectionState.clearItemStates(false);
         model.selectListObjectPossible('/qListObjectDef');
       },
     },
@@ -46,6 +48,7 @@ export default ({ layout, model, translator }) => {
       getSvgIconShape: selectAlternative,
       enabled: canSelectAlternative,
       action: () => {
+        selectionState.clearItemStates(false);
         model.selectListObjectAlternative('/qListObjectDef');
       },
     },
@@ -56,6 +59,7 @@ export default ({ layout, model, translator }) => {
       getSvgIconShape: selectExcluded,
       enabled: canSelectExcluded,
       action: () => {
+        selectionState.clearItemStates(false);
         model.selectListObjectExcluded('/qListObjectDef');
       },
     },

--- a/test/rendering/listbox/listbox.js
+++ b/test/rendering/listbox/listbox.js
@@ -5,6 +5,8 @@
       id: `listbox-${+new Date()}`,
       getListObjectData: async () => (fixture ? fixture.getListObjectData() : getMockData()),
       getLayout: async () => (fixture ? fixture.getLayout() : getListboxLayout()),
+      beginSelections: async () => {},
+      selectListObjectValues: async () => true,
       on() {},
       once() {},
     };


### PR DESCRIPTION
## Motivation

Refactor client side selection state to prevent flickering from engine update during selection

select without waiting for previous selection to be done (work for range select as local client state is updated)

(I found one edge case (also in old sense-client listbox) if a failed selection is followed by a working selection (before the response that the first failed) that unnecessary also clear both)

Properly wait for update from onging selection before starting whenthe field is calculated. (before it only waited for the selectListObjectValues to be done not for fetching the new layout/getListObjectData)

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
