### PR TITLE
chore: make api-governance job depend on build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,14 +190,8 @@ jobs:
       image: ubuntu-2004:current
     working_directory: ~/project
     steps:
-      - checkout
       - attach_workspace:
           at: ~/project
-      - restore_cache: *restore_yarn_cache
-      - run:
-          name: Install dependencies
-          command: |
-            yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
       - run:
           name: Create version.txt
           command: |
@@ -253,6 +247,8 @@ workflows:
             - build
       - api-governance:
           context: api-compliance
+          requires:
+            - build
           filters:
             branches:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
