### PR TITLE
refactor: adjust action toolbar position

### DIFF
--- a/apis/nucleus/src/components/ActionsToolbar.jsx
+++ b/apis/nucleus/src/components/ActionsToolbar.jsx
@@ -120,7 +120,7 @@ function ActionsToolbar({
   const dividerStyle = useMemo(() => ({ margin: theme.spacing(0.5, 0) }));
 
   const popoverAnchorOrigin = {
-    vertical: 15,
+    vertical: 7,
     horizontal: (popover.anchorEl?.clientWidth ?? 0) - 7,
   };
 


### PR DESCRIPTION
Moves the ActionToolbar slightly again to mitigate problem with overlapping of values.

Before:
![bef](https://user-images.githubusercontent.com/13997395/228861004-c2365260-ad92-4c12-b3fb-c6c152a8f6dc.png)

After:
![aft](https://user-images.githubusercontent.com/13997395/228861035-2bf43282-6698-4778-bfd8-3135d2e0c551.png)
