### PR TITLE
fix(ActionsToolbar): Catch mousedown to prevent click through

### DIFF
--- a/apis/nucleus/src/components/ActionsToolbar.jsx
+++ b/apis/nucleus/src/components/ActionsToolbar.jsx
@@ -223,6 +223,9 @@ function ActionsToolbar({
       transformOrigin={popoverTransformOrigin}
       hideBackdrop
       style={popoverStyle}
+      onMouseDown={(e) => {
+        e.stopPropagation(); // prevent click through, closing when it should not
+      }}
       slotProps={{
         paper: {
           id: 'njs-action-toolbar-popover',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

### Problem:

Clicks go through the detached actions toolbar and causes it close. This is visible to users e.g. when clicking the more actions button.

### Fix:

Add a `mousedown` with a prevent default on the event.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
