### PR TITLE
fix(Listbox): Limit search length to 64000 characters

### DIFF
--- a/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
@@ -6,7 +6,7 @@ import InstanceContext from '../../../contexts/InstanceContext';
 import useDataStore from '../hooks/useDataStore';
 import { CELL_PADDING_LEFT } from '../constants';
 
-const MAX_SEARCH_LENGTH = 5000; // limitation in Engine
+const MAX_SEARCH_LENGTH = 64000;
 const TREE_PATH = '/qListObjectDef';
 const WILDCARD = '**';
 

--- a/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
@@ -10,7 +10,7 @@ const MAX_SEARCH_LENGTH = 5000; // limitation in Engine
 const TREE_PATH = '/qListObjectDef';
 const WILDCARD = '**';
 
-const sanitizeValue = (val) => val?.substring(0, MAX_SEARCH_LENGTH); // limit length
+const limitSearchLength = (val) => val?.substring(0, MAX_SEARCH_LENGTH);
 
 const StyledOutlinedInput = styled(OutlinedInput, {
   shouldForwardProp: (p) => !['styles', 'dense', 'isRtl'].includes(p),
@@ -122,7 +122,7 @@ export default function ListBoxSearch({
   }, [value]);
 
   const onChange = async (e) => {
-    const searchValue = sanitizeValue(e.target.value);
+    const searchValue = limitSearchLength(e.target.value);
     setValue(searchValue);
     if (!searchValue.length) {
       return abortSearch();
@@ -147,7 +147,7 @@ export default function ListBoxSearch({
 
   const performSearch = async () => {
     let response;
-    const searchValue = sanitizeValue(value);
+    const searchValue = limitSearchLength(value);
     const success = await model.searchListObjectFor(TREE_PATH, searchValue);
     if (selectionState.selectDisabled()) {
       return success;

--- a/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
@@ -6,8 +6,11 @@ import InstanceContext from '../../../contexts/InstanceContext';
 import useDataStore from '../hooks/useDataStore';
 import { CELL_PADDING_LEFT } from '../constants';
 
+const MAX_SEARCH_LENGTH = 5000; // limitation in Engine
 const TREE_PATH = '/qListObjectDef';
 const WILDCARD = '**';
+
+const sanitizeValue = (val) => val?.substring(0, MAX_SEARCH_LENGTH); // limit length
 
 const StyledOutlinedInput = styled(OutlinedInput, {
   shouldForwardProp: (p) => !['styles', 'dense', 'isRtl'].includes(p),
@@ -119,11 +122,12 @@ export default function ListBoxSearch({
   }, [value]);
 
   const onChange = async (e) => {
-    setValue(e.target.value);
-    if (!e.target.value.length) {
+    const searchValue = sanitizeValue(e.target.value);
+    setValue(searchValue);
+    if (!searchValue.length) {
       return abortSearch();
     }
-    return model.searchListObjectFor(TREE_PATH, e.target.value);
+    return model.searchListObjectFor(TREE_PATH, searchValue);
   };
 
   const handleFocus = () => {
@@ -143,11 +147,12 @@ export default function ListBoxSearch({
 
   const performSearch = async () => {
     let response;
-    const success = await model.searchListObjectFor(TREE_PATH, value);
+    const searchValue = sanitizeValue(value);
+    const success = await model.searchListObjectFor(TREE_PATH, searchValue);
     if (selectionState.selectDisabled()) {
       return success;
     }
-    if (success && value.length && hasHits()) {
+    if (success && searchValue.length && hasHits()) {
       response = model.acceptListObjectSearch(TREE_PATH, true);
       // eslint-disable-next-line no-param-reassign
       selections.selectionsMade = true;

--- a/apis/nucleus/src/components/listbox/components/__tests__/list-box-search.test.jsx
+++ b/apis/nucleus/src/components/listbox/components/__tests__/list-box-search.test.jsx
@@ -306,7 +306,7 @@ describe('<ListBoxSearch />', () => {
     expect(type.props.value).toBe('');
   });
 
-  test('should limit text length to 5000 characters', async () => {
+  test('should limit text length to 64000 characters', async () => {
     const testRenderer = create(
       <InstanceContext.Provider value={{ translator: { get: () => 'Search' } }}>
         <ListBoxSearch
@@ -321,11 +321,11 @@ describe('<ListBoxSearch />', () => {
     );
     const testInstance = testRenderer.root;
     const type = testInstance.findByType(OutlinedInput);
-    const tooLongString = Array(5100).fill('M').join('');
+    const tooLongString = Array(64100).fill('M').join('');
     await act(async () => {
       await type.props.onChange({ target: { value: tooLongString } });
     });
-    expect(type.props.value).toHaveLength(5000);
+    expect(type.props.value).toHaveLength(64000);
   });
 
   describe('selectDisabled should prevent some search interactions', () => {
@@ -391,9 +391,9 @@ describe('<ListBoxSearch />', () => {
       expect(model.searchListObjectFor).toHaveBeenCalled();
     });
 
-    test('Should shorten search value to 5000 in both onChange and onKeyDown-Enter calls', async () => {
+    test('Should shorten search value to 64000 in both onChange and onKeyDown-Enter calls', async () => {
       const type = getType(false);
-      const tooLongString = Array(5100).fill('M').join('');
+      const tooLongString = Array(64100).fill('M').join('');
       await act(async () => {
         await type.props.onChange({ target: { value: tooLongString } });
         await onKeyDown(type, 'Enter');
@@ -401,8 +401,8 @@ describe('<ListBoxSearch />', () => {
       expect(model.searchListObjectFor).toHaveBeenCalledTimes(2);
       const firstSearchValue = model.searchListObjectFor.mock.calls[0][1];
       const secondSearchValue = model.searchListObjectFor.mock.calls[1][1];
-      expect(firstSearchValue).toHaveLength(5000);
-      expect(secondSearchValue).toHaveLength(5000);
+      expect(firstSearchValue).toHaveLength(64000);
+      expect(secondSearchValue).toHaveLength(64000);
     });
 
     test('selectDisabled() => true should NOT call model.acceptListObjectSearch()', async () => {

--- a/apis/nucleus/src/components/listbox/components/__tests__/list-box-search.test.jsx
+++ b/apis/nucleus/src/components/listbox/components/__tests__/list-box-search.test.jsx
@@ -306,6 +306,28 @@ describe('<ListBoxSearch />', () => {
     expect(type.props.value).toBe('');
   });
 
+  test('should limit text length to 5000 characters', async () => {
+    const testRenderer = create(
+      <InstanceContext.Provider value={{ translator: { get: () => 'Search' } }}>
+        <ListBoxSearch
+          selectionState={selectionState}
+          styles={styles}
+          selections={selections}
+          model={model}
+          keyboard={keyboard}
+          wildCardSearch={false}
+        />
+      </InstanceContext.Provider>
+    );
+    const testInstance = testRenderer.root;
+    const type = testInstance.findByType(OutlinedInput);
+    const tooLongString = Array(5100).fill('M').join('');
+    await act(async () => {
+      await type.props.onChange({ target: { value: tooLongString } });
+    });
+    expect(type.props.value).toHaveLength(5000);
+  });
+
   describe('selectDisabled should prevent some search interactions', () => {
     let getType;
     let onKeyDown;
@@ -366,6 +388,21 @@ describe('<ListBoxSearch />', () => {
         await onKeyDown(type, 'Enter');
       });
       expect(model.acceptListObjectSearch).toHaveBeenCalled();
+      expect(model.searchListObjectFor).toHaveBeenCalled();
+    });
+
+    test('Should shorten search value to 5000 in both onChange and onKeyDown-Enter calls', async () => {
+      const type = getType(false);
+      const tooLongString = Array(5100).fill('M').join('');
+      await act(async () => {
+        await type.props.onChange({ target: { value: tooLongString } });
+        await onKeyDown(type, 'Enter');
+      });
+      expect(model.searchListObjectFor).toHaveBeenCalledTimes(2);
+      const firstSearchValue = model.searchListObjectFor.mock.calls[0][1];
+      const secondSearchValue = model.searchListObjectFor.mock.calls[1][1];
+      expect(firstSearchValue).toHaveLength(5000);
+      expect(secondSearchValue).toHaveLength(5000);
     });
 
     test('selectDisabled() => true should NOT call model.acceptListObjectSearch()', async () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

There is a limitation in how many characters we should allow users to search for. This limitation existed in the old Listbox in sense-client but has so far not been added to the new Listbox.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
