### PR TITLE
fix: resolve server url to empty string

### DIFF
--- a/apis/nucleus/src/utils/background-props.js
+++ b/apis/nucleus/src/utils/background-props.js
@@ -34,7 +34,7 @@ function getSenseServerUrl(app) {
     protocol = isSecure ? 'https://' : 'http://';
     return protocol + wsUrl.host;
   }
-  return undefined;
+  return '';
 }
 
 function getBackgroundPosition(bgComp) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

When rendering snapshots there is no app to get the url from. Chart monitoring in hub is using snapshots. It would create the image urls in the following way:
`baseUrl/undefined/api/v1/.....`

This will make sure the url will at least be:
`baseUrl/api/v1/.....`

But will only fix requests from the same domain

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
