### PR TITLE
fix: show search icon in edit mode if the search checkbox is on

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -245,7 +245,7 @@ function ListBoxInline({ options, layout }) {
     containerPadding = layoutOptions.layoutOrder === 'row' ? '2px 4px' : '2px 6px 2px 4px';
   }
 
-  const SearchIconComp = constraints?.active ? (
+  const searchIconComp = constraints?.active ? (
     <SearchIcon title={translator.get('Listbox.Search')} size="large" style={{ fontSize: '12px', padding: '7px' }} />
   ) : (
     <IconButton
@@ -260,7 +260,7 @@ function ListBoxInline({ options, layout }) {
     </IconButton>
   );
 
-  const LockIconComp = selectDisabled() ? (
+  const lockIconComp = selectDisabled() ? (
     <Lock size="large" style={{ fontSize: '12px', padding: '7px' }} />
   ) : (
     <IconButton title={translator.get('SelectionToolbar.ClickToUnlock')} tabIndex={-1} onClick={unlock} size="large">
@@ -306,7 +306,7 @@ function ListBoxInline({ options, layout }) {
             >
               {showIcons && (
                 <Grid item sx={{ display: 'flex', alignItems: 'center', width: iconsWidth }}>
-                  {isLocked ? LockIconComp : showSearchIcon && SearchIconComp}
+                  {isLocked ? lockIconComp : showSearchIcon && searchIconComp}
                   {isDrillDown && (
                     <DrillDownIcon
                       tabIndex={-1}

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -245,6 +245,33 @@ function ListBoxInline({ options, layout }) {
     containerPadding = layoutOptions.layoutOrder === 'row' ? '2px 4px' : '2px 6px 2px 4px';
   }
 
+  const SearchIconComp = constraints?.active ? (
+    <SearchIcon title={translator.get('Listbox.Search')} size="large" style={{ fontSize: '12px', padding: '7px' }} />
+  ) : (
+    <IconButton
+      onClick={onShowSearch}
+      tabIndex={-1}
+      title={translator.get('Listbox.Search')}
+      size="large"
+      disableRipple
+      data-testid="search-toggle-btn"
+    >
+      <SearchIcon style={{ fontSize: '12px' }} />
+    </IconButton>
+  );
+
+  const LockIconComp = selectDisabled() ? (
+    <Lock
+      title={translator.get('SelectionToolbar.ClickToUnlock')}
+      size="large"
+      style={{ fontSize: '12px', padding: '7px' }}
+    />
+  ) : (
+    <IconButton title={translator.get('SelectionToolbar.ClickToUnlock')} tabIndex={-1} onClick={unlock} size="large">
+      <Lock disableRipple style={{ fontSize: '12px' }} />
+    </IconButton>
+  );
+
   return (
     <>
       {toolbarDetachedOnly && <ActionsToolbar direction={direction} {...getActionToolbarProps(true)} />}
@@ -283,33 +310,7 @@ function ListBoxInline({ options, layout }) {
             >
               {showIcons && (
                 <Grid item sx={{ display: 'flex', alignItems: 'center', width: iconsWidth }}>
-                  {isLocked ? (
-                    <IconButton
-                      title={translator.get('SelectionToolbar.ClickToUnlock')}
-                      tabIndex={-1}
-                      onClick={unlock}
-                      disabled={selectDisabled()}
-                      size="large"
-                      sx={{ '&.Mui-disabled': { color: '#000', opacity: 0.9 } }}
-                    >
-                      <Lock disableRipple style={{ fontSize: '12px' }} />
-                    </IconButton>
-                  ) : (
-                    showSearchIcon && (
-                      <IconButton
-                        onClick={onShowSearch}
-                        disabled={!!constraints?.active}
-                        tabIndex={-1}
-                        title={translator.get('Listbox.Search')}
-                        size="large"
-                        disableRipple
-                        data-testid="search-toggle-btn"
-                        sx={{ '&.Mui-disabled': { color: '#000', opacity: 0.9 } }}
-                      >
-                        <SearchIcon style={{ fontSize: '12px' }} />
-                      </IconButton>
-                    )
-                  )}
+                  {isLocked ? LockIconComp : showSearchIcon && SearchIconComp}
                   {isDrillDown && (
                     <DrillDownIcon
                       tabIndex={-1}

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -261,11 +261,7 @@ function ListBoxInline({ options, layout }) {
   );
 
   const LockIconComp = selectDisabled() ? (
-    <Lock
-      title={translator.get('SelectionToolbar.ClickToUnlock')}
-      size="large"
-      style={{ fontSize: '12px', padding: '7px' }}
-    />
+    <Lock size="large" style={{ fontSize: '12px', padding: '7px' }} />
   ) : (
     <IconButton title={translator.get('SelectionToolbar.ClickToUnlock')} tabIndex={-1} onClick={unlock} size="large">
       <Lock disableRipple style={{ fontSize: '12px' }} />

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -231,7 +231,7 @@ function ListBoxInline({ options, layout }) {
     });
 
   const shouldAutoFocus = searchVisible && search === 'toggle';
-  const showSearchIcon = searchEnabled !== false && search === 'toggle' && !constraints?.active;
+  const showSearchIcon = searchEnabled !== false && search === 'toggle';
   const showSearchOrLockIcon = isLocked || showSearchIcon;
   const showIcons = showSearchOrLockIcon || isDrillDown;
   const iconsWidth = (showSearchOrLockIcon ? BUTTON_ICON_WIDTH : 0) + (isDrillDown ? ICON_WIDTH + ICON_PADDING : 0); // Drill-down icon needs padding right so there is space between the icon and the title
@@ -290,6 +290,7 @@ function ListBoxInline({ options, layout }) {
                       onClick={unlock}
                       disabled={selectDisabled()}
                       size="large"
+                      sx={{ '&.Mui-disabled': { color: '#000', opacity: 0.9 } }}
                     >
                       <Lock disableRipple style={{ fontSize: '12px' }} />
                     </IconButton>
@@ -297,11 +298,13 @@ function ListBoxInline({ options, layout }) {
                     showSearchIcon && (
                       <IconButton
                         onClick={onShowSearch}
+                        disabled={!!constraints?.active}
                         tabIndex={-1}
                         title={translator.get('Listbox.Search')}
                         size="large"
                         disableRipple
                         data-testid="search-toggle-btn"
+                        sx={{ '&.Mui-disabled': { color: '#000', opacity: 0.9 } }}
                       >
                         <SearchIcon style={{ fontSize: '12px' }} />
                       </IconButton>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

This is to fix https://github.com/qlik-oss/sn-list-objects/issues/183 and also make search icon and lock icon more readable when it is disabled.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
