### PR TITLE
fix(listbox): color radio buttons with custom styling

### DIFF
--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/__tests__/list-box-radio-button.test.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/__tests__/list-box-radio-button.test.jsx
@@ -1,0 +1,76 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Radio } from '@mui/material';
+import { createTheme, ThemeProvider } from '@nebula.js/ui/theme';
+import ListBoxRadioButton from '../components/ListBoxRadioButton';
+
+const PREFIX = 'ListBoxRadioButton';
+
+async function render(content) {
+  let testRenderer;
+  await renderer.act(async () => {
+    testRenderer = renderer.create(content);
+  });
+  return testRenderer;
+}
+
+describe('<ListBoxRadioButton />', () => {
+  const theme = createTheme('dark');
+  const getRenderSetup = (component) => <ThemeProvider theme={theme}>{component}</ThemeProvider>;
+
+  let onChange;
+  let label;
+  let styles;
+
+  beforeEach(() => {
+    onChange = jest.fn();
+    label = 'Check it out';
+    styles = {
+      content: {
+        color: '#content-color',
+      },
+      selections: {
+        selected: '#selected',
+      },
+    };
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  test('should render an unchecked radio button', async () => {
+    const testRenderer = await render(
+      getRenderSetup(
+        <ListBoxRadioButton onChange={onChange} label={label} dataN={2} styles={styles} value={label} name={label} />
+      )
+    );
+    const radios = testRenderer.root.findAllByType(Radio);
+    expect(radios).toHaveLength(1);
+    const [radio] = radios;
+    expect(radio.props.className.split(' ')[0]).toBe(`${PREFIX}-radioButton`);
+    expect(radio.props.checked).not.toBe(true);
+  });
+
+  test('should render a checked dense radio button', async () => {
+    const testRenderer = await render(
+      getRenderSetup(
+        <ListBoxRadioButton
+          onChange={onChange}
+          label={label}
+          dataN={2}
+          styles={styles}
+          value={label}
+          name={label}
+          checked
+          dense
+        />
+      )
+    );
+    const [radio] = testRenderer.root.findAllByType(Radio);
+    expect(radio.props.className.split(' ')[0]).toBe(`${PREFIX}-radioButton`);
+    expect(radio.props.checked).toBe(true);
+  });
+});

--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/CheckboxField.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/CheckboxField.jsx
@@ -34,7 +34,14 @@ function CheckboxField({
     />
   );
   const rb = (
-    <ListBoxRadioButton onChange={onChange} label={label} checked={isSelected} dense={dense} dataN={qElemNumber} />
+    <ListBoxRadioButton
+      onChange={onChange}
+      label={label}
+      checked={isSelected}
+      dense={dense}
+      dataN={qElemNumber}
+      styles={styles}
+    />
   );
 
   return (

--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRadioButton.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRadioButton.jsx
@@ -5,7 +5,6 @@ import { Radio } from '@mui/material';
 const PREFIX = 'ListBoxRadioButton';
 
 const classes = {
-  denseRadioButton: `${PREFIX}-denseRadioButton`,
   radioButton: `${PREFIX}-radioButton`,
 };
 

--- a/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRadioButton.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxRowColumn/components/ListBoxRadioButton.jsx
@@ -9,14 +9,18 @@ const classes = {
   radioButton: `${PREFIX}-radioButton`,
 };
 
-const StyledRadio = styled(Radio)(({ theme, checked }) => ({
-  [`&.${classes.radioButton}`]: {
-    right: '5px',
-    color: checked ? theme.palette.selected.main : theme.palette.main,
-  },
-}));
+const StyledRadio = styled(Radio, { shouldForwardProp: (p) => !['dense', 'styles'].includes(p) })(
+  ({ checked, styles, dense }) => ({
+    [`&.${classes.radioButton}`]: {
+      right: '5px',
+      color: checked ? styles.selections.selected : styles.content.color,
+      padding: dense ? '0px 0px 0px 12px' : undefined,
+      backgroundColor: 'transparent',
+    },
+  })
+);
 
-export default function ListBoxRadioButton({ onChange, checked, label, dense, dataN }) {
+export default function ListBoxRadioButton({ onChange, checked, label, dense, dataN, styles }) {
   return (
     <StyledRadio
       checked={checked}
@@ -25,10 +29,10 @@ export default function ListBoxRadioButton({ onChange, checked, label, dense, da
       name={label}
       className={classes.radioButton}
       inputProps={{ 'data-n': dataN }}
-      style={{ backgroundColor: 'transparent' }}
       disableRipple
       size={dense ? 'small' : 'medium'}
-      sx={dense && { padding: '0px 0px 0px 12px' }}
+      dense={dense}
+      styles={styles}
     />
   );
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

### Problem:

Radio buttons do not pick up the selected color.

![image](https://github.com/qlik-oss/nebula.js/assets/5780544/a3310ec4-0c91-4f4f-b69e-5116c7bcbb4c)

### Solution:

Apply `styles.selections.selected` on checked radio buttons.

Also, apply `styles.content.color` for unselected boxes to allow for customisation of unselected radio buttons through the theme (allowing for customisation through the selection state color, such as excluded or possible, might just add confusion and look bad in some cases).

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
