### PR TITLE
fix: fix selection close when there are many objects with the same model

### DIFF
--- a/apis/nucleus/src/components/selections/SelectedFields.jsx
+++ b/apis/nucleus/src/components/selections/SelectedFields.jsx
@@ -52,8 +52,8 @@ export default function SelectedFields({ api, app }) {
   const [maxItems, setMaxItems] = useState(0);
 
   const isInListboxPopover = () => {
-    const object = modalObjectStore.get(app.id);
-    return object && object.genericType === 'njsListbox';
+    const { model } = modalObjectStore.get(app.id) || {};
+    return model?.genericType === 'njsListbox';
   };
 
   useEffect(() => {

--- a/apis/nucleus/src/components/selections/__tests__/selected-fields.test.jsx
+++ b/apis/nucleus/src/components/selections/__tests__/selected-fields.test.jsx
@@ -133,7 +133,7 @@ describe('<SelectedFields />', () => {
   });
 
   test('should keep item in modal state', async () => {
-    modalObjectStore.get.mockReturnValue({ genericType: 'njsListbox' });
+    modalObjectStore.get.mockReturnValue({ model: { genericType: 'njsListbox' } });
     const data = {
       qSelectionObject: {
         qSelections: [
@@ -176,7 +176,7 @@ describe('<SelectedFields />', () => {
       .mockReturnValueOnce([newData]);
     await render();
     const types = renderer.root.findAllByType(OneField);
-    expect(types.length).toBe(3);
+    expect(types).toHaveLength(3);
     expect(types[0].props.field.name).toBe('my-field0');
     expect(types[1].props.field.name).toBe('my-field1');
     expect(types[2].props.field.name).toBe('my-field2');

--- a/apis/nucleus/src/hooks/__tests__/use-app-selections.test.jsx
+++ b/apis/nucleus/src/hooks/__tests__/use-app-selections.test.jsx
@@ -25,7 +25,8 @@ describe('useAppSelections', () => {
   let currentSelectionsLayout;
   let appSel;
   let appModal;
-  let object;
+  let model;
+  let objectSelections;
   let beginSelections;
   let endSelections;
 
@@ -80,11 +81,6 @@ describe('useAppSelections', () => {
         },
       },
     ]);
-    selectionStoreModule.objectSelectionsStore = {
-      get: () => ({
-        emit: jest.fn(),
-      }),
-    };
     selectionStoreModule.appModalStore = {
       set: (k, v) => {
         appModal = v;
@@ -94,9 +90,12 @@ describe('useAppSelections', () => {
 
     beginSelections = jest.fn();
     endSelections = jest.fn();
-    object = {
+    model = {
       beginSelections,
       endSelections,
+    };
+    objectSelections = {
+      emit: jest.fn(),
     };
   });
 
@@ -116,7 +115,7 @@ describe('useAppSelections', () => {
     const res = Promise.resolve();
     // eslint-disable-next-line prefer-promise-reject-errors
     beginSelections.mockResolvedValueOnce(Promise.reject({ code: 6003 })).mockResolvedValueOnce(res);
-    await appModal.begin(object);
+    await appModal.begin({ model, objectSelections });
     await res;
 
     expect(beginSelections).toHaveBeenCalledTimes(2);
@@ -127,7 +126,7 @@ describe('useAppSelections', () => {
 
     // eslint-disable-next-line prefer-promise-reject-errors
     beginSelections.mockResolvedValueOnce(Promise.reject({ code: 9999 }));
-    await appModal.begin(object);
+    await appModal.begin({ model, objectSelections });
 
     expect(beginSelections).toHaveBeenCalledTimes(1);
   });
@@ -145,7 +144,7 @@ describe('useAppSelections', () => {
     await render();
     const obj = {};
     modalObjectStore.get.mockReturnValue(obj);
-    expect(ref.current.result[0].isModal(obj)).toBe(true);
+    expect(ref.current.result[0].isModal(obj)).toBe(false);
     expect(ref.current.result[0].isModal({})).toBe(false);
     expect(ref.current.result[0].isModal()).toBe(true);
   });

--- a/apis/nucleus/src/hooks/useObjectSelections.js
+++ b/apis/nucleus/src/hooks/useObjectSelections.js
@@ -228,7 +228,6 @@ export default function useObjectSelections(app, model, elements, options) {
 
   useEffect(() => {
     if (!appSelections || !model || objectSelections) return;
-
     setObjectSelections(
       createObjectSelections({
         appSelections,

--- a/apis/nucleus/src/hooks/useObjectSelections.js
+++ b/apis/nucleus/src/hooks/useObjectSelections.js
@@ -1,6 +1,6 @@
 /* eslint no-underscore-dangle: 0 */
-import { useEffect } from 'react';
-import { useObjectSelectionsStore, useAppModalStore } from '../stores/selections-store';
+import { useEffect, useState } from 'react';
+import { useAppModalStore } from '../stores/selections-store';
 import useAppSelections from './useAppSelections';
 import eventmixin from '../selections/event-mixin';
 import useLayout from './useLayout';
@@ -94,7 +94,7 @@ const createObjectSelections = ({ appSelections, appModal, model }) => {
       }
       isActive = true;
       this.emit('activated');
-      return appModal.begin(model, paths, true);
+      return appModal.begin({ model, paths, accept: true, objectSelections: api });
     },
     /**
      * @returns {Promise<undefined>}
@@ -181,12 +181,12 @@ const createObjectSelections = ({ appSelections, appModal, model }) => {
     /**
      * @returns {boolean}
      */
-    isModal: () => appSelections.isModal(model),
+    isModal: () => appSelections.isModal(api),
     /**
      * @param {string[]} paths
      * @returns {Promise<undefined>}
      */
-    goModal: (paths) => appModal.begin(model, paths, false),
+    goModal: (paths) => appModal.begin({ model, paths, accept: false, objectSelections: api }),
     /**
      * @param {boolean} [accept=false]
      * @returns {Promise<undefined>}
@@ -222,23 +222,20 @@ export default function useObjectSelections(app, model, elements, options) {
 
   const [appSelections] = useAppSelections(app);
   const [layout] = useLayout(model);
-  const key = model ? model.id : null;
   const [appModalStore] = useAppModalStore();
-  const [objectSelectionsStore] = useObjectSelectionsStore();
   const appModal = appModalStore.get(app.id);
-  let objectSelections = objectSelectionsStore.get(key);
+  const [objectSelections, setObjectSelections] = useState();
 
   useEffect(() => {
     if (!appSelections || !model || objectSelections) return;
 
-    objectSelections = createObjectSelections({
-      appSelections,
-      appModal,
-      model,
-    });
-
-    objectSelectionsStore.set(key, objectSelections);
-    objectSelectionsStore.dispatch(true);
+    setObjectSelections(
+      createObjectSelections({
+        appSelections,
+        appModal,
+        model,
+      })
+    );
   }, [appSelections, model]);
 
   useEffect(() => {

--- a/apis/nucleus/src/stores/selections-store.js
+++ b/apis/nucleus/src/stores/selections-store.js
@@ -2,16 +2,13 @@ import createKeyStore from './create-key-store';
 
 const [useAppSelectionsStore, appSelectionsStore] = createKeyStore({});
 const [useAppModalStore, appModalStore] = createKeyStore({});
-const [useObjectSelectionsStore, objectSelectionsStore] = createKeyStore({});
 const [useModalObjectStore, modalObjectStore] = createKeyStore({});
 
 export {
   useAppSelectionsStore,
   useAppModalStore,
-  useObjectSelectionsStore,
   appSelectionsStore,
   appModalStore,
-  objectSelectionsStore,
   useModalObjectStore,
   modalObjectStore,
 };


### PR DESCRIPTION
If there is a master filterpane and few collapsed filterpane objects are based on this master item, then everytime the user select an item in the listbox popover from a collapsed filterpane the listbox popover will be closed right away.
The problem is that currently we use one object selection for all filterpanes with the same model and then we check if a click is outside a filterpane or not and if it is then we trigger deactivated event which will close the listbox popover.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
