### PR TITLE
fix: generic load function should work for existing charts

### DIFF
--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -400,14 +400,6 @@ const Cell = forwardRef(
 
       // Load supernova
       const withVersion = types.getSupportedVersion(layout.visualization, layout.version);
-      if (!withVersion) {
-        if (__NEBULA_DEV__) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `Version ${layout.version} of ${layout.visualization} is not registered. Falling back to other version or generic load function`
-          );
-        }
-      }
       load(layout.visualization, withVersion);
 
       return () => {};

--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -268,7 +268,16 @@ const loadType = async ({ dispatch, types, visualization, version, model, app, s
     });
     return sn;
   } catch (err) {
-    dispatch({ type: 'ERROR', error: { title: err.message } });
+    if (!version) {
+      dispatch({
+        type: 'ERROR',
+        error: {
+          title: `Could not find a version of '${visualization}' that supports current object version. Did you forget to register ${visualization}?`,
+        },
+      });
+    } else {
+      dispatch({ type: 'ERROR', error: { title: err.message } });
+    }
   }
   return undefined;
 };

--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -392,13 +392,12 @@ const Cell = forwardRef(
       // Load supernova
       const withVersion = types.getSupportedVersion(layout.visualization, layout.version);
       if (!withVersion) {
-        dispatch({
-          type: 'ERROR',
-          error: {
-            title: `Could not find a version of '${layout.visualization}' that supports current object version. Did you forget to register ${layout.visualization}?`,
-          },
-        });
-        return undefined;
+        if (__NEBULA_DEV__) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `Version ${layout.version} of ${layout.visualization} is not registered. Falling back to other version or generic load function`
+          );
+        }
       }
       load(layout.visualization, withVersion);
 

--- a/apis/nucleus/src/components/__tests__/cell.test.jsx
+++ b/apis/nucleus/src/components/__tests__/cell.test.jsx
@@ -37,6 +37,8 @@ describe('<Cell />', () => {
   let useObjectSelections;
 
   beforeEach(() => {
+    // eslint-disable-next-line no-underscore-dangle
+    global.__NEBULA_DEV__ = false;
     fakeElement = 'fakeElement';
     Loading = () => 'loading';
     LongRunningQuery = () => 'long-running-query';


### PR DESCRIPTION
## Motivation
When rendering an existing chart using a generic load function, the chart would fail to render due to it being not registerd.
Sample setup:
```
{
const nebbie = nebula.embed({
      context: {
        language: 'en-US',
        constraints: {
          select: false,
          passive: false,
          active: false,
        },
        theme: 'light',
      },
      load: ({ name, version }) => {
        if (name === 'barchart' || name === 'bar') {
          return Promise.resolve(bar);
        }
      }
});


nebbie.render({
  id: "lnjsg"
});

```
This change removes a check in Cell.jsx that stopped us getting to the generic load function. That error is now removed and replaced by a dev warning.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
