### PR TITLE
fix: handle unsupported colors and add tests

### DIFF
--- a/apis/nucleus/src/components/listbox/assets/__tests__/styling.test.js
+++ b/apis/nucleus/src/components/listbox/assets/__tests__/styling.test.js
@@ -57,6 +57,9 @@ describe('styling', () => {
     beforeAll(() => {
       jest.spyOn(muiStyles, 'getContrastRatio').mockReturnValue(0.5);
     });
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
 
     it('header', () => {
       components = [
@@ -168,11 +171,12 @@ describe('styling', () => {
   });
 
   describe('hasEnoughContrast', () => {
-    it('should not throw on transparent', () => {
+    it('should not throw on unsupported color and fall back to true', () => {
       expect(() => hasEnoughContrast('rgb(0,0,0)', 'transparent')).not.toThrow();
       expect(() => hasEnoughContrast('transparent', 'transparent')).not.toThrow();
       expect(() => hasEnoughContrast('red', 'blue')).not.toThrow();
       expect(() => hasEnoughContrast('misspelled', 'hey hey')).not.toThrow();
+      expect(hasEnoughContrast('misspelled', 'hey hey')).toEqual(true);
       expect(hasEnoughContrast('transparent', 'transparent')).toEqual(false);
     });
   });

--- a/apis/nucleus/src/components/listbox/assets/__tests__/styling.test.js
+++ b/apis/nucleus/src/components/listbox/assets/__tests__/styling.test.js
@@ -1,5 +1,5 @@
 import * as muiStyles from '@mui/material/styles';
-import getStyling, { getOverridesAsObject } from '../styling';
+import getStyling, { convertNamedColor, getOverridesAsObject, hasEnoughContrast } from '../styling';
 
 jest.mock('@mui/material/styles', () => ({
   __esModule: true,
@@ -10,10 +10,6 @@ describe('styling', () => {
   let theme = {};
   let components = [];
   let themeApi;
-
-  beforeAll(() => {
-    jest.spyOn(muiStyles, 'getContrastRatio').mockReturnValue(0.5);
-  });
 
   afterEach(() => {
     jest.resetAllMocks();
@@ -58,6 +54,10 @@ describe('styling', () => {
   });
 
   describe('should return expected header style based on theme and then overridden by components', () => {
+    beforeAll(() => {
+      jest.spyOn(muiStyles, 'getContrastRatio').mockReturnValue(0.5);
+    });
+
     it('header', () => {
       components = [
         {
@@ -164,6 +164,25 @@ describe('styling', () => {
       const inputComponents = ['general', 'selections', 'theme', 'not-supported', undefined].map((key) => ({ key }));
       expect(inputComponents).toHaveLength(5);
       expect(Object.keys(getOverridesAsObject(inputComponents)).sort()).toEqual(['selections', 'theme']);
+    });
+  });
+
+  describe('hasEnoughContrast', () => {
+    it('should not throw on transparent', () => {
+      expect(() => hasEnoughContrast('rgb(0,0,0)', 'transparent')).not.toThrow();
+      expect(() => hasEnoughContrast('transparent', 'transparent')).not.toThrow();
+      expect(() => hasEnoughContrast('red', 'blue')).not.toThrow();
+      expect(() => hasEnoughContrast('misspelled', 'hey hey')).not.toThrow();
+      expect(hasEnoughContrast('transparent', 'transparent')).toEqual(false);
+    });
+  });
+
+  describe('convertNamedColor', () => {
+    it('should return a color not present in the English dictionary', () => {
+      expect(convertNamedColor('red')).toEqual('#f44336');
+      expect(convertNamedColor('blue')).toEqual('#2196f3');
+      expect(convertNamedColor('transparent')).toEqual('rgba(255, 255, 255, 0)');
+      expect(convertNamedColor('misspelled')).toEqual('misspelled');
     });
   });
 });

--- a/apis/nucleus/src/components/listbox/assets/styling.js
+++ b/apis/nucleus/src/components/listbox/assets/styling.js
@@ -10,6 +10,7 @@ const TRANSPARENT = 'rgba(255, 255, 255, 0)';
  *
  * @param {string} c The CSS color.
  * @returns {string} Converted color or same color as before.
+ * @private
  * @example
  *  convertNamedColor('red') => '#FF0000'
  */

--- a/apis/nucleus/src/components/listbox/assets/styling.js
+++ b/apis/nucleus/src/components/listbox/assets/styling.js
@@ -39,6 +39,7 @@ export const hasEnoughContrast = (desiredTextColor, backgroundColor) => {
   } catch (err) {
     // The function throws on unsupported or misspelled colors.
     // In these cases, simply return true.
+    isContrastingEnough = true;
   }
   return isContrastingEnough;
 };

--- a/apis/nucleus/src/components/listbox/assets/styling.js
+++ b/apis/nucleus/src/components/listbox/assets/styling.js
@@ -1,15 +1,53 @@
 import { getContrastRatio } from '@mui/material/styles';
+import * as namedColors from '@mui/material/colors';
 
 const LIGHT = '#FFF';
 const DARK = '#000';
+const TRANSPARENT = 'rgba(255, 255, 255, 0)';
+
+/**
+ * If needed, converts a named color to a more reliable CSS color format.
+ *
+ * @param {string} c The CSS color.
+ * @returns {string} Converted color or same color as before.
+ * @example
+ *  convertNamedColor('red') => '#FF0000'
+ */
+export function convertNamedColor(c) {
+  let out = c;
+  try {
+    if (c in namedColors) {
+      ({ 500: out } = namedColors[c]); // 500 exposes the standard color
+    } else if (c === 'transparent') {
+      out = TRANSPARENT;
+    }
+  } catch (err) {
+    out = c;
+  }
+  return out;
+}
+
+export const hasEnoughContrast = (desiredTextColor, backgroundColor) => {
+  const desired = convertNamedColor(desiredTextColor);
+  const background = convertNamedColor(backgroundColor);
+
+  const CONTRAST_THRESHOLD = 3.0;
+  let isContrastingEnough;
+  try {
+    isContrastingEnough = getContrastRatio(desired, background) > CONTRAST_THRESHOLD;
+  } catch (err) {
+    // The function throws on unsupported or misspelled colors.
+    // In these cases, simply return true.
+  }
+  return isContrastingEnough;
+};
 
 function getContrastingColor(backgroundColor, desiredTextColor = undefined, dark = DARK, light = LIGHT) {
-  const CONTRAST_THRESHOLD = 3.0;
   let contrastingColor;
-  if (desiredTextColor && getContrastRatio(desiredTextColor, backgroundColor) > CONTRAST_THRESHOLD) {
+  if (desiredTextColor && hasEnoughContrast(desiredTextColor, backgroundColor)) {
     contrastingColor = desiredTextColor;
   } else {
-    contrastingColor = getContrastRatio(light, backgroundColor) > CONTRAST_THRESHOLD ? light : dark;
+    contrastingColor = hasEnoughContrast(light, backgroundColor) ? light : dark;
   }
   return contrastingColor;
 }

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1622,6 +1622,33 @@
         }
       }
     },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
+    },
     "Field": {
       "kind": "alias",
       "items": {
@@ -1757,33 +1784,6 @@
         }
       }
     },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
-      "kind": "interface",
-      "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
-              "type": "string"
-            }
-          }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
-        }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
-    },
     "LoadType": {
       "kind": "interface",
       "params": [
@@ -1828,24 +1828,6 @@
           "type": "object"
         }
       }
-    },
-    "convertNamedColor": {
-      "description": "If needed, converts a named color to a more reliable CSS color format.",
-      "kind": "function",
-      "params": [
-        {
-          "name": "c",
-          "description": "The CSS color.",
-          "type": "string"
-        }
-      ],
-      "returns": {
-        "description": "Converted color or same color as before.",
-        "type": "string"
-      },
-      "examples": [
-        "convertNamedColor('red') => '#FF0000'"
-      ]
     },
     "ActionToolbarElement": {
       "availability": {

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1829,6 +1829,24 @@
         }
       }
     },
+    "convertNamedColor": {
+      "description": "If needed, converts a named color to a more reliable CSS color format.",
+      "kind": "function",
+      "params": [
+        {
+          "name": "c",
+          "description": "The CSS color.",
+          "type": "string"
+        }
+      ],
+      "returns": {
+        "description": "Converted color or same color as before.",
+        "type": "string"
+      },
+      "examples": [
+        "convertNamedColor('red') => '#FF0000'"
+      ]
+    },
     "ActionToolbarElement": {
       "availability": {
         "since": "2.1.0"


### PR DESCRIPTION
## Motivation

The mui function `getContrastRatio` does not support named colors ('red', 'transparent' etc.) and will throw an error if sent in. Therefore, we must convert these colors first and as an extra safety net, wrap the function in a try-catch to be sure to prevent misspelled colors from throwing an error.

Note! This issue blocks the nebula release and bump.

### After fix:

Selections are possible and do not throw.

https://github.com/qlik-oss/nebula.js/assets/5780544/2622b808-5993-4285-aea3-a4422840c4cb

I have also tried to change styling and themes etc.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
