### PR TITLE
chore: limit contraints warnings to once per component per session

### DIFF
--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -913,7 +913,7 @@ export function useConstraints() {
       console.warn(
         'useContraints has been deprecated, please change to useInteractions instead. Note that interactions uses inverted values compared to contraints.'
       );
-      currentComponent.__hooks.contraintsWarning = true;
+      currentComponent.__hooks.contraintsWarning = false;
     }
   }
   return useInternalContext('constraints');

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -50,6 +50,7 @@ export function initiate(component, { explicitResize = false } = {}) {
     accessibility: {
       setter: null,
     },
+    contraintsWarning: true,
   };
 }
 
@@ -907,10 +908,13 @@ export function useAction(fn, deps) {
  */
 export function useConstraints() {
   if (__NEBULA_DEV__) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'useContraints has been deprecated, please change to useInteractions instead. Note that interactions uses inverted values compared to contraints.'
-    );
+    if (currentComponent.__hooks.contraintsWarning) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'useContraints has been deprecated, please change to useInteractions instead. Note that interactions uses inverted values compared to contraints.'
+      );
+      currentComponent.__hooks.contraintsWarning = true;
+    }
   }
   return useInternalContext('constraints');
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Limit the use contraints deprecation warning to once per component per session as it can be spammy.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
