### PR TITLE
fix(QB-25634): press Enter key does not close listbox

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -148,6 +148,7 @@ export default function ListBoxPopover({
           },
         },
       }}
+      onKeyDown={(e) => (e.key === 'Enter' ? popoverClose(e) : undefined)}
     >
       <Grid container direction="column" gap={0} ref={containerRef}>
         <Grid item container style={{ padding: theme.spacing(1) }}>

--- a/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
@@ -175,7 +175,7 @@ export default function ListBoxSearch({
       case 'Escape': {
         focusRow(container);
         cancel();
-        return undefined;
+        break;
       }
       case 'Tab': {
         if (e.shiftKey) {

--- a/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
@@ -175,7 +175,7 @@ export default function ListBoxSearch({
       case 'Escape': {
         focusRow(container);
         cancel();
-        break;
+        return undefined;
       }
       case 'Tab': {
         if (e.shiftKey) {

--- a/apis/nucleus/src/components/listbox/interactions/keyboard-navigation/keyboard-nav-rows.js
+++ b/apis/nucleus/src/components/listbox/interactions/keyboard-navigation/keyboard-nav-rows.js
@@ -114,14 +114,10 @@ export default function getRowsKeyboardNavigation({
         break;
       case KEYS.ENTER:
         confirm();
-        break;
+        return;
       case KEYS.ESCAPE:
-        if (isModal()) {
-          cancel();
-        } else {
-          return; // propagate to other Esc handler
-        }
-        break;
+        cancel();
+        return;
       case KEYS.HOME:
         focusListItems.setFirst(true);
         if (ctrlKey) {

--- a/apis/nucleus/src/components/listbox/interactions/keyboard-navigation/keyboard-nav-rows.js
+++ b/apis/nucleus/src/components/listbox/interactions/keyboard-navigation/keyboard-nav-rows.js
@@ -116,8 +116,12 @@ export default function getRowsKeyboardNavigation({
         confirm();
         return;
       case KEYS.ESCAPE:
+        if (isModal()) {
         cancel();
-        return;
+        } else {
+          return; // propagate to other Esc handler
+        }
+        break;
       case KEYS.HOME:
         focusListItems.setFirst(true);
         if (ctrlKey) {

--- a/apis/nucleus/src/components/listbox/interactions/keyboard-navigation/keyboard-nav-rows.js
+++ b/apis/nucleus/src/components/listbox/interactions/keyboard-navigation/keyboard-nav-rows.js
@@ -117,7 +117,7 @@ export default function getRowsKeyboardNavigation({
         return;
       case KEYS.ESCAPE:
         if (isModal()) {
-        cancel();
+          cancel();
         } else {
           return; // propagate to other Esc handler
         }

--- a/apis/nucleus/src/components/listbox/interactions/keyboard-navigation/keyboard-nav-rows.js
+++ b/apis/nucleus/src/components/listbox/interactions/keyboard-navigation/keyboard-nav-rows.js
@@ -114,7 +114,10 @@ export default function getRowsKeyboardNavigation({
         break;
       case KEYS.ENTER:
         confirm();
-        return;
+        if (typeof isModal === 'undefined') {
+          return;
+        }
+        break;
       case KEYS.ESCAPE:
         if (isModal()) {
           cancel();


### PR DESCRIPTION
**Issue:**
Pressing Enter key after making some selections via straight table search box, does not close the search listbox.

**Solution:**
Being sure that `EnterKey` confirms the selection and "return" the event to avoid stopPropagation()


In this video I clicked Enter to confirm and close the listbox.

https://github.com/qlik-oss/nebula.js/assets/20701546/05d08d82-fe52-4ad0-ab6e-9af5bfd35c14