### PR TITLE
fix: hide search icon and scrollbar of a filter pane in edit mode

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -18,6 +18,7 @@ const DEFAULT_MIN_BATCH_SIZE = 100;
 
 export default function ListBox({
   model,
+  constraints,
   layout,
   selections,
   direction,
@@ -249,6 +250,7 @@ export default function ListBox({
     setScrollPosition,
     focusListItems: getFocusState(),
     setCurrentScrollIndex: currentScrollIndex.set,
+    constraints,
   });
 
   const { columnWidth, listHeight, itemSize } = sizes || {};

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -211,24 +211,26 @@ function ListBoxInline({ options, layout }) {
       {toolbar && (
         <Grid item container style={{ padding: theme.spacing(1) }} wrap="nowrap">
           <Grid item container height={headerHeight} wrap="nowrap">
-            <Grid item sx={{ display: 'flex', alignItems: 'center', width: searchIconWidth }}>
-              {isLocked ? (
-                <IconButton tabIndex={-1} onClick={unlock} disabled={!isLocked} size="large">
-                  <Lock title={translator.get('Listbox.Unlock')} style={{ fontSize: '12px' }} />
-                </IconButton>
-              ) : (
-                searchEnabled !== false && (
-                  <IconButton
-                    onClick={onShowSearch}
-                    tabIndex={-1}
-                    title={translator.get('Listbox.Search')}
-                    size="large"
-                  >
-                    <SearchIcon style={{ fontSize: '12px' }} />
+            {(isLocked || (searchEnabled !== false && !constraints.active)) && (
+              <Grid item sx={{ display: 'flex', alignItems: 'center', width: searchIconWidth }}>
+                {isLocked ? (
+                  <IconButton tabIndex={-1} onClick={unlock} disabled={!isLocked} size="large">
+                    <Lock title={translator.get('Listbox.Unlock')} style={{ fontSize: '12px' }} />
                   </IconButton>
-                )
-              )}
-            </Grid>
+                ) : (
+                  searchEnabled !== false && (
+                    <IconButton
+                      onClick={onShowSearch}
+                      tabIndex={-1}
+                      title={translator.get('Listbox.Search')}
+                      size="large"
+                    >
+                      <SearchIcon style={{ fontSize: '12px' }} />
+                    </IconButton>
+                  )
+                )}
+              </Grid>
+            )}
             <Grid item className={classes.listBoxHeader}>
               {showTitle && (
                 <Title variant="h6" noWrap>
@@ -292,6 +294,7 @@ function ListBoxInline({ options, layout }) {
             {({ height, width }) => (
               <ListBox
                 model={model}
+                constraints={constraints}
                 layout={layout}
                 selections={selections}
                 direction={direction}

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -194,7 +194,7 @@ function ListBoxInline({ options, layout }) {
   };
 
   const shouldAutoFocus = searchVisible && search === 'toggle';
-  const showIcon = isLocked || (searchEnabled !== false && !constraints.active);
+  const showIcon = isLocked || (searchEnabled !== false && !constraints?.active);
 
   return (
     <StyledGrid

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -194,6 +194,7 @@ function ListBoxInline({ options, layout }) {
   };
 
   const shouldAutoFocus = searchVisible && search === 'toggle';
+  const showIcon = isLocked || (searchEnabled !== false && !constraints.active);
 
   return (
     <StyledGrid
@@ -211,23 +212,21 @@ function ListBoxInline({ options, layout }) {
       {toolbar && (
         <Grid item container style={{ padding: theme.spacing(1) }} wrap="nowrap">
           <Grid item container height={headerHeight} wrap="nowrap">
-            {(isLocked || (searchEnabled !== false && !constraints.active)) && (
+            {showIcon && (
               <Grid item sx={{ display: 'flex', alignItems: 'center', width: searchIconWidth }}>
                 {isLocked ? (
-                  <IconButton tabIndex={-1} onClick={unlock} disabled={!isLocked} size="large">
+                  <IconButton tabIndex={-1} onClick={unlock} disabled={selectDisabled()} size="large">
                     <Lock title={translator.get('Listbox.Unlock')} style={{ fontSize: '12px' }} />
                   </IconButton>
                 ) : (
-                  searchEnabled !== false && (
-                    <IconButton
-                      onClick={onShowSearch}
-                      tabIndex={-1}
-                      title={translator.get('Listbox.Search')}
-                      size="large"
-                    >
-                      <SearchIcon style={{ fontSize: '12px' }} />
-                    </IconButton>
-                  )
+                  <IconButton
+                    onClick={onShowSearch}
+                    tabIndex={-1}
+                    title={translator.get('Listbox.Search')}
+                    size="large"
+                  >
+                    <SearchIcon style={{ fontSize: '12px' }} />
+                  </IconButton>
                 )}
               </Grid>
             )}

--- a/apis/nucleus/src/components/listbox/components/grid-list-components/grid-list-components.jsx
+++ b/apis/nucleus/src/components/listbox/components/grid-list-components/grid-list-components.jsx
@@ -83,7 +83,7 @@ export default function getListBoxComponents({
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...commonComponentOptions}
         dataTestid="fixed-size-list"
-        scrollDisabled={constraints.active}
+        scrollDisabled={constraints?.active}
         height={listHeight}
         width={width}
         itemCount={listCount}
@@ -152,7 +152,7 @@ export default function getListBoxComponents({
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...commonComponentOptions}
         dataTestid="fixed-size-grid"
-        scrollDisabled={constraints.active}
+        scrollDisabled={constraints?.active}
         height={gridHeight}
         width={width}
         columnCount={columnCount}

--- a/apis/nucleus/src/components/listbox/components/grid-list-components/grid-list-components.jsx
+++ b/apis/nucleus/src/components/listbox/components/grid-list-components/grid-list-components.jsx
@@ -34,6 +34,7 @@ export default function getListBoxComponents({
   setScrollPosition,
   focusListItems,
   setCurrentScrollIndex,
+  constraints,
 }) {
   const { layoutOptions = {}, frequencyMax } = layout || {};
   const { itemPadding, listHeight, itemSize, rowCount, columnCount } = sizes || {};
@@ -82,6 +83,7 @@ export default function getListBoxComponents({
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...commonComponentOptions}
         dataTestid="fixed-size-list"
+        scrollDisabled={constraints.active}
         height={listHeight}
         width={width}
         itemCount={listCount}
@@ -150,6 +152,7 @@ export default function getListBoxComponents({
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...commonComponentOptions}
         dataTestid="fixed-size-grid"
+        scrollDisabled={constraints.active}
         height={gridHeight}
         width={width}
         columnCount={columnCount}

--- a/apis/nucleus/src/components/listbox/components/grid-list-components/styled-components.js
+++ b/apis/nucleus/src/components/listbox/components/grid-list-components/styled-components.js
@@ -11,9 +11,9 @@ export const classes = {
 };
 
 export default function getStyledComponents() {
-  const scrollbarStyling = {
+  const getScrollbarStyling = (scrollDisabled) => ({
     scrollbarColor: `${scrollBarThumb} ${scrollBarBackground}`,
-
+    overflow: scrollDisabled ? 'hidden !important' : undefined,
     '&::-webkit-scrollbar': {
       width: 10,
       height: 10,
@@ -31,10 +31,12 @@ export default function getStyledComponents() {
     '&::-webkit-scrollbar-thumb:hover': {
       backgroundColor: scrollBarThumbHover,
     },
-  };
+  });
 
-  const StyledFixedSizeList = styled(FixedSizeList)(() => ({
-    [`&.${classes.styledScrollbars}`]: scrollbarStyling,
+  const StyledFixedSizeList = styled(FixedSizeList, {
+    shouldForwardProp: (prop) => prop !== 'scrollDisabled',
+  })(({ scrollDisabled }) => ({
+    [`&.${classes.styledScrollbars}`]: getScrollbarStyling(scrollDisabled),
     // TODO: Verify these props and make generic together with grid component.
     '&::-webkit-scrollbar': {
       width: 10,
@@ -55,8 +57,10 @@ export default function getStyledComponents() {
     },
   }));
 
-  const StyledFixedSizeGrid = styled(FixedSizeGrid)(() => ({
-    [`&.${classes.styledScrollbars}`]: scrollbarStyling,
+  const StyledFixedSizeGrid = styled(FixedSizeGrid, {
+    shouldForwardProp: (prop) => prop !== 'scrollDisabled',
+  })(({ scrollDisabled }) => ({
+    [`&.${classes.styledScrollbars}`]: getScrollbarStyling(scrollDisabled),
 
     '&::-webkit-scrollbar': {
       width: 10,


### PR DESCRIPTION
In edit mode, the search icon should be not shown and scrolling should be disabled (or the scroll bar should not be shown).
This PR is to fix https://github.com/qlik-oss/sn-list-objects/issues/72.