### PR TITLE
feat: object conversion for readonly charts (#1335)

### DIFF
--- a/apis/conversion/src/index.js
+++ b/apis/conversion/src/index.js
@@ -47,13 +47,19 @@ const getImportPropertiesFnc = (qae) => {
   return getDefaultImportPropertiesFnc(path);
 };
 
-export const convertTo = async ({ halo, model, cellRef, newType }) => {
-  const propertyTree = await model.getFullPropertyTree();
+export const convertTo = async ({ halo, model, cellRef, newType, properties }) => {
+  const propertyTree = properties ? { qProperty: properties } : await model.getFullPropertyTree();
   const sourceQae = cellRef.current.getQae();
   const exportProperties = getExportPropertiesFnc(sourceQae);
+  if (!exportProperties) {
+    throw new Error('Source chart does not support conversion');
+  }
   const targetSnType = await getType({ halo, name: newType });
   const targetQae = targetSnType.qae;
   const importProperties = getImportPropertiesFnc(targetQae);
+  if (!importProperties) {
+    throw new Error('Target chart does not support conversion');
+  }
   const exportFormat = exportProperties({
     propertyTree,
     hypercubePath: helpers.getHypercubePath(sourceQae),

--- a/apis/nucleus/src/__tests__/viz.test.js
+++ b/apis/nucleus/src/__tests__/viz.test.js
@@ -55,6 +55,7 @@ describe('viz', () => {
 
     model = {
       getEffectiveProperties: jest.fn().mockReturnValue('old'),
+      getLayout: jest.fn().mockReturnValue({ qMeta: { privileges: ['update'] } }),
       applyPatches: jest.fn(),
       on: jest.fn(),
       once: jest.fn(),

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -99,7 +99,10 @@ const DEFAULT_CONTEXT = /** @lends Context */ {
   language: 'en-US',
   /** @type {string=} */
   deviceType: 'auto',
-  /** @type {Constraints=} Deprecated */
+  /**
+   * @type {Constraints=}
+   * @deprecated
+   * */
   constraints: {},
   /** @type {Interactions=} */
   interactions: {},

--- a/apis/nucleus/src/utils/can-set-properties.js
+++ b/apis/nucleus/src/utils/can-set-properties.js
@@ -1,0 +1,9 @@
+const canSetProperties = (layout) =>
+  !!(
+    layout &&
+    !layout.qHasSoftPatches &&
+    !layout.qExtendsId &&
+    (layout.qMeta?.privileges || []).indexOf('update') > -1
+  );
+
+export default canSetProperties;

--- a/apis/nucleus/src/utils/save-soft-properties.js
+++ b/apis/nucleus/src/utils/save-soft-properties.js
@@ -1,0 +1,27 @@
+/* eslint-disable no-underscore-dangle */
+import extend from 'extend';
+import { JSONPatch } from '@nebula.js/supernova';
+
+const saveSoftProperties = (model, prevEffectiveProperties, effectiveProperties) => {
+  if (!model) {
+    return Promise.resolve();
+  }
+
+  let patches = JSONPatch.generate(prevEffectiveProperties, effectiveProperties);
+  extend(true, prevEffectiveProperties, effectiveProperties);
+
+  if (patches && patches.length) {
+    patches = patches.map((p) => ({
+      qOp: p.op,
+      qValue: JSON.stringify(p.value),
+      qPath: p.path,
+    }));
+    if (model.__snInterceptor) {
+      return model.__snInterceptor.applyPatches.call(model, patches, true);
+    }
+    return model.applyPatches(patches, true);
+  }
+  return Promise.resolve();
+};
+
+export default saveSoftProperties;

--- a/apis/nucleus/src/utils/set-properties.js
+++ b/apis/nucleus/src/utils/set-properties.js
@@ -1,0 +1,9 @@
+/* eslint-disable no-underscore-dangle */
+const setProperties = (model, newProperties) => {
+  if (model.__snInterceptor) {
+    return model.__snInterceptor.setProperties.call(model, newProperties);
+  }
+  return model.setProperties(newProperties);
+};
+
+export default setProperties;

--- a/apis/nucleus/src/viz.js
+++ b/apis/nucleus/src/viz.js
@@ -109,11 +109,12 @@ export default function viz({ model, halo, initialError, onDestroy = async () =>
       unmountCell = noopi;
     },
     /**
-     * Converts the visualization to a different registered type. Will update properties if permissions allow, else will patch.
+     * Converts the visualization to a different registered type.
+     *
+     * Will update properties if permissions allow, else will patch (can be forced with forcePatch parameter)
      *
      * Not all chart types are compatible, similar structures are required.
      *
-     * NOTE: Consider using viz.convert.toType instead for session based conversion
      * @since 1.1.0
      * @param {string} newType - Which registered type to convert to.
      * @param {boolean=} forceUpdate - Whether to apply the change or not, else simply returns the resulting properties, defaults to true.

--- a/apis/nucleus/src/viz.js
+++ b/apis/nucleus/src/viz.js
@@ -4,6 +4,9 @@ import { convertTo as conversionConvertTo } from '@nebula.js/conversion';
 import glueCell from './components/glue';
 import getPatches from './utils/patcher';
 import validatePlugins from './plugins/plugins';
+import canSetProperties from './utils/can-set-properties';
+import setProperties from './utils/set-properties';
+import saveSoftProperties from './utils/save-soft-properties';
 
 const noopi = () => {};
 
@@ -106,27 +109,84 @@ export default function viz({ model, halo, initialError, onDestroy = async () =>
       unmountCell = noopi;
     },
     /**
-     * Converts the visualization to a different registered type
+     * Contains functionality related to conversions between types in the current session
+     * @memberof Viz#
+     * @ignore
+     * @since 4.5.0
+     */
+    convert: {
+      /**
+       * Converts the visualization to a different registered type using a patch. Only persists in session
+       * @since 4.5.0
+       * @memberof Viz.convert
+       * @param {string} newType - Which registered type to convert to.
+       * @throws {Error} Throws an error if the source or target chart does not support conversion
+       * @returns {Promise<object>} Promise object that resolves to the full property tree of the converted visualization.
+       * @example
+       * const viz = await embed(app).render({
+       *   element,
+       *   id: 'abc'
+       * });
+       * viz.convert.toType('barChart');
+       */
+      async toType(newType) {
+        const oldProperties = await model.getEffectiveProperties();
+        const propertyTree = await conversionConvertTo({ halo, model, cellRef, newType, properties: oldProperties });
+        const newProperties = propertyTree.qProperty;
+        await saveSoftProperties(model, oldProperties, newProperties);
+        return propertyTree;
+      },
+      /**
+       * Reverts any conversion done on the visualization
+       * @since 4.5.0
+       * @memberof Viz.convert
+       * @returns {Promise<object>} Promise object that resolves when the conversion is undone, returns result.
+       * @example
+       * const viz = await embed(app).render({
+       *   element,
+       *   id: 'abc'
+       * });
+       * viz.convert.toType('barChart');
+       * viz.convert.revert();
+       */
+      async revert() {
+        await model.clearSoftPatches();
+      },
+    },
+    /**
+     * Converts the visualization to a different registered type. Will update properties if permissions allow, else will patch.
+     *
+     * Not all chart types are compatible, similar structures are required.
+     *
+     * NOTE: Consider using viz.convert.toType instead for session based conversion
      * @since 1.1.0
      * @param {string} newType - Which registered type to convert to.
-     * @param {boolean=} forceUpdate - Whether to run setProperties or not, defaults to true.
+     * @param {boolean=} forceUpdate - Whether to apply the change through setProperties/applyPatches or not, defaults to true.
+     * @throws {Error} Throws an error if the source or target chart does not support conversion
      * @returns {Promise<object>} Promise object that resolves to the full property tree of the converted visualization.
      * @example
      * const viz = await embed(app).render({
      *   element,
      *   id: 'abc'
      * });
-     * viz.convertTo('barChart');
+     * await viz.convertTo('barChart');
+     * const newProperties = await viz.convertTo('lineChart', false);
      */
     async convertTo(newType, forceUpdate = true) {
-      const propertyTree = await conversionConvertTo({ halo, model, cellRef, newType });
       if (forceUpdate) {
-        if (model.__snInterceptor) {
-          await model.__snInterceptor.setProperties.call(model, propertyTree.qProperty);
-        } else {
-          await model.setProperties(propertyTree.qProperty);
+        const layout = await model.getLayout();
+        if (canSetProperties(layout)) {
+          const propertyTree = await conversionConvertTo({ halo, model, cellRef, newType });
+          await setProperties(model, propertyTree.qProperty);
+          return propertyTree;
         }
+        const oldProperties = await model.getEffectiveProperties();
+        const propertyTree = await conversionConvertTo({ halo, model, cellRef, newType, properties: oldProperties });
+        const newProperties = propertyTree.qProperty;
+        await saveSoftProperties(model, oldProperties, newProperties);
+        return propertyTree;
       }
+      const propertyTree = await conversionConvertTo({ halo, model, cellRef, newType });
       return propertyTree;
     },
     /**

--- a/apis/nucleus/src/viz.js
+++ b/apis/nucleus/src/viz.js
@@ -109,51 +109,6 @@ export default function viz({ model, halo, initialError, onDestroy = async () =>
       unmountCell = noopi;
     },
     /**
-     * Contains functionality related to conversions between types in the current session
-     * @memberof Viz#
-     * @ignore
-     * @since 4.5.0
-     */
-    convert: {
-      /**
-       * Converts the visualization to a different registered type using a patch. Only persists in session
-       * @since 4.5.0
-       * @memberof Viz.convert
-       * @param {string} newType - Which registered type to convert to.
-       * @throws {Error} Throws an error if the source or target chart does not support conversion
-       * @returns {Promise<object>} Promise object that resolves to the full property tree of the converted visualization.
-       * @example
-       * const viz = await embed(app).render({
-       *   element,
-       *   id: 'abc'
-       * });
-       * viz.convert.toType('barChart');
-       */
-      async toType(newType) {
-        const oldProperties = await model.getEffectiveProperties();
-        const propertyTree = await conversionConvertTo({ halo, model, cellRef, newType, properties: oldProperties });
-        const newProperties = propertyTree.qProperty;
-        await saveSoftProperties(model, oldProperties, newProperties);
-        return propertyTree;
-      },
-      /**
-       * Reverts any conversion done on the visualization
-       * @since 4.5.0
-       * @memberof Viz.convert
-       * @returns {Promise<object>} Promise object that resolves when the conversion is undone, returns result.
-       * @example
-       * const viz = await embed(app).render({
-       *   element,
-       *   id: 'abc'
-       * });
-       * viz.convert.toType('barChart');
-       * viz.convert.revert();
-       */
-      async revert() {
-        await model.clearSoftPatches();
-      },
-    },
-    /**
      * Converts the visualization to a different registered type. Will update properties if permissions allow, else will patch.
      *
      * Not all chart types are compatible, similar structures are required.
@@ -161,7 +116,8 @@ export default function viz({ model, halo, initialError, onDestroy = async () =>
      * NOTE: Consider using viz.convert.toType instead for session based conversion
      * @since 1.1.0
      * @param {string} newType - Which registered type to convert to.
-     * @param {boolean=} forceUpdate - Whether to apply the change through setProperties/applyPatches or not, defaults to true.
+     * @param {boolean=} forceUpdate - Whether to apply the change or not, else simply returns the resulting properties, defaults to true.
+     * @param {boolean=} forcePatch - Whether to always patch the change instead of making a permanent change
      * @throws {Error} Throws an error if the source or target chart does not support conversion
      * @returns {Promise<object>} Promise object that resolves to the full property tree of the converted visualization.
      * @example
@@ -170,12 +126,15 @@ export default function viz({ model, halo, initialError, onDestroy = async () =>
      *   id: 'abc'
      * });
      * await viz.convertTo('barChart');
-     * const newProperties = await viz.convertTo('lineChart', false);
+     * // Change the barchart to a linechart, only in the current session
+     * const newProperties = await viz.convertTo('lineChart', false, true);
+     * // Remove the conversion by clearing the patches
+     * await viz.model.clearSoftPatches();
      */
-    async convertTo(newType, forceUpdate = true) {
+    async convertTo(newType, forceUpdate = true, forcePatch = false) {
       if (forceUpdate) {
         const layout = await model.getLayout();
-        if (canSetProperties(layout)) {
+        if (canSetProperties(layout) && !forcePatch) {
           const propertyTree = await conversionConvertTo({ halo, model, cellRef, newType });
           await setProperties(model, propertyTree.qProperty);
           return propertyTree;
@@ -256,6 +215,53 @@ export default function viz({ model, halo, initialError, onDestroy = async () =>
       },
       getModel() {
         return model;
+      },
+      /**
+       * Contains functionality related to conversions between types in the current session
+       * @memberof Viz#
+       * @ignore
+       * @since 4.5.0
+       */
+      convert: {
+        /**
+         * Converts the visualization to a different registered type using a patch. Only persists in session
+         * @since 4.5.0
+         * @ignore
+         * @memberof Viz.convert
+         * @param {string} newType - Which registered type to convert to.
+         * @throws {Error} Throws an error if the source or target chart does not support conversion
+         * @returns {Promise<object>} Promise object that resolves to the full property tree of the converted visualization.
+         * @example
+         * const viz = await embed(app).render({
+         *   element,
+         *   id: 'abc'
+         * });
+         * viz.convert.toType('barChart');
+         */
+        async toType(newType) {
+          const oldProperties = await model.getEffectiveProperties();
+          const propertyTree = await conversionConvertTo({ halo, model, cellRef, newType, properties: oldProperties });
+          const newProperties = propertyTree.qProperty;
+          await saveSoftProperties(model, oldProperties, newProperties);
+          return propertyTree;
+        },
+        /**
+         * Reverts any conversion done on the visualization
+         * @since 4.5.0
+         * @ignore
+         * @memberof Viz.convert
+         * @returns {Promise<object>} Promise object that resolves when the conversion is undone, returns result.
+         * @example
+         * const viz = await embed(app).render({
+         *   element,
+         *   id: 'abc'
+         * });
+         * viz.convert.toType('barChart');
+         * viz.convert.revert();
+         */
+        async revert() {
+          await model.clearSoftPatches();
+        },
       },
     },
 

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -689,7 +689,9 @@
           "type": "string"
         },
         "constraints": {
-          "description": "Deprecated",
+          "availability": {
+            "deprecated": true
+          },
           "optional": true,
           "type": "#/definitions/Constraints"
         },
@@ -1245,7 +1247,7 @@
           ]
         },
         "convertTo": {
-          "description": "Converts the visualization to a different registered type",
+          "description": "Converts the visualization to a different registered type. Will update properties if permissions allow, else will patch.\n\nNot all chart types are compatible, similar structures are required.\n\nNOTE: Consider using viz.convert.toType instead for session based conversion",
           "availability": {
             "since": "1.1.0"
           },
@@ -1258,7 +1260,7 @@
             },
             {
               "name": "forceUpdate",
-              "description": "Whether to run setProperties or not, defaults to true.",
+              "description": "Whether to apply the change through setProperties/applyPatches or not, defaults to true.",
               "optional": true,
               "type": "boolean"
             }
@@ -1272,8 +1274,14 @@
               }
             ]
           },
+          "throws": [
+            {
+              "description": "Throws an error if the source or target chart does not support conversion",
+              "type": "Error"
+            }
+          ],
           "examples": [
-            "const viz = await embed(app).render({\n  element,\n  id: 'abc'\n});\nviz.convertTo('barChart');"
+            "const viz = await embed(app).render({\n  element,\n  id: 'abc'\n});\nawait viz.convertTo('barChart');\nconst newProperties = await viz.convertTo('lineChart', false);"
           ]
         },
         "addListener": {
@@ -1329,6 +1337,58 @@
       },
       "examples": [
         "const viz = await embed(app).render({\n  element,\n  type: 'barchart'\n});\nviz.destroy();"
+      ]
+    },
+    "Viz.convert.toType": {
+      "description": "Converts the visualization to a different registered type using a patch. Only persists in session",
+      "availability": {
+        "since": "4.5.0"
+      },
+      "kind": "function",
+      "params": [
+        {
+          "name": "newType",
+          "description": "Which registered type to convert to.",
+          "type": "string"
+        }
+      ],
+      "returns": {
+        "description": "Promise object that resolves to the full property tree of the converted visualization.",
+        "type": "Promise",
+        "generics": [
+          {
+            "type": "object"
+          }
+        ]
+      },
+      "throws": [
+        {
+          "description": "Throws an error if the source or target chart does not support conversion",
+          "type": "Error"
+        }
+      ],
+      "examples": [
+        "const viz = await embed(app).render({\n  element,\n  id: 'abc'\n});\nviz.convert.toType('barChart');"
+      ]
+    },
+    "Viz.convert.revert": {
+      "description": "Reverts any conversion done on the visualization",
+      "availability": {
+        "since": "4.5.0"
+      },
+      "kind": "function",
+      "params": [],
+      "returns": {
+        "description": "Promise object that resolves when the conversion is undone, returns result.",
+        "type": "Promise",
+        "generics": [
+          {
+            "type": "object"
+          }
+        ]
+      },
+      "examples": [
+        "const viz = await embed(app).render({\n  element,\n  id: 'abc'\n});\nviz.convert.toType('barChart');\nviz.convert.revert();"
       ]
     },
     "Flags": {
@@ -1588,6 +1648,33 @@
         }
       }
     },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
+    },
     "Field": {
       "kind": "alias",
       "items": {
@@ -1722,33 +1809,6 @@
           ]
         }
       }
-    },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
-      "kind": "interface",
-      "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
-              "type": "string"
-            }
-          }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
-        }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
     },
     "LoadType": {
       "kind": "interface",

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1260,7 +1260,13 @@
             },
             {
               "name": "forceUpdate",
-              "description": "Whether to apply the change through setProperties/applyPatches or not, defaults to true.",
+              "description": "Whether to apply the change or not, else simply returns the resulting properties, defaults to true.",
+              "optional": true,
+              "type": "boolean"
+            },
+            {
+              "name": "forcePatch",
+              "description": "Whether to always patch the change instead of making a permanent change",
               "optional": true,
               "type": "boolean"
             }
@@ -1281,7 +1287,7 @@
             }
           ],
           "examples": [
-            "const viz = await embed(app).render({\n  element,\n  id: 'abc'\n});\nawait viz.convertTo('barChart');\nconst newProperties = await viz.convertTo('lineChart', false);"
+            "const viz = await embed(app).render({\n  element,\n  id: 'abc'\n});\nawait viz.convertTo('barChart');\n// Change the barchart to a linechart, only in the current session\nconst newProperties = await viz.convertTo('lineChart', false, true);\n// Remove the conversion by clearing the patches\nawait viz.model.clearSoftPatches();"
           ]
         },
         "addListener": {
@@ -1337,58 +1343,6 @@
       },
       "examples": [
         "const viz = await embed(app).render({\n  element,\n  type: 'barchart'\n});\nviz.destroy();"
-      ]
-    },
-    "Viz.convert.toType": {
-      "description": "Converts the visualization to a different registered type using a patch. Only persists in session",
-      "availability": {
-        "since": "4.5.0"
-      },
-      "kind": "function",
-      "params": [
-        {
-          "name": "newType",
-          "description": "Which registered type to convert to.",
-          "type": "string"
-        }
-      ],
-      "returns": {
-        "description": "Promise object that resolves to the full property tree of the converted visualization.",
-        "type": "Promise",
-        "generics": [
-          {
-            "type": "object"
-          }
-        ]
-      },
-      "throws": [
-        {
-          "description": "Throws an error if the source or target chart does not support conversion",
-          "type": "Error"
-        }
-      ],
-      "examples": [
-        "const viz = await embed(app).render({\n  element,\n  id: 'abc'\n});\nviz.convert.toType('barChart');"
-      ]
-    },
-    "Viz.convert.revert": {
-      "description": "Reverts any conversion done on the visualization",
-      "availability": {
-        "since": "4.5.0"
-      },
-      "kind": "function",
-      "params": [],
-      "returns": {
-        "description": "Promise object that resolves when the conversion is undone, returns result.",
-        "type": "Promise",
-        "generics": [
-          {
-            "type": "object"
-          }
-        ]
-      },
-      "examples": [
-        "const viz = await embed(app).render({\n  element,\n  id: 'abc'\n});\nviz.convert.toType('barChart');\nviz.convert.revert();"
       ]
     },
     "Flags": {
@@ -1648,33 +1602,6 @@
         }
       }
     },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
-      "kind": "interface",
-      "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
-              "type": "string"
-            }
-          }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
-        }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
-    },
     "Field": {
       "kind": "alias",
       "items": {
@@ -1809,6 +1736,33 @@
           ]
         }
       }
+    },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
     },
     "LoadType": {
       "kind": "interface",

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -395,9 +395,13 @@ declare namespace stardust {
         destroy(): void;
 
         /**
-         * Converts the visualization to a different registered type
+         * Converts the visualization to a different registered type. Will update properties if permissions allow, else will patch.
+         * 
+         * Not all chart types are compatible, similar structures are required.
+         * 
+         * NOTE: Consider using viz.convert.toType instead for session based conversion
          * @param newType Which registered type to convert to.
-         * @param forceUpdate Whether to run setProperties or not, defaults to true.
+         * @param forceUpdate Whether to apply the change through setProperties/applyPatches or not, defaults to true.
          */
         convertTo(newType: string, forceUpdate?: boolean): Promise<object>;
 
@@ -421,6 +425,16 @@ declare namespace stardust {
         getImperativeHandle(): Promise<object>;
 
     }
+
+    /**
+     * Converts the visualization to a different registered type using a patch. Only persists in session
+     */
+    type Viz.convert.toType = (newType: string)=>Promise<object>;
+
+    /**
+     * Reverts any conversion done on the visualization
+     */
+    type Viz.convert.revert = ()=>Promise<object>;
 
     interface Flags {
         /**
@@ -504,6 +518,16 @@ declare namespace stardust {
 
     }
 
+    /**
+     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
+     */
+    interface Plugin {
+        info: {
+            name: string;
+        };
+        fn: ()=>void;
+    }
+
     type Field = string | EngineAPI.INxDimension | EngineAPI.INxMeasure | stardust.LibraryField;
 
     /**
@@ -534,16 +558,6 @@ declare namespace stardust {
     interface LibraryField {
         qLibraryId: string;
         type: "dimension" | "measure";
-    }
-
-    /**
-     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
-     */
-    interface Plugin {
-        info: {
-            name: string;
-        };
-        fn: ()=>void;
     }
 
     interface LoadType {

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -401,9 +401,10 @@ declare namespace stardust {
          * 
          * NOTE: Consider using viz.convert.toType instead for session based conversion
          * @param newType Which registered type to convert to.
-         * @param forceUpdate Whether to apply the change through setProperties/applyPatches or not, defaults to true.
+         * @param forceUpdate Whether to apply the change or not, else simply returns the resulting properties, defaults to true.
+         * @param forcePatch Whether to always patch the change instead of making a permanent change
          */
-        convertTo(newType: string, forceUpdate?: boolean): Promise<object>;
+        convertTo(newType: string, forceUpdate?: boolean, forcePatch?: boolean): Promise<object>;
 
         /**
          * Listens to custom events from inside the visualization. See useEmitter
@@ -425,16 +426,6 @@ declare namespace stardust {
         getImperativeHandle(): Promise<object>;
 
     }
-
-    /**
-     * Converts the visualization to a different registered type using a patch. Only persists in session
-     */
-    type Viz.convert.toType = (newType: string)=>Promise<object>;
-
-    /**
-     * Reverts any conversion done on the visualization
-     */
-    type Viz.convert.revert = ()=>Promise<object>;
 
     interface Flags {
         /**
@@ -518,16 +509,6 @@ declare namespace stardust {
 
     }
 
-    /**
-     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
-     */
-    interface Plugin {
-        info: {
-            name: string;
-        };
-        fn: ()=>void;
-    }
-
     type Field = string | EngineAPI.INxDimension | EngineAPI.INxMeasure | stardust.LibraryField;
 
     /**
@@ -558,6 +539,16 @@ declare namespace stardust {
     interface LibraryField {
         qLibraryId: string;
         type: "dimension" | "measure";
+    }
+
+    /**
+     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
+     */
+    interface Plugin {
+        info: {
+            name: string;
+        };
+        fn: ()=>void;
     }
 
     interface LoadType {

--- a/apis/supernova/src/index.js
+++ b/apis/supernova/src/index.js
@@ -1,6 +1,7 @@
 import generator from './generator';
+import JSONPatch from './json-patch';
 
-export { generator };
+export { generator, JSONPatch };
 
 // core hooks
 export { hook, useState, useEffect, useMemo, useImperativeHandle } from './hooks';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

I decided to make this simpler for now just add a parameter to the current api to support patching and keep the new API hidden.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
