### PR TITLE
fix: move listbox screen reader instruction to aria-label

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -344,6 +344,7 @@ function ListBoxInline({ options, layout }) {
           containerRectRef(el);
         }}
         isGridMode={isGridMode}
+        aria-label={keyboard.active ? translator.get('Listbox.ScreenReaderInstructions') : ''}
       >
         {showToolbarWithTitle && (
           <Grid
@@ -413,7 +414,6 @@ function ListBoxInline({ options, layout }) {
             />
           </Grid>
           <Grid item xs className={classes.listboxWrapper}>
-            <div className={classes.screenReaderOnly}>{translator.get('Listbox.ScreenReaderInstructions')}</div>
             {isInvalid ? (
               <ListBoxError text={errorText} />
             ) : (


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation
When a listbox row get focus, screen reader user should be informed that content on the page can change when row is  activated.
fixes https://jira.qlikdev.com/browse/QB-19506
![Kapture 2023-06-05 at 08 28 14](https://github.com/qlik-oss/nebula.js/assets/99665802/3212094e-2d5f-4576-8175-83506137c29c)

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
