### PR TITLE
fix: do not crash on unknown chart + footer

### DIFF
--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -569,7 +569,7 @@ const Cell = forwardRef(
           >
             {Content}
           </Grid>
-          <Footer layout={layout} titleStyles={titleStyles} />
+          {cellNode && layout && state.sn && <Footer layout={layout} titleStyles={titleStyles} />}
         </Grid>
         {state.longRunningQuery && <LongRunningQuery canCancel={canCancel} canRetry={canRetry} api={longrunning} />}
       </Paper>

--- a/apis/nucleus/src/sn/__tests__/types.test.js
+++ b/apis/nucleus/src/sn/__tests__/types.test.js
@@ -101,9 +101,9 @@ describe('types', () => {
       expect(v).toEqual('1.5.1');
     });
 
-    test('should return null when no fit is found', () => {
+    test('should return undefined when no fit is found', () => {
       const v = c.getSupportedVersion('pie', '1.2.0');
-      expect(v).toBe(null);
+      expect(v).toBe(undefined);
     });
 
     test('should return the requested type and version', () => {

--- a/apis/nucleus/src/sn/types.js
+++ b/apis/nucleus/src/sn/types.js
@@ -66,7 +66,7 @@ export function create({ halo, parent }) {
     },
     getSupportedVersion: (name, propertyVersion) => {
       if (!tc[name]) {
-        return null;
+        return propertyVersion;
       }
       return tc[name].getMatchingVersionFromProperties(propertyVersion);
     },

--- a/apis/nucleus/src/sn/types.js
+++ b/apis/nucleus/src/sn/types.js
@@ -66,7 +66,7 @@ export function create({ halo, parent }) {
     },
     getSupportedVersion: (name, propertyVersion) => {
       if (!tc[name]) {
-        return propertyVersion;
+        return undefined;
       }
       return tc[name].getMatchingVersionFromProperties(propertyVersion);
     },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

When rendering a sheet (or multiple charts) of an un-supported type Nebula would crash instead of just showing a warning. This was due to a missmatch between a null version and undefined version.

Also fixed the rendering of the footer to be hidden when the chart fails to load.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [ ] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
