### PR TITLE
feat: supress "use client" warnings in charts build with watch flag

### DIFF
--- a/commands/build/lib/watch.js
+++ b/commands/build/lib/watch.js
@@ -67,10 +67,16 @@ const watch = async (argv) => {
 
   const watcher = rollup.watch({
     ...c.input,
-    onwarn({ loc, message }) {
+    onwarn({ loc, message, code }) {
       if (!hasWarnings) {
         clearScreen();
       }
+
+      // Supress "use client" warnings coming from MUI bundling
+      if (code === 'MODULE_LEVEL_DIRECTIVE' && message.includes(`"use client"`)) {
+        return;
+      }
+
       console.log(
         `${chalk.black.bgYellow(' WARN  ')} ${chalk.yellow(
           loc ? `${loc.file} (${loc.line}:${loc.column}) ${message}` : message


### PR DESCRIPTION
Extends #1349 to also include when building using the watch flag

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
