### PR TITLE
docs: fix links to stardust in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ Follow the instructions in our [contributing guide](./.github/CONTRIBUTING.md).
 
 `nebula.js/stardust` is [MIT licensed](./LICENSE).
 
-[stardust]: https://github.com/qlik-oss/apis/stardust
+[stardust]: https://github.com/qlik-oss/nebula.js/tree/master/apis/stardust
 [stardust-status]: https://img.shields.io/npm/v/@nebula.js/stardust.svg
 [stardust-npm]: https://www.npmjs.com/package/@nebula.js/stardust


### PR DESCRIPTION
## Motivation

Repair broken link to stardust readme from main readme.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
