### PR TITLE
fix: use a key which triggers update of highlight component

### DIFF
--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/FieldWithRanges.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/FieldWithRanges.jsx
@@ -5,16 +5,19 @@ import ValueField from './ValueField';
 function LabelsWithRanges({ labels, dense, showGray, checkboxes }) {
   return (
     <>
-      {labels.map(([label, highlighted]) => (
-        <ValueField
-          label={label}
-          key={label}
-          highlighted={highlighted}
-          dense={dense}
-          showGray={showGray}
-          checkboxes={checkboxes}
-        />
-      ))}
+      {labels.map(([label, highlighted], index) => {
+        const key = `${index}`;
+        return (
+          <ValueField
+            label={label}
+            key={key}
+            highlighted={highlighted}
+            dense={dense}
+            showGray={showGray}
+            checkboxes={checkboxes}
+          />
+        );
+      })}
     </>
   );
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

fixes(https://github.com/qlik-oss/sn-list-objects/issues/70)

The algorithm is ok but the `<ValueLabel />` component was not updating due to an incorrect `key`.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
