### PR TITLE
fix: add tooltip lock button

### DIFF
--- a/apis/locale/locales/de.json
+++ b/apis/locale/locales/de.json
@@ -149,6 +149,10 @@
     "comment": "Action text to select possible selections",
     "version": "UYEx1K96g9h4HCK3GH/6kg=="
   },
+  "SelectionToolbar.ClickToUnlock": {
+    "value": "Klicken zum Freigeben",
+    "comment": "Unlock a selection from listbox"
+  },
   "Visualization.Incomplete": {
     "value": "Unvollständige Visualisierung",
     "comment": "Status text shown when a visualization is incomplete",

--- a/apis/locale/locales/en-US.json
+++ b/apis/locale/locales/en-US.json
@@ -119,6 +119,10 @@
     "value": "Select possible",
     "comment": "Action text to select possible selections"
   },
+  "SelectionToolbar.ClickToUnlock": {
+    "value": "Click to unlock",
+    "comment": "Unlock a selection in selection toolbar (drl 131023)"
+  },
   "Visualization.LayoutError": {
     "value": "Error",
     "comment": "Status text shown when a visualization has layout errors"

--- a/apis/locale/locales/en-US.json
+++ b/apis/locale/locales/en-US.json
@@ -121,7 +121,7 @@
   },
   "SelectionToolbar.ClickToUnlock": {
     "value": "Click to unlock",
-    "comment": "Unlock a selection in selection toolbar (drl 131023)"
+    "comment": "Unlock a selection from listbox"
   },
   "Visualization.LayoutError": {
     "value": "Error",

--- a/apis/locale/locales/es.json
+++ b/apis/locale/locales/es.json
@@ -149,6 +149,10 @@
     "comment": "Action text to select possible selections",
     "version": "UYEx1K96g9h4HCK3GH/6kg=="
   },
+  "SelectionToolbar.ClickToUnlock": {
+    "value": "Haga clic para desbloquearla",
+    "comment": "Unlock a selection from listbox"
+  },
   "Visualization.Incomplete": {
     "value": "Visualización incompleta",
     "comment": "Status text shown when a visualization is incomplete",

--- a/apis/locale/locales/fr.json
+++ b/apis/locale/locales/fr.json
@@ -149,6 +149,10 @@
     "comment": "Action text to select possible selections",
     "version": "UYEx1K96g9h4HCK3GH/6kg=="
   },
+  "SelectionToolbar.ClickToUnlock": {
+    "value": "Cliquez pour déverrouiller",
+    "comment": "Unlock a selection from listbox"
+  },
   "Visualization.Incomplete": {
     "value": "Visualisation incomplète",
     "comment": "Status text shown when a visualization is incomplete",

--- a/apis/locale/locales/it.json
+++ b/apis/locale/locales/it.json
@@ -149,6 +149,10 @@
     "comment": "Action text to select possible selections",
     "version": "UYEx1K96g9h4HCK3GH/6kg=="
   },
+  "SelectionToolbar.ClickToUnlock": {
+    "value": "Fare clic per sbloccare",
+    "comment": "Unlock a selection from listbox"
+  },
   "Visualization.Incomplete": {
     "value": "Visualizzazione incompleta",
     "comment": "Status text shown when a visualization is incomplete",

--- a/apis/locale/locales/ja.json
+++ b/apis/locale/locales/ja.json
@@ -149,6 +149,10 @@
     "comment": "Action text to select possible selections",
     "version": "UYEx1K96g9h4HCK3GH/6kg=="
   },
+  "SelectionToolbar.ClickToUnlock": {
+    "value": "クリックしてロック解除",
+    "comment": "Unlock a selection from listbox"
+  },
   "Visualization.Incomplete": {
     "value": "未完了のビジュアライゼーション",
     "comment": "Status text shown when a visualization is incomplete",

--- a/apis/locale/locales/ko.json
+++ b/apis/locale/locales/ko.json
@@ -149,6 +149,10 @@
     "comment": "Action text to select possible selections",
     "version": "UYEx1K96g9h4HCK3GH/6kg=="
   },
+  "SelectionToolbar.ClickToUnlock": {
+    "value": "잠금을 해제하려면 클릭하십시오.",
+    "comment": "Unlock a selection from listbox"
+  },
   "Visualization.Incomplete": {
     "value": "완료되지 않은 시각화",
     "comment": "Status text shown when a visualization is incomplete",

--- a/apis/locale/locales/nl.json
+++ b/apis/locale/locales/nl.json
@@ -149,6 +149,10 @@
     "comment": "Action text to select possible selections",
     "version": "UYEx1K96g9h4HCK3GH/6kg=="
   },
+  "SelectionToolbar.ClickToUnlock": {
+    "value": "Klik om te ontgrendelen",
+    "comment": "Unlock a selection from listbox"
+  },
   "Visualization.Incomplete": {
     "value": "Onvolledige visualisatie",
     "comment": "Status text shown when a visualization is incomplete",

--- a/apis/locale/locales/pl.json
+++ b/apis/locale/locales/pl.json
@@ -149,6 +149,10 @@
     "comment": "Action text to select possible selections",
     "version": "UYEx1K96g9h4HCK3GH/6kg=="
   },
+  "SelectionToolbar.ClickToUnlock": {
+    "value": "Aby odblokować, kliknij",
+    "comment": "Unlock a selection from listbox"
+  },
   "Visualization.Incomplete": {
     "value": "Niekompletna wizualizacja",
     "comment": "Status text shown when a visualization is incomplete",

--- a/apis/locale/locales/pt.json
+++ b/apis/locale/locales/pt.json
@@ -149,6 +149,10 @@
     "comment": "Action text to select possible selections",
     "version": "UYEx1K96g9h4HCK3GH/6kg=="
   },
+  "SelectionToolbar.ClickToUnlock": {
+    "value": "Clique para destravar",
+    "comment": "Unlock a selection from listbox"
+  },
   "Visualization.Incomplete": {
     "value": "Visualização incompleta",
     "comment": "Status text shown when a visualization is incomplete",

--- a/apis/locale/locales/ru.json
+++ b/apis/locale/locales/ru.json
@@ -149,6 +149,10 @@
     "comment": "Action text to select possible selections",
     "version": "UYEx1K96g9h4HCK3GH/6kg=="
   },
+  "SelectionToolbar.ClickToUnlock": {
+    "value": "Щелкните, чтобы разблокировать",
+    "comment": "Unlock a selection from listbox"
+  },
   "Visualization.Incomplete": {
     "value": "Незавершенная визуализация",
     "comment": "Status text shown when a visualization is incomplete",

--- a/apis/locale/locales/sv.json
+++ b/apis/locale/locales/sv.json
@@ -149,6 +149,10 @@
     "comment": "Action text to select possible selections",
     "version": "UYEx1K96g9h4HCK3GH/6kg=="
   },
+  "SelectionToolbar.ClickToUnlock": {
+    "value": "Klicka för att låsa upp",
+    "comment": "Unlock a selection from listbox"
+  },
   "Visualization.Incomplete": {
     "value": "Ofullständig visualisering",
     "comment": "Status text shown when a visualization is incomplete",

--- a/apis/locale/locales/tr.json
+++ b/apis/locale/locales/tr.json
@@ -149,6 +149,10 @@
     "comment": "Action text to select possible selections",
     "version": "UYEx1K96g9h4HCK3GH/6kg=="
   },
+  "SelectionToolbar.ClickToUnlock": {
+    "value": "Kilidi kaldırmak için tıklayın",
+    "comment": "Unlock a selection from listbox"
+  },
   "Visualization.Incomplete": {
     "value": "Tamamlanmamış görselleştirme",
     "comment": "Status text shown when a visualization is incomplete",

--- a/apis/locale/locales/zh-CN.json
+++ b/apis/locale/locales/zh-CN.json
@@ -149,6 +149,10 @@
     "comment": "Action text to select possible selections",
     "version": "UYEx1K96g9h4HCK3GH/6kg=="
   },
+  "SelectionToolbar.ClickToUnlock": {
+    "value": "单击以解锁",
+    "comment": "Unlock a selection from listbox"
+  },
   "Visualization.Incomplete": {
     "value": "不完整的可视化",
     "comment": "Status text shown when a visualization is incomplete",

--- a/apis/locale/locales/zh-TW.json
+++ b/apis/locale/locales/zh-TW.json
@@ -149,6 +149,10 @@
     "comment": "Action text to select possible selections",
     "version": "UYEx1K96g9h4HCK3GH/6kg=="
   },
+  "SelectionToolbar.ClickToUnlock": {
+    "value": "按一下以解除鎖定",
+    "comment": "Unlock a selection from listbox"
+  },
   "Visualization.Incomplete": {
     "value": "視覺化未完成",
     "comment": "Status text shown when a visualization is incomplete",

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -275,8 +275,14 @@ function ListBoxInline({ options, layout }) {
               {showIcons && (
                 <Grid item sx={{ display: 'flex', alignItems: 'center', width: iconsWidth }}>
                   {isLocked ? (
-                    <IconButton tabIndex={-1} onClick={unlock} disabled={selectDisabled()} size="large">
-                      <Lock title={translator.get('Listbox.Unlock')} disableRipple style={{ fontSize: '12px' }} />
+                    <IconButton
+                      title={translator.get('SelectionToolbar.ClickToUnlock')}
+                      tabIndex={-1}
+                      onClick={unlock}
+                      disabled={selectDisabled()}
+                      size="large"
+                    >
+                      <Lock disableRipple style={{ fontSize: '12px' }} />
                     </IconButton>
                   ) : (
                     showSearchIcon && (


### PR DESCRIPTION
Add a tooltip for the lock button in listbox inline
## Motivation
Resolves https://github.com/qlik-oss/sn-list-objects/issues/93

<img width="522" alt="Screenshot 2023-03-17 at 13 46 30" src="https://user-images.githubusercontent.com/13185716/225908603-91cea859-07e7-4ea1-aa88-d86c67451f2b.png">
<img width="522" alt="Screenshot 2023-03-17 at 16 03 06" src="https://user-images.githubusercontent.com/13185716/225943416-405c1e29-62d5-47b0-b05d-d64ec44fa75f.png">


<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
