### PR TITLE
fix: always store session model (also when not fetching it)

### DIFF
--- a/apis/nucleus/src/components/listbox/hooks/__tests__/useExistingModel.test.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/__tests__/useExistingModel.test.jsx
@@ -21,7 +21,7 @@ describe('useExistingModel', () => {
   let ref;
   let once;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.useFakeTimers();
 
     setMock = jest.fn();
@@ -49,9 +49,12 @@ describe('useExistingModel', () => {
 
   afterEach(() => {
     jest.useRealTimers();
-    jest.restoreAllMocks();
     jest.resetAllMocks();
     renderer.unmount();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
   });
 
   test('providing a qId should give a model fetched from the app', async () => {
@@ -59,10 +62,15 @@ describe('useExistingModel', () => {
     expect(getMock).toHaveBeenCalledWith('generic-id');
     expect(setMock).toHaveBeenCalledWith('generic-id', { id: 'generic-id', once });
     expect(ref.current.result).toEqual({ id: 'generic-id', once });
+    expect(once).toHaveBeenCalled();
+    expect(once.mock.calls[0][0]).toEqual('closed');
   });
 
   test('providing sessionModel should simply use that model', async () => {
-    await render(useExistingModel, { options: { sessionModel: { id: 'session-model' } } });
-    expect(ref.current.result).toEqual({ id: 'session-model' });
+    const sessionModel = { id: 'session-model', once };
+    await render(useExistingModel, { options: { sessionModel } });
+    expect(ref.current.result?.id).toEqual('session-model');
+    expect(once).toHaveBeenCalled();
+    expect(once.mock.calls[0][0]).toEqual('closed');
   });
 });

--- a/apis/nucleus/src/components/listbox/hooks/__tests__/useExistingModel.test.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/__tests__/useExistingModel.test.jsx
@@ -21,7 +21,7 @@ describe('useExistingModel', () => {
   let ref;
   let once;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.useFakeTimers();
 
     setMock = jest.fn();

--- a/apis/nucleus/src/components/listbox/hooks/__tests__/useExistingModel.test.jsx
+++ b/apis/nucleus/src/components/listbox/hooks/__tests__/useExistingModel.test.jsx
@@ -51,9 +51,6 @@ describe('useExistingModel', () => {
     jest.useRealTimers();
     jest.resetAllMocks();
     renderer.unmount();
-  });
-
-  afterAll(() => {
     jest.restoreAllMocks();
   });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

### Problem:

It was noticed that layout changes did not trigger the useEffect in `ListBoxInline.jsx`. After some investigation help from @T-Wizard it was found that this was caused by the session model not being stored in Nebula's model store. This in turn lead to the fetch layout call never being performed and the useEffect callback not being called.

### Expected:

The useEffect callback should always be called when layout changes (in this case, tested with `qLocked` state).

### Solution:

With this PR, the session model is *always* stored. The code was also refactored to reduce duplication of code logic.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
