### PR TITLE
chore: make listbox api public

### DIFF
--- a/apis/stardust/api-spec/listbox-spec.conf.js
+++ b/apis/stardust/api-spec/listbox-spec.conf.js
@@ -2,9 +2,13 @@ module.exports = {
   fromJsdoc: {
     glob: ['../nucleus/src/components/listbox/default-properties.js'],
     api: {
-      stability: 'experimental',
+      stability: 'stable',
       name: '@nebula.js/stardust:listbox',
       description: 'nebula listbox properties definition',
+      properties: {
+        'x-qlik-visibility': 'public',
+      },
+      visibility: 'public',
     },
     output: {
       sort: {

--- a/apis/stardust/api-spec/listbox-spec.json
+++ b/apis/stardust/api-spec/listbox-spec.json
@@ -5,7 +5,8 @@
     "description": "nebula listbox properties definition",
     "version": "4.1.0",
     "license": "MIT",
-    "stability": "experimental"
+    "stability": "stable",
+    "x-qlik-visibility": "public"
   },
   "entries": {},
   "definitions": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation
Make the Listbox api public on qlik.dev
Current look on internal: https://internal.qlik.dev/apis/javascript/nebulajsstardustlistbox
<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
