### PR TITLE
fix: prevent only one item rendering in single grid mode

### DIFF
--- a/apis/nucleus/src/components/listbox/assets/list-sizes/column-mode.js
+++ b/apis/nucleus/src/components/listbox/assets/list-sizes/column-mode.js
@@ -16,6 +16,8 @@ export default function calculateColumnMode({
     rowCount = Math.min(listCount, maxRows, autoRowCount);
   }
 
+  rowCount = Math.max(rowCount, 1);
+
   const columnCount = Math.ceil(listCount / rowCount);
   const columnWidth = Math.max(columnAutoWidth, containerWidth / columnCount, itemMinWidth);
 

--- a/apis/nucleus/src/components/listbox/assets/list-sizes/row-mode.js
+++ b/apis/nucleus/src/components/listbox/assets/list-sizes/row-mode.js
@@ -20,6 +20,9 @@ export default function calculateRowMode({
   } else {
     columnCount = Math.min(listCount, maxColumns, autoColumnCount);
   }
+
+  columnCount = Math.max(columnCount, 1);
+
   const columnWidth = innerWidth / columnCount;
   const rowCount = Math.ceil(listCount / columnCount);
   return {

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1653,6 +1653,33 @@
         }
       }
     },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
+    },
     "Field": {
       "kind": "alias",
       "items": {
@@ -1787,33 +1814,6 @@
           ]
         }
       }
-    },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
-      "kind": "interface",
-      "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
-              "type": "string"
-            }
-          }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
-        }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
     },
     "LoadType": {
       "kind": "interface",

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -222,6 +222,10 @@ export namespace EnigmaMocker {
 }
 
 declare namespace stardust {
+    interface Component {
+        key: string;
+    }
+
     interface Configuration {
         load?: stardust.LoadType;
         context?: stardust.Context;
@@ -344,6 +348,7 @@ declare namespace stardust {
             checkboxes?: boolean;
             dense?: boolean;
             stateName?: string;
+            components?: stardust.Component[];
             properties?: object;
         }): Promise<void>;
 
@@ -527,6 +532,16 @@ declare namespace stardust {
 
     }
 
+    /**
+     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
+     */
+    interface Plugin {
+        info: {
+            name: string;
+        };
+        fn: ()=>void;
+    }
+
     type Field = string | EngineAPI.INxDimension | EngineAPI.INxMeasure | stardust.LibraryField;
 
     /**
@@ -557,16 +572,6 @@ declare namespace stardust {
     interface LibraryField {
         qLibraryId: string;
         type: "dimension" | "measure";
-    }
-
-    /**
-     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
-     */
-    interface Plugin {
-        info: {
-            name: string;
-        };
-        fn: ()=>void;
     }
 
     interface LoadType {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

### Before

<img width="756" alt="image" src="https://github.com/qlik-oss/nebula.js/assets/5780544/340fcb2b-8fbc-4cc9-b94f-0242e82672f6">

### After

<img width="740" alt="image" src="https://github.com/qlik-oss/nebula.js/assets/5780544/901dfd45-b0c6-4aa3-89ac-2234fdb20133">


### Caused by:

Division by 0 lead to `columnCount == Infinity`.

### Fixed by:

Force `rowCount` or `columnCount` to be at least 1.


## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
