### PR TITLE
fix: support Enter to go from a folded listbox to a row

### DIFF
--- a/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
@@ -115,7 +115,7 @@ export default function ListBoxSearch({
 
   function focusRow(container) {
     const row = container?.querySelector('.last-focused') || container?.querySelector('[role="row"]:first-child');
-    row.setAttribute('tabIndex', 0);
+    row.setAttribute('tabIndex', -1);
     row?.focus();
   }
 

--- a/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
@@ -115,7 +115,7 @@ export default function ListBoxSearch({
 
   function focusRow(container) {
     const row = container?.querySelector('.last-focused') || container?.querySelector('[role="row"]:first-child');
-    row.setAttribute('tabIndex', -1);
+    row.setAttribute('tabIndex', 0);
     row?.focus();
   }
 

--- a/apis/nucleus/src/components/listbox/components/useTempKeyboard.js
+++ b/apis/nucleus/src/components/listbox/components/useTempKeyboard.js
@@ -38,7 +38,7 @@ export default function useTempKeyboard({ containerRef, enabled }) {
       removeLastFocused(containerRef.current);
       if (resetFocus && vizCell) {
         // Move focus to the viz's cell.
-        vizCell.setAttribute('tabIndex', -1);
+        vizCell.setAttribute('tabIndex', 0);
         vizCell.focus();
       }
     },
@@ -53,12 +53,12 @@ export default function useTempKeyboard({ containerRef, enabled }) {
       const firstRowElement = c?.querySelector('.value.selector, .value');
       const confirmButton = c?.querySelector('.actions-toolbar-default-actions .actions-toolbar-confirm');
       const elementToFocus = searchField || lastSelectedRow || firstRowElement || confirmButton;
-      elementToFocus?.setAttribute('tabIndex', -1);
+      elementToFocus?.setAttribute('tabIndex', 0);
       elementToFocus?.focus();
     },
     focusSelection() {
       const confirmButton = document.querySelector('.actions-toolbar-default-actions .actions-toolbar-confirm');
-      confirmButton?.setAttribute('tabIndex', -1);
+      confirmButton?.setAttribute('tabIndex', 0);
       confirmButton?.focus();
     },
   };

--- a/apis/nucleus/src/components/listbox/components/useTempKeyboard.js
+++ b/apis/nucleus/src/components/listbox/components/useTempKeyboard.js
@@ -50,9 +50,9 @@ export default function useTempKeyboard({ containerRef, enabled }) {
       const c = containerRef.current;
       const searchField = c?.querySelector('.search input');
       const lastSelectedRow = c?.querySelector('.value.last-focused');
-      const fieldElement = c?.querySelector('.value.selector, .value, .ActionsToolbar-item button');
-
-      const elementToFocus = searchField || lastSelectedRow || fieldElement;
+      const firstRowElement = c?.querySelector('.value.selector, .value');
+      const confirmButton = c?.querySelector('.actions-toolbar-default-actions .actions-toolbar-confirm');
+      const elementToFocus = searchField || lastSelectedRow || firstRowElement || confirmButton;
       elementToFocus?.setAttribute('tabIndex', -1);
       elementToFocus?.focus();
     },

--- a/apis/nucleus/src/components/listbox/components/useTempKeyboard.js
+++ b/apis/nucleus/src/components/listbox/components/useTempKeyboard.js
@@ -38,7 +38,7 @@ export default function useTempKeyboard({ containerRef, enabled }) {
       removeLastFocused(containerRef.current);
       if (resetFocus && vizCell) {
         // Move focus to the viz's cell.
-        vizCell.setAttribute('tabIndex', 0);
+        vizCell.setAttribute('tabIndex', -1);
         vizCell.focus();
       }
     },
@@ -53,12 +53,12 @@ export default function useTempKeyboard({ containerRef, enabled }) {
       const fieldElement = c?.querySelector('.value.selector, .value, .ActionsToolbar-item button');
 
       const elementToFocus = searchField || lastSelectedRow || fieldElement;
-      elementToFocus?.setAttribute('tabIndex', 0);
+      elementToFocus?.setAttribute('tabIndex', -1);
       elementToFocus?.focus();
     },
     focusSelection() {
       const confirmButton = document.querySelector('.actions-toolbar-default-actions .actions-toolbar-confirm');
-      confirmButton?.setAttribute('tabIndex', 0);
+      confirmButton?.setAttribute('tabIndex', -1);
       confirmButton?.focus();
     },
   };

--- a/apis/nucleus/src/components/listbox/interactions/listbox-keyboard-navigation.js
+++ b/apis/nucleus/src/components/listbox/interactions/listbox-keyboard-navigation.js
@@ -217,13 +217,6 @@ export function getListboxInlineKeyboardNavigation({
         prevent();
         break;
       case KEYS.ENTER:
-        if (inSelection) {
-          focusSearch(container) || focusRow(container);
-        } else {
-          break;
-        }
-        prevent();
-        break;
       case KEYS.SPACE:
         if (!event.target.classList.contains('listbox-container')) {
           break; // don't mess with keydown handlers within the listbox (e.g. row seletion)

--- a/apis/nucleus/src/components/listbox/interactions/listbox-keyboard-navigation.js
+++ b/apis/nucleus/src/components/listbox/interactions/listbox-keyboard-navigation.js
@@ -12,7 +12,7 @@ const focusSearch = (container) => {
 
 const focusRow = (container) => {
   const row = container?.querySelector('.value.last-focused, .value.selector, .value');
-  row?.setAttribute('tabIndex', 0);
+  row?.setAttribute('tabIndex', -1);
   row?.focus();
   return row;
 };
@@ -180,7 +180,7 @@ export function getListboxInlineKeyboardNavigation({
       // 3. Blur row and focus the listbox container.
       keyboard.blur();
       const c = currentTarget.closest('.listbox-container');
-      c.setAttribute('tabIndex', 0);
+      c.setAttribute('tabIndex', -1);
       c?.focus();
     }
   };
@@ -217,6 +217,13 @@ export function getListboxInlineKeyboardNavigation({
         prevent();
         break;
       case KEYS.ENTER:
+        if (inSelection) {
+          focusSearch(container) || focusRow(container);
+        } else {
+          break;
+        }
+        prevent();
+        break;
       case KEYS.SPACE:
         if (!event.target.classList.contains('listbox-container')) {
           break; // don't mess with keydown handlers within the listbox (e.g. row seletion)

--- a/apis/nucleus/src/components/listbox/interactions/listbox-keyboard-navigation.js
+++ b/apis/nucleus/src/components/listbox/interactions/listbox-keyboard-navigation.js
@@ -12,7 +12,7 @@ const focusSearch = (container) => {
 
 const focusRow = (container) => {
   const row = container?.querySelector('.value.last-focused, .value.selector, .value');
-  row?.setAttribute('tabIndex', -1);
+  row?.setAttribute('tabIndex', 0);
   row?.focus();
   return row;
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

To fix https://github.com/qlik-oss/sn-list-objects/issues/263.
The user should be able to go from a folded listbox to the first row by Enter like an unfolded listbox.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
