### PR TITLE
feat: pick up enigmaOptions from fixture

### DIFF
--- a/commands/serve/web/render-fixture.js
+++ b/commands/serve/web/render-fixture.js
@@ -103,8 +103,12 @@ const renderFixture = async (params) => {
   const element = document.querySelector('#chart-container');
   const serverInfo = await getConnectionInfo();
   const fixture = await getFixture(params.fixture);
-  const { type, load, genericObjects, instanceConfig, snConfig } = await getOptions({ fixture, params, serverInfo });
-  const mockedApp = await EnigmaMocker.fromGenericObjects(genericObjects);
+  const { type, load, genericObjects, instanceConfig, snConfig, enigmaOptions } = await getOptions({
+    fixture,
+    params,
+    serverInfo,
+  });
+  const mockedApp = await EnigmaMocker.fromGenericObjects(genericObjects, enigmaOptions);
   const qId = getQId(genericObjects);
 
   const nebbie = embed(mockedApp, {


### PR DESCRIPTION
Makes it possible to pass in options to enigmaMocker even when using it indirectly through nebula serve by picking up `enigmaOptions` from the root of the fixture. 