### PR TITLE
feat: support listobjectDef in render session objects

### DIFF
--- a/apis/nucleus/src/object/__tests__/populator.test.js
+++ b/apis/nucleus/src/object/__tests__/populator.test.js
@@ -1,19 +1,29 @@
 import * as hcHandlerModule from '../hc-handler';
+import * as loHandlerModule from '../lo-handler';
 import populate, { fieldType as ft } from '../populator';
 
 describe('populator', () => {
   let h;
+  let l;
   let warn;
   let handler;
+  let lohandler;
 
   beforeEach(() => {
     h = {
       addMeasure: jest.fn(),
       addDimension: jest.fn(),
     };
+    l = {
+      addMeasure: jest.fn(),
+      addDimension: jest.fn(),
+    };
     const fn = () => h;
+    const fnl = () => l;
     handler = jest.fn().mockImplementation(fn);
+    lohandler = jest.fn().mockImplementation(fnl);
     jest.spyOn(hcHandlerModule, 'default').mockImplementation(handler);
+    jest.spyOn(loHandlerModule, 'default').mockImplementation(lohandler);
 
     global.__NEBULA_DEV__ = true; // eslint-disable-line no-underscore-dangle
     warn = jest.fn();
@@ -89,6 +99,22 @@ describe('populator', () => {
     const resolved = { qDimensions: [] };
     populate({ sn, properties: { a: { b: { c: resolved } } }, fields: ['=A'] });
     expect(h.addMeasure).toHaveBeenCalledWith('=A');
+  });
+
+  test('should work for qListObjectDef', () => {
+    const target = {
+      propertyPath: '/qListObjectDef',
+    };
+    const sn = {
+      qae: {
+        data: {
+          targets: [target],
+        },
+      },
+    };
+    const resolved = { qDimensions: [] };
+    populate({ sn, properties: { a: { b: { c: resolved } } }, fields: ['A'] });
+    expect(l.addDimension).toHaveBeenCalledWith('A');
   });
 
   test("should identify field as measure when prefixed with '='", () => {

--- a/apis/nucleus/src/object/populator.js
+++ b/apis/nucleus/src/object/populator.js
@@ -1,4 +1,5 @@
 import hcHandler from './hc-handler';
+import loHandler from './lo-handler';
 
 /**
  * @interface LibraryField
@@ -40,7 +41,9 @@ export default function populateData({ sn, properties, fields }) {
     p = s ? p[s] : p;
   }
 
-  const hc = hcHandler({
+  const createHandler = propertyPath.match('/qListObjectDef') ? loHandler : hcHandler;
+
+  const handler = createHandler({
     dc: p,
     def: target,
     properties,
@@ -50,9 +53,9 @@ export default function populateData({ sn, properties, fields }) {
     const type = fieldType(f);
 
     if (type === 'measure') {
-      hc.addMeasure(f);
+      handler.addMeasure(f);
     } else {
-      hc.addDimension(f);
+      handler.addDimension(f);
     }
   });
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

embed.render(..) session objects didn't work for objects using /qListObjectDef as data path, this fixes that.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
