### PR TITLE
fix: take empty field into account

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBox.jsx
+++ b/apis/nucleus/src/components/listbox/ListBox.jsx
@@ -103,11 +103,13 @@ export default function ListBox({
       selectDisabled,
       layout,
     });
+  }
 
-    if (itemsLoader.pages.length && !awaitingFrequencyMax) {
-      // All necessary data fetching done - signal rendering done!
-      renderedCallback?.();
-    }
+  const cardinal = layout?.qListObject.qDimensionInfo.qCardinal;
+
+  if ((itemsLoader?.pages.length && !awaitingFrequencyMax) || cardinal === 0) {
+    // All necessary data fetching done - signal rendering done!
+    renderedCallback?.();
   }
 
   const isItemLoaded = useCallback(
@@ -307,7 +309,7 @@ export default function ListBox({
   return (
     <StyledWrapper>
       <ScreenReaderForSelections className="screenReaderOnly" layout={layout} />
-      {!listCount && <ListBoxDisclaimer width={width} text="Listbox.NoMatchesForYourTerms" />}
+      {!listCount && cardinal > 0 && <ListBoxDisclaimer width={width} text="Listbox.NoMatchesForYourTerms" />}
       <InfiniteLoader
         isItemLoaded={isItemLoaded}
         itemCount={listCount || 1} // must be more than 0 or loadMoreItems will never be called again

--- a/apis/nucleus/src/components/listbox/__tests__/list-box.test.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box.test.jsx
@@ -278,6 +278,7 @@ describe('<Listbox />', () => {
 
     test('should render a disclaimer when list count is 0 but should still render a list component', async () => {
       layout.qListObject.qSize.qcy = 0;
+      layout.qListObject.qDimensionInfo.qCardinal = 1;
       await render();
       const disclaimers = renderer.root.findAllByType(ListBoxDisclaimer);
       expect(disclaimers).toHaveLength(1);

--- a/apis/nucleus/src/components/listbox/__tests__/list-box.test.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box.test.jsx
@@ -285,5 +285,13 @@ describe('<Listbox />', () => {
       const listRows = renderer.root.findAllByProps({ className: 'a-value-row' });
       expect(listRows).toHaveLength(1);
     });
+
+    test('should not render a disclaimer when list count is 0 and qCardinal is 0', async () => {
+      layout.qListObject.qSize.qcy = 0;
+      layout.qListObject.qDimensionInfo.qCardinal = 0;
+      await render();
+      const disclaimers = renderer.root.findAllByType(ListBoxDisclaimer);
+      expect(disclaimers).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Only show "No matches for your search" disclaimer when qCardinal is > 0.
Also trigger `renderedCallback?.()` when qCardinal is 0.
fixes https://github.com/qlik-oss/sn-list-objects/issues/293
fixes https://github.com/qlik-oss/sn-list-objects/issues/269

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
