### PR TITLE
fix: repair listlayout option

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -24,7 +24,6 @@ export default function ListBox({
   checkboxes: checkboxOption,
   height,
   width,
-  listLayout = 'vertical',
   frequencyMode,
   update = undefined,
   fetchStart = undefined,
@@ -164,9 +163,7 @@ export default function ListBox({
 
   let minimumBatchSize = DEFAULT_MIN_BATCH_SIZE;
 
-  const isVertical = layoutOptions.dataLayout
-    ? layoutOptions.dataLayout === 'singleColumn'
-    : listLayout !== 'horizontal';
+  const isVertical = layoutOptions.dataLayout ? layoutOptions.dataLayout === 'singleColumn' : true;
 
   const count = layout?.qListObject.qSize?.qcy;
 

--- a/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useOnTheFlyModel.jsx
@@ -35,7 +35,7 @@ export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, opti
     }
   }, []);
 
-  const { dense, checkboxes, properties = {} } = options;
+  const { dense, checkboxes, properties = {}, listLayout } = options;
   let { frequencyMode, histogram = false } = options;
 
   if (fieldDef && fieldDef.failedToFetchFieldDef) {
@@ -100,6 +100,11 @@ export default function useOnTheFlyModel({ app, fieldIdentifier, stateName, opti
     checkboxes,
     layoutOptions: {
       dense,
+      dataLayout: listLayout === 'horizontal' ? 'grid' : 'singleColumn',
+      layoutOrder: listLayout === 'horizontal' ? 'row' : 'column',
+      maxVisibleColumns: {
+        auto: true,
+      },
     },
     title,
   };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

The listlayout option was broken, so I added it into the useOnTheFlyModel using the props from sn-listbox. This should later be changed so that options always override the props if passed, regardless of which listbox you are using.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
