### PR TITLE
fix: display correct override URL

### DIFF
--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -334,7 +334,7 @@ module.exports = async ({
          `);
 
         if (serveConfig.mfe) {
-          const bundleUrl = `${url}/pkg/${snName}`;
+          const bundleUrl = `${url}/pkg/${encodeURIComponent(snName)}`;
           console.log('Development server running in MFE mode');
           console.log(`Bundle served at ${chalk.green(bundleUrl)}`);
           console.log('');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Fixes the displayed URL to actually work for the override when it contains illegal URL characters such as @ and / 

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
