### PR TITLE
feat: add browser, and preferBuiltins cli args

### DIFF
--- a/commands/build/README.md
+++ b/commands/build/README.md
@@ -26,6 +26,8 @@ Options:
                                  [string] [choices: "production", "development"]
   --core           Set a core build target            [string] [default: "core"]
   --typescript     Enable typescript bundling         [boolean] [default: false]
+  --preferBuiltins Configuration option that specifies whether to use Node.js built-in modules [boolean] [default: false]
+  --browser        Configuration option that specifies whether the bundle is intended to run in a browser environment.  [boolean] [default: false]
 ```
 
 ## Example

--- a/commands/build/README.md
+++ b/commands/build/README.md
@@ -27,7 +27,7 @@ Options:
   --core           Set a core build target            [string] [default: "core"]
   --typescript     Enable typescript bundling         [boolean] [default: false]
   --preferBuiltins Configuration option that specifies whether to use Node.js built-in modules [boolean] [default: true]
-  --browser        Configuration option that specifies whether the bundle is intended to run in a browser environment.  [boolean] [default: false]
+  --browser        Instructs the build to use the browser module resolutions in package.json and adds 'browser' to exportConditions if it is not present so browser conditionals in exports are applied.  [boolean] [default: false]
 ```
 
 ## Example

--- a/commands/build/README.md
+++ b/commands/build/README.md
@@ -26,7 +26,7 @@ Options:
                                  [string] [choices: "production", "development"]
   --core           Set a core build target            [string] [default: "core"]
   --typescript     Enable typescript bundling         [boolean] [default: false]
-  --preferBuiltins Configuration option that specifies whether to use Node.js built-in modules [boolean] [default: false]
+  --preferBuiltins Configuration option that specifies whether to use Node.js built-in modules [boolean] [default: true]
   --browser        Configuration option that specifies whether the bundle is intended to run in a browser environment.  [boolean] [default: false]
 ```
 

--- a/commands/build/lib/config.js
+++ b/commands/build/lib/config.js
@@ -77,7 +77,7 @@ const config = ({
   let pkg = require(path.resolve(CWD, 'package.json')); // eslint-disable-line
   const corePkg = core ? require(path.resolve(core, 'package.json')) : null; // eslint-disable-line
   pkg = reactNative ? require(path.resolve(reactNativePath, 'package.json')) : pkg; // eslint-disable-line
-  const { sourcemap, replacementStrings = {}, typescript } = argv;
+  const { sourcemap, replacementStrings = {}, typescript, preferBuiltins, browser } = argv;
   const banner = getBanner({ pkg });
   const outputName = getOutputName({ pkg, config: argv });
 
@@ -126,6 +126,8 @@ const config = ({
         }),
         nodeResolve({
           extensions,
+          browser,
+          preferBuiltins,
         }),
         commonjs({
           ignoreTryCatch: false, // Avoids problems with require() inside try catch (https://github.com/rollup/plugins/issues/1004)
@@ -149,7 +151,7 @@ const config = ({
           ],
           plugins: [[jsxPlugin]],
         }),
-        sourcemaps(),
+        ...[sourcemap ? sourcemaps() : undefined],
         postcss({}),
         ...[typescript ? typescriptPlugin() : false],
         ...[

--- a/commands/build/lib/init-config.js
+++ b/commands/build/lib/init-config.js
@@ -46,7 +46,7 @@ const options = {
     description:
       'In Rollup, preferBuiltins is a configuration option that specifies whether to use Node.js built-in modules (such as fs or path) when bundling for Node.js environment.',
     type: 'boolean',
-    default: false,
+    default: true,
   },
   browser: {
     description:

--- a/commands/build/lib/init-config.js
+++ b/commands/build/lib/init-config.js
@@ -42,6 +42,18 @@ const options = {
     type: 'boolean',
     default: false,
   },
+  preferBuiltins: {
+    description:
+      'In Rollup, preferBuiltins is a configuration option that specifies whether to use Node.js built-in modules (such as fs or path) when bundling for Node.js environment.',
+    type: 'boolean',
+    default: false,
+  },
+  browser: {
+    description:
+      'In Rollup, the browser option is a configuration option that specifies whether the bundle is intended to run in a browser environment.',
+    type: 'boolean',
+    default: false,
+  },
 };
 
 // nebula build --watch                - watch umd bundle


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation
In some scenarios, integrating third-party packages require no source maps, browser to be set to true and preferBuiltins set to false.
This PR creates the following flags

- disableSourceMaps; will prevent the sourcemaps from being generated
- browser; boolean
- preferBuiltins; boolean

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
