### PR TITLE
fix: clear old handler when sn-filter-pane is cut/deleted

### DIFF
--- a/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/useExistingModel.jsx
@@ -22,6 +22,9 @@ export default function useExistingModel({ app, qId, options = {} }) {
       } else {
         const m = await app.getObject(qId);
         modelStore.set(m.id, m);
+        m.once('closed', () => {
+          modelStore.clear(m.id);
+        });
         setModel(m);
       }
     }


### PR DESCRIPTION
On cutting or deleting a listbox, its handler become invalid so we should clear its handler.
This is to fix https://github.com/qlik-oss/sn-list-objects/issues/133

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
