### PR TITLE
Hva/sn filter pane 184

### DIFF
--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/ListBoxRowColumn.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/ListBoxRowColumn.jsx
@@ -164,7 +164,7 @@ function RowColumn({ index, rowIndex, columnIndex, style, data }) {
   const isFirstElement = index === 0;
   const flexBasisVal = checkboxes ? 'auto' : 'max-content';
 
-  const showLock = isSelected && isLocked;
+  const showLock = isSelected && isLocked && sizePermitsTick;
   const showTick = !checkboxes && isSelected && !isLocked && sizePermitsTick;
   const showIcon = !checkboxes && (showTick || showLock);
 

--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
@@ -157,7 +157,7 @@ const RowColRoot = styled('div', {
   [`& .${classes.frequencyCount}`]: {
     justifyContent: 'flex-end',
     ...ellipsis,
-    flex: `0 1 ${frequencyWidth + (showIcon || checkboxes ? 0 : iconWidth)}px`,
+    flex: `0 1 ${frequencyWidth + (showIcon || checkboxes || (isGridMode && !isGridCol) ? 0 : iconWidth)}px`,
     textAlign: 'right',
     paddingLeft: '2px',
   },

--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
@@ -68,7 +68,7 @@ const RowColRoot = styled('div', {
     minWidth: 0,
     flexGrow: 1,
     // Note that this padding is overridden when using checkboxes.
-    paddingLeft: `${CELL_PADDING_LEFT}px`,
+    paddingLeft: isGridMode && !isGridCol ? 0 : `${CELL_PADDING_LEFT}px`,
     paddingRight: 0,
   },
 
@@ -77,7 +77,7 @@ const RowColRoot = styled('div', {
     flexBasis: flexBasisProp,
     lineHeight: '16px',
     userSelect: 'none',
-    paddingRight: showIcon || checkboxes ? '1px' : `${iconWidth}px`,
+    paddingRight: showIcon || checkboxes || (isGridMode && !isGridCol) ? '1px' : `${iconWidth}px`,
     ...ellipsis,
     whiteSpace: 'pre', // to keep white-space on highlight
     fontSize: theme.listBox?.content?.fontSize,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

To fix https://github.com/qlik-oss/sn-list-objects/issues/184.
Ticks and lock icons for cells should not be shown in grid mode row and no frequency count. Based on this we update padding for cells.
## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
