### PR TITLE
fix: add right divider to listbox last column items

### DIFF
--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/ListBoxRowColumn.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/ListBoxRowColumn.jsx
@@ -169,6 +169,7 @@ function RowColumn({ index, rowIndex, columnIndex, style, data }) {
     justifyContent: valueTextAlign,
   };
 
+  const isLastCell = cellIndex + 1 === pages['0']?.qMatrix?.length;
   const isFirstElement = index === 0;
   const flexBasisVal = checkboxes ? 'auto' : 'max-content';
 
@@ -195,6 +196,7 @@ function RowColumn({ index, rowIndex, columnIndex, style, data }) {
       isGridMode={dataLayout === 'grid'}
       dense={dense}
       frequencyWidth={frequencyWidth}
+      isLast={isLastCell}
       data-testid="listbox.item"
     >
       <ItemGrid

--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/ListBoxRowColumn.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/ListBoxRowColumn.jsx
@@ -169,7 +169,7 @@ function RowColumn({ index, rowIndex, columnIndex, style, data }) {
     justifyContent: valueTextAlign,
   };
 
-  const isLastCell = cellIndex + 1 === pages['0']?.qMatrix?.length;
+  const isLastColItem = columnIndex === columnCount - 1;
   const isFirstElement = index === 0;
   const flexBasisVal = checkboxes ? 'auto' : 'max-content';
 
@@ -196,7 +196,7 @@ function RowColumn({ index, rowIndex, columnIndex, style, data }) {
       isGridMode={dataLayout === 'grid'}
       dense={dense}
       frequencyWidth={frequencyWidth}
-      isLast={isLastCell}
+      isLastCol={isLastColItem}
       direction={direction}
       data-testid="listbox.item"
     >

--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
@@ -26,8 +26,8 @@ const iconWidth = 24; // tick and lock icon width in px
 
 const RowColRoot = styled('div', {
   shouldForwardProp: (prop) =>
-    !['flexBasisProp', 'isGridMode', 'isGridCol', 'dense', 'frequencyWidth', 'direction', 'isLast'].includes(prop),
-})(({ theme, flexBasisProp, isGridMode, isGridCol, dense, frequencyWidth, direction, isLast }) => ({
+    !['flexBasisProp', 'isGridMode', 'isGridCol', 'dense', 'frequencyWidth', 'direction', 'isLastCol'].includes(prop),
+})(({ theme, flexBasisProp, isGridMode, isGridCol, dense, frequencyWidth, direction, isLastCol }) => ({
   '&:focus': {
     boxShadow: `inset 0 0 0 2px ${theme.palette.custom.focusBorder} !important`,
   },
@@ -52,7 +52,7 @@ const RowColRoot = styled('div', {
   [`& .${classes.rowBorderBottom}`]: {
     borderBottom: isGridCol ? 'none' : `1px solid ${theme.palette.divider}`,
     borderLeft: isGridCol ? `1px solid ${theme.palette.divider}` : 'none',
-    borderRight: isGridCol && isLast ? `1px solid ${theme.palette.divider}` : 'none',
+    borderRight: isGridCol && isLastCol ? `1px solid ${theme.palette.divider}` : 'none',
   },
 
   [`& .${classes.column}`]: {

--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRoot.jsx
@@ -25,8 +25,9 @@ const ellipsis = {
 const iconWidth = 24; // tick and lock icon width in px
 
 const RowColRoot = styled('div', {
-  shouldForwardProp: (prop) => !['flexBasisProp', 'isGridMode', 'isGridCol', 'dense', 'frequencyWidth'].includes(prop),
-})(({ theme, flexBasisProp, isGridMode, isGridCol, dense, frequencyWidth }) => ({
+  shouldForwardProp: (prop) =>
+    !['flexBasisProp', 'isGridMode', 'isGridCol', 'dense', 'frequencyWidth', 'isLast'].includes(prop),
+})(({ theme, flexBasisProp, isGridMode, isGridCol, dense, frequencyWidth, isLast }) => ({
   '&:focus': {
     boxShadow: `inset 0 0 0 2px ${theme.palette.custom.focusBorder} !important`,
   },
@@ -51,6 +52,7 @@ const RowColRoot = styled('div', {
   [`& .${classes.rowBorderBottom}`]: {
     borderBottom: isGridCol ? 'none' : `1px solid ${theme.palette.divider}`,
     borderLeft: isGridCol ? `1px solid ${theme.palette.divider}` : 'none',
+    borderRight: isGridCol && isLast ? `1px solid ${theme.palette.divider}` : 'none',
   },
 
   [`& .${classes.column}`]: {


### PR DESCRIPTION
## Motivation

Add a right divider to all the items of the last column.
Not adding it to all last items of each row, as in that case will be mis-aligned with the left dividers of previous items in the same column.
Resolves https://github.com/qlik-oss/sn-list-objects/issues/233

Screenshot with latest fix: 
<img width="586" alt="Screenshot 2023-04-14 at 13 51 49" src="https://user-images.githubusercontent.com/13185716/232037348-b81ceec5-947d-4314-a69d-3bb5e5822b24.png">


## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
