### PR TITLE
docs: remove internal fn from api spec

### DIFF
--- a/apis/nucleus/src/utils/color/color.js
+++ b/apis/nucleus/src/utils/color/color.js
@@ -28,7 +28,7 @@ const { round } = Math;
  * @class
  * @classdesc Class which provides color transformation functionality
  * @description This is a constructor.
- * @private This is a constructor.
+ * @private
  * @param {object} - Parameters to create a color from different notations
  * @example
  * // a few ways of instantiating a red color

--- a/apis/nucleus/src/utils/style/shadow-utils.js
+++ b/apis/nucleus/src/utils/style/shadow-utils.js
@@ -19,6 +19,7 @@ export const getShadows = (shadowString) => {
 
 /**
  * Combine box shadow with box shadow color.
+ * @ignore
  * @param {string} boxShadow - Box shadow which may include color
  * @param {string} themeBoxShadow - Box shadow from theme which may include color
  * @param {string | undefined} boxShadowColor - Box shadow color

--- a/apis/nucleus/src/utils/style/shadow-utils.js
+++ b/apis/nucleus/src/utils/style/shadow-utils.js
@@ -19,7 +19,7 @@ export const getShadows = (shadowString) => {
 
 /**
  * Combine box shadow with box shadow color.
- * @ignore
+ * @private
  * @param {string} boxShadow - Box shadow which may include color
  * @param {string} themeBoxShadow - Box shadow from theme which may include color
  * @param {string | undefined} boxShadowColor - Box shadow color

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1829,21 +1829,6 @@
         }
       }
     },
-    "getFullBoxShadow": {
-      "description": "Combine box shadow with box shadow color.",
-      "type": "any",
-      "examples": [
-        "getFullBoxShadow('none', '', 'red') returns 'none'",
-        "getFullBoxShadow('initial', '', 'red') returns 'initial'",
-        "getFullBoxShadow('inherit', '', 'red') returns 'inherit'",
-        "getFullBoxShadow('', '', 'red') returns ''",
-        "getFullBoxShadow('1px 2px blue, 3px 6px green', '', 'red') returns '1px 2px blue, 3px 6px green'",
-        "getFullBoxShadow('1px 2px blue', '', 'red') returns '1px 2px red'",
-        "getFullBoxShadow('1px 2px', '', 'red') returns '1px 2px red'",
-        "getFullBoxShadow('1px 2px', '2px 5px green', undefined) returns '1px 2px green'",
-        "getFullBoxShadow('1px 2px', '2px 5px', undefined) returns '1px 2px'"
-      ]
-    },
     "ActionToolbarElement": {
       "availability": {
         "since": "2.1.0"

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -570,8 +570,6 @@ declare namespace stardust {
         meta?: object;
     }
 
-    type getFullBoxShadow = any;
-
     interface ActionToolbarElement extends HTMLElement{
         className: "njs-action-toolbar-popover";
     }


### PR DESCRIPTION
Removes the utility function `getFullBoxShadow` from the api spec (was accidentally included in the last nebula version).