### PR TITLE
fix: sanity check color input in uiColor resolver

### DIFF
--- a/apis/theme/src/__tests__/palette-resolver.test.js
+++ b/apis/theme/src/__tests__/palette-resolver.test.js
@@ -132,5 +132,17 @@ describe('palette-resolver', () => {
       uiPalettesMock.mockReturnValue([{ colors: ['a', 'b', 'c'] }]);
       expect(p.uiColor({ color: 'red', index: 1 })).toBe('b');
     });
+
+    describe('should sanity check inputs', () => {
+      beforeEach(() => {
+        uiPalettesMock.mockReturnValue([{ colors: ['a', 'b', 'c'] }]);
+      });
+      test('should not throw', () => {
+        expect(() => p.uiColor(undefined)).not.toThrow();
+      });
+      test('check input color without digging into the object', () => {
+        expect(p.uiColor({ color: undefined, index: undefined })).toBe(undefined);
+      });
+    });
   });
 });

--- a/apis/theme/src/palette-resolver.js
+++ b/apis/theme/src/palette-resolver.js
@@ -76,9 +76,15 @@ export default function theme(resolvedTheme) {
       };
     },
     uiColor(c, shift) {
+      const indexIsValid = typeof c?.index === 'number' && !Number.isNaN(c?.index);
+      const colorIsValid = typeof c?.color === 'string';
+      const somethingIsValid = indexIsValid || colorIsValid;
+      if (!somethingIsValid) {
+        return undefined;
+      }
       // eslint-disable-next-line no-param-reassign
       shift = !!shift;
-      if (c.index < 0 || typeof c.index === 'undefined') {
+      if (c?.index < 0 || typeof c?.index === 'undefined') {
         return c.color;
       }
       if (typeof uiPalette === 'undefined') {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

When an invalid color is sent in to the `uiColor` resolver function, it starts digging into the object without sanity checking it first. This throws an error that causes the listbox not to render in some cases. It can also be reproduced by resetting background styling.

## Fix

This PR adds a sanity check, that checks for the existence of either `index` or `color` on the object (one of them is required to exist). This solves the problem in mentioned cases.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
