### PR TITLE
fix: bgColor with useColorExpression property

### DIFF
--- a/apis/nucleus/src/utils/style/__tests__/styling-props.test.js
+++ b/apis/nucleus/src/utils/style/__tests__/styling-props.test.js
@@ -80,6 +80,16 @@ describe('Styling property resolver', () => {
       expect(color).toBe('resolvedColor');
     });
 
+    test('should resolve background color by expression using useColorExpression property', () => {
+      jest.spyOn(resolveColor, 'default').mockReturnValue('resolvedColor');
+      bgCompLayout.bgColor.useColorExpression = true;
+      bgCompLayout.bgColor.useExpression = false;
+
+      const color = resolveBgColor(bgCompLayout, t);
+      expect(resolveColor.default).toHaveBeenCalledTimes(0);
+      expect(color).toBe('rgb(255, 0, 0)');
+    });
+
     test('should resolve background color by theme', () => {
       jest.spyOn(resolveColor, 'default').mockReturnValue('resolvedColor');
       const color = resolveBgColor({}, t, 'peoplechart');

--- a/apis/nucleus/src/utils/style/styling-props.js
+++ b/apis/nucleus/src/utils/style/styling-props.js
@@ -87,7 +87,7 @@ export function resolveBgImage(bgComp, app) {
 export function resolveBgColor(comp, theme, objectType) {
   const bgColor = comp?.bgColor;
   if (bgColor && theme) {
-    if (bgColor.useExpression) {
+    if (bgColor.useExpression || bgColor.useColorExpression) {
       return theme.validateColor(bgColor.colorExpression);
     }
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

In Sense you can set a background per chart using the Styling panel and General tab, there you can set the background to "color by expression". When setting a color by expression via the Styling panel, `useColorExpression` is set as a property in indicate that the color expression should be used.

Not really sure what is the single source of truth here but I'm assuming charts have been using that panel to set the background, which means there are charts in the wild using `useColorExpression`.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
