### PR TITLE
test: add data-testid for search input field

### DIFF
--- a/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
@@ -190,6 +190,7 @@ export default function ListBoxSearch({
       inputProps={{
         tabIndex: keyboard && (!keyboard.enabled || keyboard.active) ? 0 : -1,
         style: { textAlign: `${inpuTextAlign}` },
+        'data-testid': 'search-input-field',
       }}
     />
   );


### PR DESCRIPTION
Adds data-testid="search-input-field" for search input for the listbox to allow for better auto-testing.