### PR TITLE
fix: use 12px as default font size in theme

### DIFF
--- a/apis/theme/src/themes/base.json
+++ b/apis/theme/src/themes/base.json
@@ -1,5 +1,5 @@
 {
-  "fontSize": "13px",
+  "fontSize": "12px",
   "fontFamily": "'Source Sans Pro', 'Arial', 'sans-serif'",
   "backgroundColor": "transparent",
   "dataColors": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

To align with the design for most of our sn charts, the default font size should be 12px

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
