### PR TITLE
fix: align search icons and cells

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -15,9 +15,9 @@ import ListBoxSearch from './components/ListBoxSearch';
 import { getListboxInlineKeyboardNavigation } from './interactions/listbox-keyboard-navigation';
 import addListboxTheme from './assets/addListboxTheme';
 import useAppSelections from '../../hooks/useAppSelections';
+import { CELL_PADDING_LEFT, ICON_PADDING } from './constants';
 
 const PREFIX = 'ListBoxInline';
-const ICON_PADDING = 7;
 const searchIconWidth = 28;
 const drillDownIconWidth = 24;
 const classes = {
@@ -200,7 +200,7 @@ function ListBoxInline({ options, layout }) {
   const showIcons = showSearchOrLockIcon || isDrillDown;
   const iconsWidth = (showSearchOrLockIcon ? searchIconWidth : 0) + (isDrillDown ? drillDownIconWidth : 0);
   const drillDownPaddingLeft = showSearchOrLockIcon ? 0 : ICON_PADDING;
-  const headerPaddingLeft = parseFloat(theme.spacing(1)) - (showIcons ? ICON_PADDING : 0);
+  const headerPaddingLeft = CELL_PADDING_LEFT - (showIcons ? ICON_PADDING : 0);
 
   return (
     <StyledGrid

--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { styled } from '@mui/material/styles';
 import classes from '../helpers/classes';
 import { barBorderWidthPx, barPadPx, barWithCheckboxLeftPadPx } from '../helpers/constants';
+import { CELL_PADDING_LEFT } from '../../../constants';
 
 const getSelectedStyle = ({ theme }) => ({
   background: theme.palette.selected.main,
@@ -55,7 +56,7 @@ const RowColRoot = styled('div', {
     minWidth: 0,
     flexGrow: 1,
     // Note that this padding is overridden when using checkboxes.
-    paddingLeft: '9px',
+    paddingLeft: `${CELL_PADDING_LEFT}px`,
     paddingRight: 0,
   },
 

--- a/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
@@ -5,6 +5,7 @@ import { styled } from '@mui/material/styles';
 import Search from '@nebula.js/ui/icons/search';
 import InstanceContext from '../../../contexts/InstanceContext';
 import useDataStore from '../hooks/useDataStore';
+import { CELL_PADDING_LEFT } from '../constants';
 
 const TREE_PATH = '/qListObjectDef';
 const WILDCARD = '**';
@@ -147,6 +148,7 @@ export default function ListBoxSearch({
           '&:hover': {
             border: 'none',
           },
+          paddingLeft: `${CELL_PADDING_LEFT}px`,
         },
         dense && {
           fontSize: 12,

--- a/apis/nucleus/src/components/listbox/constants.jsx
+++ b/apis/nucleus/src/components/listbox/constants.jsx
@@ -1,0 +1,2 @@
+export const ICON_PADDING = 7;
+export const CELL_PADDING_LEFT = 9;


### PR DESCRIPTION
Since now a header can contains many icons like search icon/lock icon and/or drill-down icon, so we also need to align the search icon in the header with the search icon in the search box.

Before (search icons do not align well)
![listbox-basic-linux](https://user-images.githubusercontent.com/20044781/224696721-3ae11584-9c71-49e3-8bb0-b976aacc7b45.png)

After:
![Screenshot 2023-03-13 at 13 07 02](https://user-images.githubusercontent.com/20044781/224697211-0e870690-be0d-4999-a075-c377ac47fef3.png)


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
