### PR TITLE
docs: ignore jsdoc for internal fn that is not part of api

### DIFF
--- a/apis/nucleus/src/components/listbox/components/ScreenReaders.jsx
+++ b/apis/nucleus/src/components/listbox/components/ScreenReaders.jsx
@@ -35,6 +35,7 @@ export function getValueLabel({ translator, label, qState, isSelected, currentIn
 /**
  * Announces the selection state.
  *
+ * @ignore
  * @param {Layout} object
  * @returns {Element} An (invisible) component.
  */


### PR DESCRIPTION
ignores `ScreenReaderForSelections` so that it doesn't end up in the api specs.