### PR TITLE
fix: handle sync calls to session storage

### DIFF
--- a/apis/nucleus/src/hooks/__tests__/use-session-model.test.jsx
+++ b/apis/nucleus/src/hooks/__tests__/use-session-model.test.jsx
@@ -1,0 +1,59 @@
+/* eslint no-import-assign: 0 */
+import React, { forwardRef, useImperativeHandle } from 'react';
+import { create, act } from 'react-test-renderer';
+
+import useSessionModel from '../useSessionModel';
+
+const TestHook = forwardRef(({ hook, hookProps = [] }, ref) => {
+  const result = hook(...hookProps);
+  const result2 = hook(...hookProps);
+  useImperativeHandle(ref, () => ({
+    result,
+    result2,
+  }));
+  return null;
+});
+
+describe('useSessionModel', () => {
+  let renderer;
+  let render;
+  let ref;
+  let app;
+
+  beforeEach(() => {
+    app = {
+      id: 'appSel',
+      session: {},
+      createSessionObject: jest.fn().mockReturnValue(
+        Promise.resolve({
+          id: 'modelID',
+          on: jest.fn(),
+          once: jest.fn(),
+        })
+      ),
+    };
+
+    ref = React.createRef();
+    render = async () => {
+      await act(async () => {
+        renderer = create(<TestHook ref={ref} hook={useSessionModel} hookProps={[{ id: 'inputID' }, app]} />);
+      });
+    };
+  });
+
+  afterEach(() => {
+    renderer.unmount();
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  test('create session object', async () => {
+    await render();
+    const model = await ref.current.result[0];
+    expect(app.createSessionObject).toHaveBeenCalledTimes(1);
+    expect(model.id).toEqual('modelID');
+
+    await ref.current.result2[0];
+    expect(app.createSessionObject).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apis/nucleus/src/hooks/useSessionModel.js
+++ b/apis/nucleus/src/hooks/useSessionModel.js
@@ -7,21 +7,15 @@ export default function useSessionModel(definition, app, ...deps) {
   const [rpcRequestSessionModelStore] = useRpcRequestSessionModelStore();
   const [model, setModel] = useState();
 
-  let rpcShared;
-
-  if (key) {
-    rpcShared = rpcRequestSessionModelStore.get(key);
-  }
-
   useEffect(() => {
     if (!app) {
       return;
     }
     // Create new session object
     const create = async () => {
+      let rpcShared = rpcRequestSessionModelStore.get(key);
       if (!rpcShared) {
-        const rpc = app.createSessionObject(definition);
-        rpcShared = rpc;
+        rpcShared = app.createSessionObject(definition);
         rpcRequestSessionModelStore.set(key, rpcShared);
       }
       const newModel = await rpcShared;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Fixes an issue where the alternate states wasn't displayed at all in current selections. 
Instead of using a shared model there where two current-selections session objects, with only one getting the alternate states patch. This looks to be due to a timing issue where the two calls to useCurrentSelectionsModel was done too close to eachother thus not having time to store the rpcCall. This change introduces a sync storage of the call promise instead of waiting fo the actual call to be made.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
