### PR TITLE
fix: missing path require in build-watcher

### DIFF
--- a/commands/build/lib/watch.js
+++ b/commands/build/lib/watch.js
@@ -1,4 +1,5 @@
 const chalk = require('chalk');
+const path = require('path');
 const rollup = require('rollup');
 const readline = require('readline');
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Issue with the build watcher when running --mfe

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
