### PR TITLE
fix: render listLayout opt properly

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -25,7 +25,6 @@ export default function ListBox({
   checkboxes: checkboxOption,
   height,
   width,
-  listLayout = 'vertical',
   frequencyMode,
   update = undefined,
   fetchStart = undefined,
@@ -165,9 +164,7 @@ export default function ListBox({
 
   let minimumBatchSize = DEFAULT_MIN_BATCH_SIZE;
 
-  const isVertical = layoutOptions.dataLayout
-    ? layoutOptions.dataLayout === 'singleColumn'
-    : listLayout !== 'horizontal';
+  const isVertical = layoutOptions.dataLayout !== 'grid';
 
   const count = layout?.qListObject.qSize?.qcy;
 

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -49,7 +49,6 @@ function ListBoxInline({ options, layout }) {
     app,
     direction,
     frequencyMode,
-    listLayout,
     checkboxes,
     search = true,
     focusSearch = false,
@@ -297,7 +296,6 @@ function ListBoxInline({ options, layout }) {
                 layout={layout}
                 selections={selections}
                 direction={direction}
-                listLayout={listLayout}
                 frequencyMode={frequencyMode}
                 rangeSelect={rangeSelect}
                 checkboxes={checkboxes}

--- a/apis/nucleus/src/components/listbox/__tests__/list-box.test.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box.test.jsx
@@ -157,7 +157,6 @@ describe('<Listbox />', () => {
                 direction={mergedArgs.direction}
                 height={mergedArgs.height}
                 width={mergedArgs.width}
-                listLayout={mergedArgs.listLayout}
                 update={mergedArgs.update}
                 selectDisabled={mergedArgs.selectDisabled}
                 fetchStart={mergedArgs.fetchStart}
@@ -239,8 +238,24 @@ describe('<Listbox />', () => {
       expect(FixedSizeList.mock.calls.length).toBeGreaterThan(0);
     });
 
-    test('should use columns for horizontal layout', async () => {
-      args.listLayout = 'horizontal';
+    test('should render as list by default and when layoutOption.dataLayout is set to "singleColumn"', async () => {
+      await render();
+      expect(FixedSizeGrid.mock.calls).toHaveLength(0);
+      expect(FixedSizeList.mock.calls.length).toBeGreaterThan(0);
+
+      layout.layoutOptions = {
+        dataLayout: 'singleColumn',
+      };
+
+      await render();
+      expect(FixedSizeGrid.mock.calls).toHaveLength(0);
+      expect(FixedSizeList.mock.calls.length).toBeGreaterThan(0);
+    });
+
+    test('should render as grid when layoutOptions.dataLayout is set to "grid"', async () => {
+      layout.layoutOptions = {
+        dataLayout: 'grid',
+      };
       await render();
       expect(FixedSizeGrid.mock.calls.length).toBeGreaterThan(0);
       expect(FixedSizeList.mock.calls).toHaveLength(0);

--- a/apis/nucleus/src/components/listbox/components/grid-list-components/__tests__/__snapshots__/grid-list-components.spec.jsx.snap
+++ b/apis/nucleus/src/components/listbox/components/grid-list-components/__tests__/__snapshots__/grid-list-components.spec.jsx.snap
@@ -91,7 +91,7 @@ exports[`grid-list-components should create a List component 1`] = `
     }
   }
   itemSize={100}
-  layout="listLayout"
+  layout="vertical"
   onItemsRendered={[Function]}
   overscanCount={2}
   useIsScrolling={true}

--- a/apis/nucleus/src/components/listbox/components/grid-list-components/__tests__/grid-list-components.spec.jsx
+++ b/apis/nucleus/src/components/listbox/components/grid-list-components/__tests__/grid-list-components.spec.jsx
@@ -82,7 +82,6 @@ describe('grid-list-components', () => {
         setScrollPos: jest.fn(),
       },
       direction: 'ltr',
-      listLayout: 'listLayout',
       sizes: {
         listHeight: 300,
         listCount: 100,

--- a/apis/nucleus/src/components/listbox/components/grid-list-components/grid-list-components.jsx
+++ b/apis/nucleus/src/components/listbox/components/grid-list-components/grid-list-components.jsx
@@ -27,7 +27,6 @@ export default function getListBoxComponents({
   showGray,
   scrollState,
   direction,
-  listLayout,
   sizes,
   listCount,
   overflowDisclaimer,
@@ -87,7 +86,6 @@ export default function getListBoxComponents({
         height={listHeight}
         width={width}
         itemCount={listCount}
-        layout={listLayout}
         itemData={{ ...commonItemData, listCount }}
         itemSize={itemSize}
         onItemsRendered={(renderProps) => {

--- a/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
@@ -35,7 +35,7 @@ export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, opti
     }
   }, []);
 
-  const { dense, checkboxes, properties = {} } = options;
+  const { dense, checkboxes, listLayout, properties = {} } = options;
   let { frequencyMode, histogram = false } = options;
 
   if (fieldDef && fieldDef.failedToFetchFieldDef) {
@@ -62,6 +62,14 @@ export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, opti
   }
 
   const getListdefFrequencyMode = () => (histogram && frequencyMode === 'N' ? 'V' : frequencyMode);
+  const layoutOptions = { dense };
+
+  if (listLayout === 'horizontal') {
+    layoutOptions.dataLayout = 'grid';
+    layoutOptions.layoutOrder = 'column';
+    layoutOptions.maxVisibleColumns = { auto: true };
+    layoutOptions.maxVisibleRows = { auto: false, maxRows: 1 };
+  }
 
   const id = useRef();
   if (!id.current) {
@@ -99,9 +107,7 @@ export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, opti
     },
     histogram,
     checkboxes,
-    layoutOptions: {
-      dense,
-    },
+    layoutOptions,
     title,
   };
   extend(true, listdef, properties);


### PR DESCRIPTION
Solves #1120 - rendering of field with `listLayout` option set to `"horizontal"` which has been broken for a while.

This is how it looks like:
<img width="807" alt="onerow" src="https://user-images.githubusercontent.com/13997395/224553976-7283ea06-c226-4ddc-84fa-e6cb5f0efc13.png">

Behind the scenes, the option is picked up when rendering a session-based/"one the fly" field and "translated" into the following properties:

```
layoutOptions: {
  dataLayout: 'grid',
  layoutOrder: 'column',
  maxVisibleColumns: { auto: true },
  maxVisibleRows: { auto: false, maxRows: 1 }
}
```