### PR TITLE
chore: enable IM_1869_HIDE_DIM_MEA_LINE by default

### DIFF
--- a/apis/nucleus/src/__tests__/nucleus.test.js
+++ b/apis/nucleus/src/__tests__/nucleus.test.js
@@ -205,9 +205,11 @@ describe('nucleus', () => {
 
   test('should allow for default flags and overrides', () => {
     const nuked = Nuked.createConfiguration({ flags: { foo: true } });
-    expect(nuked.config.flags).toEqual({ foo: true, KPI_REACTCOLORPICKER: true });
+    expect(nuked.config.flags).toEqual({ foo: true, KPI_REACTCOLORPICKER: true, IM_1869_HIDE_DIM_MEA_LINE: true });
 
-    const nuked2 = Nuked.createConfiguration({ flags: { foo: true, KPI_REACTCOLORPICKER: false } });
-    expect(nuked2.config.flags).toEqual({ foo: true, KPI_REACTCOLORPICKER: false });
+    const nuked2 = Nuked.createConfiguration({
+      flags: { foo: true, KPI_REACTCOLORPICKER: false },
+    });
+    expect(nuked2.config.flags).toEqual({ foo: true, KPI_REACTCOLORPICKER: false, IM_1869_HIDE_DIM_MEA_LIN: true });
   });
 });

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -119,6 +119,7 @@ const DEFAULT_CONFIG = {
   anything: {},
   flags: {
     KPI_REACTCOLORPICKER: true,
+    IM_1869_HIDE_DIM_MEA_LINE: true,
   },
   snapshot: DEFAULT_SNAPSHOT_CONFIG,
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Enables flag IM_1869_HIDE_DIM_MEA_LINE

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
