### PR TITLE
fix: pass theme to listbox

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -197,6 +197,7 @@ export default function ListBoxPopover({
             direction="ltr"
             onSetListCount={(c) => setListCount(c)}
             onCtrlF={onCtrlF}
+            theme={theme}
           />
         </Grid>
       </Grid>

--- a/apis/nucleus/src/components/listbox/assets/list-sizes/use-list-sizes.js
+++ b/apis/nucleus/src/components/listbox/assets/list-sizes/use-list-sizes.js
@@ -8,7 +8,7 @@ export default function useListSizes({ layout, width, height, listCount, count, 
   const { layoutOptions = {} } = layout || {};
   const { layoutOrder, maxVisibleRows = {}, maxVisibleColumns, dense, dataLayout } = layoutOptions;
 
-  const { fontSize = '12px', fontFamily = 'Source sans pro' } = theme.listBox?.content || {};
+  const { fontSize = '12px', fontFamily = 'Source sans pro' } = theme?.listBox?.content || {};
   const font = `${fontSize} ${fontFamily}`; // font format as supported by HTML canvas
   const textWidth = useTextWidth({ text: getMeasureText(layout), font });
   const freqMinWidth = useTextWidth({ text: getMeasureText(5), font });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation
The popover listbox was failing since the listbox assumed that theme existed. Both passing it from the popover and adding a sanity check. We probably need a component test for the popover or type some of the props so this would have been discovered before releasing

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
