### PR TITLE
fix: remove correct listener & add extra event

### DIFF
--- a/apis/nucleus/src/components/listbox/hooks/selections/useSelectionsInteractions.js
+++ b/apis/nucleus/src/components/listbox/hooks/selections/useSelectionsInteractions.js
@@ -141,7 +141,7 @@ export default function useSelectionsInteractions({ selectionState, selections, 
   }, [onMouseUpDoc]);
 
   useEffect(() => {
-    const onDeactivated = () => {
+    const clearItemStates = () => {
       selectionState.clearItemStates(false);
     };
     const onCleared = () => {
@@ -149,10 +149,12 @@ export default function useSelectionsInteractions({ selectionState, selections, 
       selectionState.triggerStateChanged();
     };
 
-    selections.on('deactivated', onDeactivated);
+    selections.on('clearItemStates', clearItemStates);
+    selections.on('deactivated', clearItemStates);
     selections.on('cleared', onCleared);
     return () => {
-      selections.removeListener('activated', onDeactivated);
+      selections.removeListener('clearItemStates', clearItemStates);
+      selections.removeListener('deactivated', clearItemStates);
       selections.removeListener('cleared', onCleared);
     };
   }, [selections]);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

fix removeListener call 'deactivated' not 'activated'
add extra event ('clearItemStates') for use in direct query use case in sense-client 
(when sense client selection toolbar and not the nebula one is used)

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
