### PR TITLE
fix(type): add missing type info required by `sn-table`

### DIFF
--- a/apis/locale/src/translator.js
+++ b/apis/locale/src/translator.js
@@ -14,6 +14,7 @@ export default function translator({ initial = 'en-US', fallback = 'en-US' } = {
   const api = /** @lends Translator# */ {
     /**
      * Returns current locale.
+     * @param {string=} lang - language Locale to updated the currentLocale value
      * @returns {string} current locale.
      */
     language: (lang) => {

--- a/apis/locale/src/translator.js
+++ b/apis/locale/src/translator.js
@@ -12,6 +12,10 @@ export default function translator({ initial = 'en-US', fallback = 'en-US' } = {
    * @class Translator
    */
   const api = /** @lends Translator# */ {
+    /**
+     * Returns current locale.
+     * @returns {string} current locale.
+     */
     language: (lang) => {
       if (lang) {
         currentLocale = lang;

--- a/apis/nucleus/src/hooks/useObjectSelections.js
+++ b/apis/nucleus/src/hooks/useObjectSelections.js
@@ -53,11 +53,11 @@ const createObjectSelections = ({ appSelections, appModal, model }) => {
    * Event listener function on instance
    *
    * @method
-   * @name ObjectSelections#on
+   * @name ObjectSelections#addListener
    * @param {string} eventType event type that function needs to listen
    * @param {Function} callback a callback function to run when event emits
    * @example
-   * api.on('someEvent', () => {...});
+   * api.addListener('someEvent', () => {...});
    */
 
   /**

--- a/apis/nucleus/src/hooks/useObjectSelections.js
+++ b/apis/nucleus/src/hooks/useObjectSelections.js
@@ -50,6 +50,28 @@ const createObjectSelections = ({ appSelections, appModal, model }) => {
   let hasSelected = false;
 
   /**
+   * Event listener function on instance
+   *
+   * @method
+   * @name ObjectSelections#on
+   * @param {string} eventType event type that function needs to listen
+   * @param {Function} callback a callback function to run when event emits
+   * @example
+   * api.on('someEvent', () => {...});
+   */
+
+  /**
+   * Remove listener function on instance
+   *
+   * @method
+   * @name ObjectSelections#removeListener
+   * @param {string} eventType event type that function needs to listen
+   * @param {Function} callback a callback function to run when event emits
+   * @example
+   * api.removeListener('someEvent', () => {...});
+   */
+
+  /**
    * @class
    * @alias ObjectSelections
    */

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1544,6 +1544,33 @@
         }
       }
     },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
+    },
     "Field": {
       "kind": "alias",
       "items": {
@@ -1678,33 +1705,6 @@
           ]
         }
       }
-    },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
-      "kind": "interface",
-      "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
-              "type": "string"
-            }
-          }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
-        }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
     },
     "LoadType": {
       "kind": "interface",
@@ -2125,8 +2125,8 @@
       "kind": "function",
       "params": [
         {
-          "name": "blurState",
-          "description": "parameter to indicate blur state",
+          "name": "resetFocus",
+          "description": "parameter to determines whether the chart should be focused after blurring from inside",
           "type": "boolean"
         }
       ]
@@ -2136,8 +2136,8 @@
       "kind": "function",
       "params": [
         {
-          "name": "focusState",
-          "description": "parameter to indicate focus state",
+          "name": "focusLast",
+          "description": "parameter to determines if the selection toolbar should be focuses the first or last element in the toolbar. if true, the last item is focused.",
           "type": "boolean"
         }
       ]

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1287,6 +1287,26 @@
         "const viz = await embed(app).render({\n  element,\n  type: 'barchart'\n});\nviz.destroy();"
       ]
     },
+    "Flags": {
+      "kind": "interface",
+      "entries": {
+        "isEnabled": {
+          "description": "Checks whether the specified flag is enabled.",
+          "kind": "function",
+          "params": [
+            {
+              "name": "flag",
+              "description": "The value flag to check.",
+              "type": "string"
+            }
+          ],
+          "returns": {
+            "description": "True if the specified flag is enabled, false otherwise.",
+            "type": "boolean"
+          }
+        }
+      }
+    },
     "AppSelections": {
       "kind": "class",
       "constructor": {
@@ -1520,26 +1540,6 @@
                 "type": "undefined"
               }
             ]
-          }
-        }
-      }
-    },
-    "Flags": {
-      "kind": "interface",
-      "entries": {
-        "isEnabled": {
-          "description": "Checks whether the specified flag is enabled.",
-          "kind": "function",
-          "params": [
-            {
-              "name": "flag",
-              "description": "The value flag to check.",
-              "type": "string"
-            }
-          ],
-          "returns": {
-            "description": "True if the specified flag is enabled, false otherwise.",
-            "type": "boolean"
           }
         }
       }

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1344,6 +1344,46 @@
         "params": []
       },
       "entries": {
+        "on": {
+          "description": "Event listener function on instance",
+          "kind": "function",
+          "params": [
+            {
+              "name": "eventType",
+              "description": "event type that function needs to listen",
+              "type": "string"
+            },
+            {
+              "name": "callback",
+              "description": "a callback function to run when event emits",
+              "kind": "function",
+              "params": []
+            }
+          ],
+          "examples": [
+            "api.on('someEvent', () => {...});"
+          ]
+        },
+        "removeListener": {
+          "description": "Remove listener function on instance",
+          "kind": "function",
+          "params": [
+            {
+              "name": "eventType",
+              "description": "event type that function needs to listen",
+              "type": "string"
+            },
+            {
+              "name": "callback",
+              "description": "a callback function to run when event emits",
+              "kind": "function",
+              "params": []
+            }
+          ],
+          "examples": [
+            "api.removeListener('someEvent', () => {...});"
+          ]
+        },
         "begin": {
           "kind": "function",
           "params": [
@@ -2080,6 +2120,39 @@
         }
       }
     },
+    "BlurFunction": {
+      "description": "Blur function",
+      "kind": "function",
+      "params": [
+        {
+          "name": "blurState",
+          "description": "parameter to indicate blur state",
+          "type": "boolean"
+        }
+      ]
+    },
+    "FocusFunction": {
+      "description": "Focus function",
+      "kind": "function",
+      "params": [
+        {
+          "name": "focusState",
+          "description": "parameter to indicate focus state",
+          "type": "boolean"
+        }
+      ]
+    },
+    "FocusSelectionFunction": {
+      "description": "Focus Selection function",
+      "kind": "function",
+      "params": [
+        {
+          "name": "focusState",
+          "description": "parameter to indicate focus state",
+          "type": "boolean"
+        }
+      ]
+    },
     "Keyboard": {
       "stability": "experimental",
       "kind": "interface",
@@ -2094,21 +2167,15 @@
         },
         "blur": {
           "description": "Function used by the visualization to tell Nebula to it wants to relinquish focus",
-          "optional": true,
-          "kind": "function",
-          "params": []
+          "type": "#/definitions/BlurFunction"
         },
         "focus": {
           "description": "Function used by the visualization to tell Nebula to it wants focus",
-          "optional": true,
-          "kind": "function",
-          "params": []
+          "type": "#/definitions/FocusFunction"
         },
         "focusSelection": {
           "description": "Function used by the visualization to tell Nebula to focus the selection toolbar",
-          "optional": true,
-          "kind": "function",
-          "params": []
+          "type": "#/definitions/FocusSelectionFunction"
         }
       }
     },
@@ -2335,6 +2402,15 @@
         "params": []
       },
       "entries": {
+        "language": {
+          "description": "Returns current locale.",
+          "kind": "function",
+          "params": [],
+          "returns": {
+            "description": "current locale.",
+            "type": "string"
+          }
+        },
         "add": {
           "description": "Registers a string in multiple locales",
           "kind": "function",
@@ -2397,6 +2473,18 @@
         "params": []
       },
       "entries": {
+        "name": {
+          "description": "Returns theme name",
+          "kind": "function",
+          "params": [],
+          "returns": {
+            "description": "Current theme.",
+            "type": "string"
+          },
+          "examples": [
+            "theme.name();"
+          ]
+        },
         "getDataColorScales": {
           "kind": "function",
           "params": [],

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1544,33 +1544,6 @@
         }
       }
     },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
-      "kind": "interface",
-      "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
-              "type": "string"
-            }
-          }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
-        }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
-    },
     "Field": {
       "kind": "alias",
       "items": {
@@ -1705,6 +1678,33 @@
           ]
         }
       }
+    },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
     },
     "LoadType": {
       "kind": "interface",
@@ -2156,6 +2156,7 @@
         },
         "blur": {
           "description": "Function used by the visualization to tell Nebula to it wants to relinquish focus",
+          "optional": true,
           "type": "#/definitions/BlurFunction"
         },
         "focus": {
@@ -2166,6 +2167,7 @@
         },
         "focusSelection": {
           "description": "Function used by the visualization to tell Nebula to focus the selection toolbar",
+          "optional": true,
           "type": "#/definitions/FocusSelectionFunction"
         }
       }

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -2131,17 +2131,6 @@
         }
       ]
     },
-    "FocusFunction": {
-      "description": "Focus function",
-      "kind": "function",
-      "params": [
-        {
-          "name": "focusState",
-          "description": "parameter to indicate focus state",
-          "type": "boolean"
-        }
-      ]
-    },
     "FocusSelectionFunction": {
       "description": "Focus Selection function",
       "kind": "function",
@@ -2171,7 +2160,9 @@
         },
         "focus": {
           "description": "Function used by the visualization to tell Nebula to it wants focus",
-          "type": "#/definitions/FocusFunction"
+          "optional": true,
+          "kind": "function",
+          "params": []
         },
         "focusSelection": {
           "description": "Function used by the visualization to tell Nebula to focus the selection toolbar",

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1287,26 +1287,6 @@
         "const viz = await embed(app).render({\n  element,\n  type: 'barchart'\n});\nviz.destroy();"
       ]
     },
-    "Flags": {
-      "kind": "interface",
-      "entries": {
-        "isEnabled": {
-          "description": "Checks whether the specified flag is enabled.",
-          "kind": "function",
-          "params": [
-            {
-              "name": "flag",
-              "description": "The value flag to check.",
-              "type": "string"
-            }
-          ],
-          "returns": {
-            "description": "True if the specified flag is enabled, false otherwise.",
-            "type": "boolean"
-          }
-        }
-      }
-    },
     "AppSelections": {
       "kind": "class",
       "constructor": {
@@ -1344,7 +1324,7 @@
         "params": []
       },
       "entries": {
-        "on": {
+        "addListener": {
           "description": "Event listener function on instance",
           "kind": "function",
           "params": [
@@ -1361,7 +1341,7 @@
             }
           ],
           "examples": [
-            "api.on('someEvent', () => {...});"
+            "api.addListener('someEvent', () => {...});"
           ]
         },
         "removeListener": {
@@ -1544,32 +1524,25 @@
         }
       }
     },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
+    "Flags": {
       "kind": "interface",
       "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
+        "isEnabled": {
+          "description": "Checks whether the specified flag is enabled.",
+          "kind": "function",
+          "params": [
+            {
+              "name": "flag",
+              "description": "The value flag to check.",
               "type": "string"
             }
+          ],
+          "returns": {
+            "description": "True if the specified flag is enabled, false otherwise.",
+            "type": "boolean"
           }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
         }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
+      }
     },
     "Field": {
       "kind": "alias",
@@ -1705,6 +1678,33 @@
           ]
         }
       }
+    },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
     },
     "LoadType": {
       "kind": "interface",

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1544,6 +1544,33 @@
         }
       }
     },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
+    },
     "Field": {
       "kind": "alias",
       "items": {
@@ -1678,33 +1705,6 @@
           ]
         }
       }
-    },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
-      "kind": "interface",
-      "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
-              "type": "string"
-            }
-          }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
-        }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
     },
     "LoadType": {
       "kind": "interface",
@@ -2120,28 +2120,6 @@
         }
       }
     },
-    "BlurFunction": {
-      "description": "Blur function",
-      "kind": "function",
-      "params": [
-        {
-          "name": "resetFocus",
-          "description": "parameter to determines whether the chart should be focused after blurring from inside",
-          "type": "boolean"
-        }
-      ]
-    },
-    "FocusSelectionFunction": {
-      "description": "Focus Selection function",
-      "kind": "function",
-      "params": [
-        {
-          "name": "focusLast",
-          "description": "parameter to determines if the selection toolbar should be focuses the first or last element in the toolbar. if true, the last item is focused.",
-          "type": "boolean"
-        }
-      ]
-    },
     "Keyboard": {
       "stability": "experimental",
       "kind": "interface",
@@ -2155,20 +2133,30 @@
           "type": "boolean"
         },
         "blur": {
-          "description": "Function used by the visualization to tell Nebula to it wants to relinquish focus",
+          "description": "Function used by the visualization to tell Nebula it wants to relinquish focus",
           "optional": true,
-          "type": "#/definitions/BlurFunction"
+          "kind": "function",
+          "params": [
+            {
+              "type": "boolean"
+            }
+          ]
         },
         "focus": {
-          "description": "Function used by the visualization to tell Nebula to it wants focus",
+          "description": "Function used by the visualization to tell Nebula it wants to focus",
           "optional": true,
           "kind": "function",
           "params": []
         },
         "focusSelection": {
-          "description": "Function used by the visualization to tell Nebula to focus the selection toolbar",
+          "description": "Function used by the visualization to tell Nebula that focus the selection toolbar",
           "optional": true,
-          "type": "#/definitions/FocusSelectionFunction"
+          "kind": "function",
+          "params": [
+            {
+              "type": "boolean"
+            }
+          ]
         }
       }
     },
@@ -2398,7 +2386,14 @@
         "language": {
           "description": "Returns current locale.",
           "kind": "function",
-          "params": [],
+          "params": [
+            {
+              "name": "lang",
+              "description": "language Locale to updated the currentLocale value",
+              "optional": true,
+              "type": "string"
+            }
+          ],
           "returns": {
             "description": "current locale.",
             "type": "string"

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -489,16 +489,6 @@ declare namespace stardust {
 
     }
 
-    /**
-     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
-     */
-    interface Plugin {
-        info: {
-            name: string;
-        };
-        fn: ()=>void;
-    }
-
     type Field = string | EngineAPI.INxDimension | EngineAPI.INxMeasure | stardust.LibraryField;
 
     /**
@@ -529,6 +519,16 @@ declare namespace stardust {
     interface LibraryField {
         qLibraryId: string;
         type: "dimension" | "measure";
+    }
+
+    /**
+     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
+     */
+    interface Plugin {
+        info: {
+            name: string;
+        };
+        fn: ()=>void;
     }
 
     interface LoadType {
@@ -653,12 +653,12 @@ declare namespace stardust {
     interface Keyboard {
         enabled: boolean;
         active: boolean;
-        blur: stardust.BlurFunction;
+        blur?: stardust.BlurFunction;
         /**
          * Function used by the visualization to tell Nebula to it wants focus
          */
         focus?(): void;
-        focusSelection: stardust.FocusSelectionFunction;
+        focusSelection?: stardust.FocusSelectionFunction;
     }
 
     /**

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -646,11 +646,6 @@ declare namespace stardust {
     type BlurFunction = (blurState: boolean)=>void;
 
     /**
-     * Focus function
-     */
-    type FocusFunction = (focusState: boolean)=>void;
-
-    /**
      * Focus Selection function
      */
     type FocusSelectionFunction = (focusState: boolean)=>void;
@@ -659,7 +654,10 @@ declare namespace stardust {
         enabled: boolean;
         active: boolean;
         blur: stardust.BlurFunction;
-        focus: stardust.FocusFunction;
+        /**
+         * Function used by the visualization to tell Nebula to it wants focus
+         */
+        focus?(): void;
         focusSelection: stardust.FocusSelectionFunction;
     }
 

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -407,14 +407,6 @@ declare namespace stardust {
 
     }
 
-    interface Flags {
-        /**
-         * Checks whether the specified flag is enabled.
-         * @param flag The value flag to check.
-         */
-        isEnabled(flag: string): boolean;
-    }
-
     class AppSelections {
         constructor();
 
@@ -439,7 +431,7 @@ declare namespace stardust {
          * @param eventType event type that function needs to listen
          * @param callback a callback function to run when event emits
          */
-        on(eventType: string, callback: ()=>void): void;
+        addListener(eventType: string, callback: ()=>void): void;
 
         /**
          * Remove listener function on instance
@@ -489,14 +481,12 @@ declare namespace stardust {
 
     }
 
-    /**
-     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
-     */
-    interface Plugin {
-        info: {
-            name: string;
-        };
-        fn: ()=>void;
+    interface Flags {
+        /**
+         * Checks whether the specified flag is enabled.
+         * @param flag The value flag to check.
+         */
+        isEnabled(flag: string): boolean;
     }
 
     type Field = string | EngineAPI.INxDimension | EngineAPI.INxMeasure | stardust.LibraryField;
@@ -529,6 +519,16 @@ declare namespace stardust {
     interface LibraryField {
         qLibraryId: string;
         type: "dimension" | "measure";
+    }
+
+    /**
+     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
+     */
+    interface Plugin {
+        info: {
+            name: string;
+        };
+        fn: ()=>void;
     }
 
     interface LoadType {

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -489,6 +489,16 @@ declare namespace stardust {
 
     }
 
+    /**
+     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
+     */
+    interface Plugin {
+        info: {
+            name: string;
+        };
+        fn: ()=>void;
+    }
+
     type Field = string | EngineAPI.INxDimension | EngineAPI.INxMeasure | stardust.LibraryField;
 
     /**
@@ -519,16 +529,6 @@ declare namespace stardust {
     interface LibraryField {
         qLibraryId: string;
         type: "dimension" | "measure";
-    }
-
-    /**
-     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
-     */
-    interface Plugin {
-        info: {
-            name: string;
-        };
-        fn: ()=>void;
     }
 
     interface LoadType {
@@ -640,25 +640,23 @@ declare namespace stardust {
         restore: any;
     }
 
-    /**
-     * Blur function
-     */
-    type BlurFunction = (resetFocus: boolean)=>void;
-
-    /**
-     * Focus Selection function
-     */
-    type FocusSelectionFunction = (focusLast: boolean)=>void;
-
     interface Keyboard {
         enabled: boolean;
         active: boolean;
-        blur?: stardust.BlurFunction;
         /**
-         * Function used by the visualization to tell Nebula to it wants focus
+         * Function used by the visualization to tell Nebula it wants to relinquish focus
+         * @param $
+         */
+        blur?($: boolean): void;
+        /**
+         * Function used by the visualization to tell Nebula it wants to focus
          */
         focus?(): void;
-        focusSelection?: stardust.FocusSelectionFunction;
+        /**
+         * Function used by the visualization to tell Nebula that focus the selection toolbar
+         * @param $
+         */
+        focusSelection?($: boolean): void;
     }
 
     /**
@@ -711,8 +709,9 @@ declare namespace stardust {
 
         /**
          * Returns current locale.
+         * @param lang language Locale to updated the currentLocale value
          */
-        language(): string;
+        language(lang?: string): string;
 
         /**
          * Registers a string in multiple locales

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -435,6 +435,20 @@ declare namespace stardust {
         constructor();
 
         /**
+         * Event listener function on instance
+         * @param eventType event type that function needs to listen
+         * @param callback a callback function to run when event emits
+         */
+        on(eventType: string, callback: ()=>void): void;
+
+        /**
+         * Remove listener function on instance
+         * @param eventType event type that function needs to listen
+         * @param callback a callback function to run when event emits
+         */
+        removeListener(eventType: string, callback: ()=>void): void;
+
+        /**
          * @param paths
          */
         begin(paths: string[]): Promise<undefined>;
@@ -626,21 +640,27 @@ declare namespace stardust {
         restore: any;
     }
 
+    /**
+     * Blur function
+     */
+    type BlurFunction = (blurState: boolean)=>void;
+
+    /**
+     * Focus function
+     */
+    type FocusFunction = (focusState: boolean)=>void;
+
+    /**
+     * Focus Selection function
+     */
+    type FocusSelectionFunction = (focusState: boolean)=>void;
+
     interface Keyboard {
         enabled: boolean;
         active: boolean;
-        /**
-         * Function used by the visualization to tell Nebula to it wants to relinquish focus
-         */
-        blur?(): void;
-        /**
-         * Function used by the visualization to tell Nebula to it wants focus
-         */
-        focus?(): void;
-        /**
-         * Function used by the visualization to tell Nebula to focus the selection toolbar
-         */
-        focusSelection?(): void;
+        blur: stardust.BlurFunction;
+        focus: stardust.FocusFunction;
+        focusSelection: stardust.FocusSelectionFunction;
     }
 
     /**
@@ -692,6 +712,11 @@ declare namespace stardust {
         constructor();
 
         /**
+         * Returns current locale.
+         */
+        language(): string;
+
+        /**
          * Registers a string in multiple locales
          * @param item
          */
@@ -711,6 +736,11 @@ declare namespace stardust {
 
     class Theme {
         constructor();
+
+        /**
+         * Returns theme name
+         */
+        name(): string;
 
         getDataColorScales(): stardust.Theme.ScalePalette[];
 

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -489,6 +489,16 @@ declare namespace stardust {
 
     }
 
+    /**
+     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
+     */
+    interface Plugin {
+        info: {
+            name: string;
+        };
+        fn: ()=>void;
+    }
+
     type Field = string | EngineAPI.INxDimension | EngineAPI.INxMeasure | stardust.LibraryField;
 
     /**
@@ -519,16 +529,6 @@ declare namespace stardust {
     interface LibraryField {
         qLibraryId: string;
         type: "dimension" | "measure";
-    }
-
-    /**
-     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
-     */
-    interface Plugin {
-        info: {
-            name: string;
-        };
-        fn: ()=>void;
     }
 
     interface LoadType {
@@ -643,12 +643,12 @@ declare namespace stardust {
     /**
      * Blur function
      */
-    type BlurFunction = (blurState: boolean)=>void;
+    type BlurFunction = (resetFocus: boolean)=>void;
 
     /**
      * Focus Selection function
      */
-    type FocusSelectionFunction = (focusState: boolean)=>void;
+    type FocusSelectionFunction = (focusLast: boolean)=>void;
 
     interface Keyboard {
         enabled: boolean;

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -407,6 +407,14 @@ declare namespace stardust {
 
     }
 
+    interface Flags {
+        /**
+         * Checks whether the specified flag is enabled.
+         * @param flag The value flag to check.
+         */
+        isEnabled(flag: string): boolean;
+    }
+
     class AppSelections {
         constructor();
 
@@ -479,14 +487,6 @@ declare namespace stardust {
          */
         noModal(accept?: boolean): Promise<undefined>;
 
-    }
-
-    interface Flags {
-        /**
-         * Checks whether the specified flag is enabled.
-         * @param flag The value flag to check.
-         */
-        isEnabled(flag: string): boolean;
     }
 
     type Field = string | EngineAPI.INxDimension | EngineAPI.INxMeasure | stardust.LibraryField;

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -1199,7 +1199,7 @@ export function useKeyboard() {
   const focusHandler = useInternalContext('focusHandler');
 
   if (!currentComponent.__hooks.accessibility.exitFunction) {
-    const exitFunction = function (resetFocus) {
+    const exitFunction = function (resetFocus = false) {
       const acc = this.__hooks.accessibility;
       if (acc.enabled && acc.active) {
         blur(this);
@@ -1219,7 +1219,7 @@ export function useKeyboard() {
 
     currentComponent.__hooks.accessibility.focusFunction = focusFunction;
 
-    const focusSelectionFunction = function (focusLast) {
+    const focusSelectionFunction = function (focusLast = false) {
       const acc = this.__hooks.accessibility;
       if (acc.enabled) {
         focusHandler && focusHandler.focusToolbarButton && focusHandler.focusToolbarButton(focusLast);

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -1144,25 +1144,13 @@ export function useEmitter() {
 }
 
 /**
- * Blur function
- * @callback BlurFunction
- * @param {boolean} resetFocus parameter to determines whether the chart should be focused after blurring from inside
- */
-
-/**
- * Focus Selection function
- * @callback FocusSelectionFunction
- * @param {boolean} focusLast parameter to determines if the selection toolbar should be focuses the first or last element in the toolbar. if true, the last item is focused.
- */
-
-/**
  * @experimental
  * @interface Keyboard
  * @property {boolean} enabled Whether or not Nebula handles keyboard navigation or not.
  * @property {boolean} active Set to true when the chart is activated, ie a user tabs to the chart and presses Enter or Space.
- * @property {BlurFunction=} blur Function used by the visualization to tell Nebula to it wants to relinquish focus
- * @property {function=} focus Function used by the visualization to tell Nebula to it wants focus
- * @property {FocusSelectionFunction=} focusSelection Function used by the visualization to tell Nebula to focus the selection toolbar
+ * @property {function(boolean)=} blur Function used by the visualization to tell Nebula it wants to relinquish focus
+ * @property {function=} focus Function used by the visualization to tell Nebula it wants to focus
+ * @property {function(boolean)=} focusSelection Function used by the visualization to tell Nebula that focus the selection toolbar
  */
 
 /**

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -1145,16 +1145,14 @@ export function useEmitter() {
 
 /**
  * Blur function
- * @name BlurFunction
- * @function
- * @param {boolean} blurState parameter to indicate blur state
+ * @callback BlurFunction
+ * @param {boolean} resetFocus parameter to determines whether the chart should be focused after blurring from inside
  */
 
 /**
  * Focus Selection function
- * @name FocusSelectionFunction
- * @function
- * @param {boolean} focusState parameter to indicate focus state
+ * @callback FocusSelectionFunction
+ * @param {boolean} focusLast parameter to determines if the selection toolbar should be focuses the first or last element in the toolbar. if true, the last item is focused.
  */
 
 /**

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -1151,13 +1151,6 @@ export function useEmitter() {
  */
 
 /**
- * Focus function
- * @name FocusFunction
- * @function
- * @param {boolean} focusState parameter to indicate focus state
- */
-
-/**
  * Focus Selection function
  * @name FocusSelectionFunction
  * @function
@@ -1170,7 +1163,7 @@ export function useEmitter() {
  * @property {boolean} enabled Whether or not Nebula handles keyboard navigation or not.
  * @property {boolean} active Set to true when the chart is activated, ie a user tabs to the chart and presses Enter or Space.
  * @property {BlurFunction} blur Function used by the visualization to tell Nebula to it wants to relinquish focus
- * @property {FocusFunction} focus Function used by the visualization to tell Nebula to it wants focus
+ * @property {function=} focus Function used by the visualization to tell Nebula to it wants focus
  * @property {FocusSelectionFunction} focusSelection Function used by the visualization to tell Nebula to focus the selection toolbar
  */
 

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -1144,13 +1144,34 @@ export function useEmitter() {
 }
 
 /**
+ * Blur function
+ * @name BlurFunction
+ * @function
+ * @param {boolean} blurState parameter to indicate blur state
+ */
+
+/**
+ * Focus function
+ * @name FocusFunction
+ * @function
+ * @param {boolean} focusState parameter to indicate focus state
+ */
+
+/**
+ * Focus Selection function
+ * @name FocusSelectionFunction
+ * @function
+ * @param {boolean} focusState parameter to indicate focus state
+ */
+
+/**
  * @experimental
  * @interface Keyboard
  * @property {boolean} enabled Whether or not Nebula handles keyboard navigation or not.
  * @property {boolean} active Set to true when the chart is activated, ie a user tabs to the chart and presses Enter or Space.
- * @property {function=} blur Function used by the visualization to tell Nebula to it wants to relinquish focus
- * @property {function=} focus Function used by the visualization to tell Nebula to it wants focus
- * @property {function=} focusSelection Function used by the visualization to tell Nebula to focus the selection toolbar
+ * @property {BlurFunction} blur Function used by the visualization to tell Nebula to it wants to relinquish focus
+ * @property {FocusFunction} focus Function used by the visualization to tell Nebula to it wants focus
+ * @property {FocusSelectionFunction} focusSelection Function used by the visualization to tell Nebula to focus the selection toolbar
  */
 
 /**

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -1160,9 +1160,9 @@ export function useEmitter() {
  * @interface Keyboard
  * @property {boolean} enabled Whether or not Nebula handles keyboard navigation or not.
  * @property {boolean} active Set to true when the chart is activated, ie a user tabs to the chart and presses Enter or Space.
- * @property {BlurFunction} blur Function used by the visualization to tell Nebula to it wants to relinquish focus
+ * @property {BlurFunction=} blur Function used by the visualization to tell Nebula to it wants to relinquish focus
  * @property {function=} focus Function used by the visualization to tell Nebula to it wants focus
- * @property {FocusSelectionFunction} focusSelection Function used by the visualization to tell Nebula to focus the selection toolbar
+ * @property {FocusSelectionFunction=} focusSelection Function used by the visualization to tell Nebula to focus the selection toolbar
  */
 
 /**

--- a/apis/theme/src/index.js
+++ b/apis/theme/src/index.js
@@ -16,6 +16,16 @@ export default function theme() {
   let contraster;
 
   /**
+   * Returns theme name
+   *
+   * @method
+   * @name Theme#name
+   * @returns {string} Current theme.
+   * @example
+   * theme.name();
+   */
+
+  /**
    * @class
    * @alias Theme
    */


### PR DESCRIPTION
## Motivation
We have some missing types requirement from some of the startdust APIs listed below: 
1. `stardust.ObjectSelections`
2. `stardust.Translator`
3. `stardust.Theme`
4. `stardust.keyboard`

for first 3, we were extending the stardust interface in our side [like this](https://github.com/qlik-oss/sn-table/blob/0ac826331ff9b64804f7e128043726f70ea8c481/src/types.ts#L173-L185).

but for last one (`stardust.keyboard`), we were using `@ts-ignore` for functions like: 
1. `keyboard.blur(...)`
2. `keyboard.focusSelection(...)`

because those functions does not accept any parameter by **types** (which they do in code [at here for focus selection](https://github.com/qlik-oss/nebula.js/blob/64a3b201dd9938a94765a4948230b3a8e7337624/apis/supernova/src/hooks.js#L1131) and [here for blur](https://github.com/qlik-oss/nebula.js/blob/64a3b201dd9938a94765a4948230b3a8e7337624/apis/supernova/src/hooks.js#L1111))

So this PR fixes those types!


## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
