### PR TITLE
fix: do not show search box on selection

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -150,6 +150,9 @@ function ListBoxInline({ options, layout }) {
     };
     const hide = () => {
       setShowToolbar(false);
+      if (search === 'toggle') {
+        setShowSearch(false);
+      }
     };
     if (selections) {
       if (!selections.isModal()) {

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -147,15 +147,9 @@ function ListBoxInline({ options, layout }) {
   useEffect(() => {
     const show = () => {
       setShowToolbar(true);
-      if (search === 'toggle' && toolbar === false) {
-        setShowSearch(true);
-      }
     };
     const hide = () => {
       setShowToolbar(false);
-      if (search === 'toggle') {
-        setShowSearch(false);
-      }
     };
     if (selections) {
       if (!selections.isModal()) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation
Currently if the listbox has no title, the search box will be shown on selection activated. However, search box should only be shown if the user clicks the search icon, otherwise it should not be shown.
This is to fix https://github.com/qlik-oss/sn-list-objects/issues/181.
## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
