### PR TITLE
fix: change react-virtualized-auto-sizer to 1.0.7 to fix width problem

### DIFF
--- a/apis/nucleus/package.json
+++ b/apis/nucleus/package.json
@@ -19,7 +19,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-test-renderer": "18.2.0",
-    "react-virtualized-auto-sizer": "^1.0.11",
+    "react-virtualized-auto-sizer": "1.0.7",
     "react-window": "1.8.8",
     "react-window-infinite-loader": "1.0.8",
     "semver": "6.3.0"

--- a/apis/stardust/package.json
+++ b/apis/stardust/package.json
@@ -60,7 +60,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-test-renderer": "18.2.0",
-    "react-virtualized-auto-sizer": "^1.0.11",
+    "react-virtualized-auto-sizer": "1.0.7",
     "react-window": "1.8.8",
     "react-window-infinite-loader": "1.0.8",
     "regenerator-runtime": "0.13.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19013,10 +19013,10 @@ react-transition-group@^4.3.0, react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-virtualized-auto-sizer@^1.0.11:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.11.tgz#2ec880161c91327531f56b218d067736fd4ae3fe"
-  integrity sha512-v2YlC4KCnjEF7V5KtxrHCy50vPhbL73BS1qNOXFYaaE1XGeRqZHrGP+F4BE0QDv2pP+f1t9twL1n5pRp5GPMkQ==
+react-virtualized-auto-sizer@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.7.tgz#bfb8414698ad1597912473de3e2e5f82180c1195"
+  integrity sha512-Mxi6lwOmjwIjC1X4gABXMJcKHsOo0xWl3E3ugOgufB8GJU+MqrtY35aBuvCYv/razQ1Vbp7h1gWJjGjoNN5pmA==
 
 react-window-infinite-loader@1.0.8:
   version "1.0.8"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

There is a problem of a popover width calculation caused by "react-virtualized-auto-sizer" ^1.0.11. Changing "react-virtualized-auto-sizer" to 1.0.7 to solve this problem.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
