### PR TITLE
fix: race condition for mocked charts

### DIFF
--- a/apis/enigma-mocker/src/from-generic-objects.js
+++ b/apis/enigma-mocker/src/from-generic-objects.js
@@ -13,6 +13,7 @@ export default function fromGenericObjects(genericObjects, options = {}) {
     id: `app - ${+Date.now()}`,
     session,
     createSessionObject,
+    destroySessionObject: async () => {},
     getObject,
     getAppLayout,
   };

--- a/apis/nucleus/src/hooks/__tests__/use-rpc.test.jsx
+++ b/apis/nucleus/src/hooks/__tests__/use-rpc.test.jsx
@@ -1,94 +1,92 @@
-import React, { forwardRef, useImperativeHandle } from 'react';
-import { create, act } from 'react-test-renderer';
+import { renderHook, act, waitFor } from '@testing-library/react';
 
 import useRpc from '../useRpc';
 import { rpcRequestStore } from '../../stores/model-store';
 
-const TestHook = forwardRef(({ hook, hookProps }, ref) => {
-  const result = hook(...hookProps);
-  useImperativeHandle(ref, () => ({
-    result,
-  }));
-  return null;
-});
-
 describe('useRpc', () => {
-  let renderer;
-  let render;
-  let ref;
   let model;
 
   beforeEach(() => {
-    ref = React.createRef();
     model = {
       id: 'useRpc',
-      getLayout: jest.fn().mockReturnValue({ foo: 'bar' }),
+      getLayout: jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => resolve({ foo: 'bar' }), 20);
+          })
+      ),
       session: {
         getObjectApi: jest.fn().mockReturnValue({ cancelRequest: jest.fn() }),
       },
     };
-    render = async (hook, ...hookProps) => {
-      await act(async () => {
-        renderer = create(<TestHook ref={ref} hook={hook} hookProps={hookProps} />);
-      });
-    };
   });
 
   afterEach(() => {
-    renderer.unmount();
     rpcRequestStore.clear('useRpc');
   });
 
   test('should call method', async () => {
-    await render(useRpc, model, 'getLayout');
+    renderHook(() => useRpc(model, 'getLayout'));
     expect(model.getLayout).toHaveBeenCalledTimes(1);
   });
 
   test('should set result', async () => {
-    await render(useRpc, model, 'getLayout');
-    expect(ref.current.result[0]).toEqual({ foo: 'bar' });
-    expect(ref.current.result[1]).toEqual({ validating: false, canCancel: false, canRetry: false });
+    const { result } = renderHook(() => useRpc(model, 'getLayout'));
+    await waitFor(() => {
+      expect(result?.current?.[0]).toEqual({ foo: 'bar' });
+      expect(result?.current?.[1]).toEqual({ validating: false, canCancel: false, canRetry: false });
+    });
   });
 
   test('should cache result', async () => {
-    await render(useRpc, model, 'getLayout');
+    renderHook(() => useRpc(model, 'getLayout'));
     expect(model.getLayout).toHaveBeenCalledTimes(1);
-    await render(useRpc, model, 'getLayout');
-    await render(useRpc, model, 'getLayout');
-    await render(useRpc, model, 'getLayout');
+    renderHook(() => useRpc(model, 'getLayout'));
+    renderHook(() => useRpc(model, 'getLayout'));
+    renderHook(() => useRpc(model, 'getLayout'));
     expect(model.getLayout).toHaveBeenCalledTimes(1);
   });
 
   test('should dispatch invalid', async () => {
     model.getLayout = jest.fn().mockResolvedValue(new Promise(() => {}));
-    await render(useRpc, model, 'getLayout');
-    expect(ref.current.result[1]).toEqual({ validating: true, canCancel: true, canRetry: false });
+    const { result } = renderHook(() => useRpc(model, 'getLayout'));
+    await waitFor(() => {
+      expect(result.current[1]).toEqual({ validating: true, canCancel: true, canRetry: false });
+    });
   });
 
   test('should dispatch cancelled', async () => {
-    await render(useRpc, model, 'getLayout');
-    await act(async () => ref.current.result[2].cancel());
-    expect(ref.current.result[0]).toEqual({ foo: 'bar' });
-    expect(ref.current.result[1]).toEqual({
-      validating: false,
-      canCancel: false,
-      canRetry: true,
+    const { result } = renderHook(() => useRpc(model, 'getLayout'));
+
+    await act(async () => {
+      await result.current[2].cancel();
+    });
+
+    await waitFor(() => {
+      expect(result.current[1]).toEqual({
+        validating: false,
+        canCancel: false,
+        canRetry: true,
+      });
     });
   });
 
   test('should retry', async () => {
     model.getLayout = jest.fn().mockReturnValue(new Promise(() => {}));
-    await render(useRpc, model, 'getLayout');
-    act(() => {
-      ref.current.result[2].cancel();
+    let result;
+    ({ result } = renderHook(() => useRpc(model, 'getLayout')));
+    await act(async () => {
+      result.current[2].cancel();
     });
-    await render(useRpc, model, 'getLayout');
+    ({ result } = renderHook(() => useRpc(model, 'getLayout')));
     model.getLayout = jest.fn().mockReturnValue({ success: true });
-    act(() => {
-      ref.current.result[2].retry();
+    await act(async () => {
+      result.current[2].retry();
     });
-    await render(useRpc, model, 'getLayout');
-    expect(ref.current.result[0]).toEqual({ success: true });
-    expect(ref.current.result[1]).toEqual({ validating: false, canCancel: false, canRetry: false });
+    ({ result } = renderHook(() => useRpc(model, 'getLayout')));
+    await waitFor(() => {
+      expect(result.current[0]).toEqual({ success: true });
+      expect(result.current[1]).toEqual({ validating: false, canCancel: false, canRetry: false });
+    });
   });
 });

--- a/apis/nucleus/src/hooks/useRpc.js
+++ b/apis/nucleus/src/hooks/useRpc.js
@@ -100,6 +100,9 @@ export default function useRpc(model, method) {
 
     try {
       // await sleep(5000);
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0); // To avoid race condition related to react hooks
+      });
       const result = await cache.rpc;
       dispatch({ type: 'VALID', result, key, method, model, rpcResultStore });
     } catch (err) {

--- a/apis/nucleus/src/hooks/useRpc.js
+++ b/apis/nucleus/src/hooks/useRpc.js
@@ -1,7 +1,6 @@
 import { useReducer, useEffect } from 'react';
 import { useModelChangedStore, useRpcResultStore, useRpcRequestStore } from '../stores/model-store';
 
-// eslint-disable-next-line no-unused-vars
 const sleep = (delay) =>
   new Promise((resolve) => {
     setTimeout(resolve, delay);
@@ -99,10 +98,9 @@ export default function useRpc(model, method) {
     }
 
     try {
-      // await sleep(5000);
-      await new Promise((resolve) => {
-        setTimeout(resolve, 0); // To avoid race condition related to react hooks
-      });
+      // To avoid possible race condition causing an infinite loop.
+      // Problem has been observed for mocked models appeared after switching to react 18 (reactDOM render -> createRoot).
+      await sleep(0);
       const result = await cache.rpc;
       dispatch({ type: 'VALID', result, key, method, model, rpcResultStore });
     } catch (err) {


### PR DESCRIPTION
Solves a race condition that has occurred a couple of times when rendering charts using a mocked data model (no real engine), both when using EnigmaMocker and when "manually" mocking the engima app model.

I have no really good explanation to exactly how this solves the problem, but it does. And I see no big risk in introducing this extra await with the setTimeout into `useRpc`, since all of those backend calls are asynchronous anyway - they will always have some kind of delay in real life scenarios.

TODO:
- [x] Some more manual regression testing before merging