### PR TITLE
fix: escapeField used for getFrequencyMaxExpression

### DIFF
--- a/apis/nucleus/src/components/listbox/utils/__tests__/frequencyMaxUtil.test.jsx
+++ b/apis/nucleus/src/components/listbox/utils/__tests__/frequencyMaxUtil.test.jsx
@@ -1,0 +1,9 @@
+import { getFrequencyMaxExpression } from '../frequencyMaxUtil';
+
+describe('frequencyMaxUtil - getFrequencyMaxExpression', () => {
+  test('should create correct expression and wrap and escape field if needed', async () => {
+    const result = getFrequencyMaxExpression('dimension with ] in it');
+
+    expect(result).toEqual('Max(AGGR(Count([dimension with ]] in it]), [dimension with ]] in it]))');
+  });
+});

--- a/apis/nucleus/src/components/listbox/utils/frequencyMaxUtil.js
+++ b/apis/nucleus/src/components/listbox/utils/frequencyMaxUtil.js
@@ -2,7 +2,10 @@ const escapeField = (field) => {
   if (!field) {
     return field;
   }
-  return `${field.replace(/\]/g, ']]')}`;
+  if (/^[A-Za-z][A-Za-z0-9_]*$/.test(field)) {
+    return field;
+  }
+  return `[${field.replace(/\]/g, ']]')}]`;
 };
 
 export const needToFetchFrequencyMax = (layout) => layout?.frequencyMax === 'fetch';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

was borken when the field needed to be wrapped in [...].

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
