### PR TITLE
fix(listbox): conform to previous background image properties naming

### DIFF
--- a/apis/nucleus/src/components/listbox/assets/__tests__/styling.test.js
+++ b/apis/nucleus/src/components/listbox/assets/__tests__/styling.test.js
@@ -88,9 +88,9 @@ describe('styling', () => {
       it('background image should be exposed', () => {
         components[0].background.image = {
           mode: 'media',
-          url: { qStaticContentUrl: { qUrl: 'some-image.png' } },
+          mediaUrl: { qStaticContentUrl: { qUrl: 'some-image.png' } },
           qStaticContentUrl: {},
-          size: 'stretchFit',
+          sizing: 'stretchFit',
         };
         const styles = getStyling({ app, themeApi, theme, components });
         expect(styles.background.backgroundImage).toEqual("url('https://hey-heysome-image.png')");

--- a/apis/nucleus/src/utils/style/styling-props.js
+++ b/apis/nucleus/src/utils/style/styling-props.js
@@ -51,7 +51,7 @@ function getBackgroundPosition(bgComp) {
 
 function getBackgroundSize(bgComp) {
   let bkgImageSize = imageSizingToCssProperty.originalSize;
-  const size = bgComp?.bgImage?.sizing || bgComp?.bgImage?.size;
+  const size = bgComp?.bgImage?.sizing;
   if (size) {
     bkgImageSize = imageSizingToCssProperty[size];
   }
@@ -68,7 +68,7 @@ export function resolveBgImage(bgComp, app) {
   if (bgImageDef) {
     let url = '';
     if (bgImageDef.mode === 'media' || bgComp.useImage === 'media') {
-      const urlObj = bgImageDef?.mediaUrl || bgImageDef?.url;
+      const urlObj = bgImageDef?.mediaUrl;
       const { qUrl } = urlObj?.qStaticContentUrl || {};
       url = qUrl ? decodeURIComponent(qUrl) : undefined;
       url = resolveImageUrl(app, url);

--- a/test/rendering/listbox/__fixtures__/multi_scenario_list_1_bgimage.js
+++ b/test/rendering/listbox/__fixtures__/multi_scenario_list_1_bgimage.js
@@ -11,13 +11,13 @@ const fixture = {
           },
           image: {
             mode: 'media',
-            url: {
+            mediaUrl: {
               qStaticContentUrl: {
                 qUrl: './__fixtures__/resources/snowy_street.jpg',
               },
             },
             position: 'center-center',
-            size: 'stretchFit',
+            sizing: 'stretchFit',
           },
         },
         header: {


### PR DESCRIPTION
## Motivation

Remove support for alternative naming of properties, e.g. seen in the ActionButton repo, as it is just adding confusion.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
