### PR TITLE
fix: avoid triggering scroll on search box open

### DIFF
--- a/apis/nucleus/src/components/listbox/interactions/keyboard-navigation/__tests__/keyboard-nav-container.test.js
+++ b/apis/nucleus/src/components/listbox/interactions/keyboard-navigation/__tests__/keyboard-nav-container.test.js
@@ -193,7 +193,7 @@ describe('keyboard navigation', () => {
       app.isInModalSelection = () => true;
       hovering.current = false;
       handleOnMouseEnter();
-      expect(hovering.current).toBe(false);
+      expect(hovering.current).toBe(true);
       app.isInModalSelection = () => false;
     });
     test('should handle mouse leave', () => {
@@ -207,6 +207,7 @@ describe('keyboard navigation', () => {
         preventDefault: jest.fn(),
         stopPropagation: jest.fn(),
       };
+      isModal.mockReturnValue(false);
       handleGlobalKeyDown(event);
       expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(updateKeyScroll).toHaveBeenCalledWith({ up: 1 });
@@ -218,6 +219,7 @@ describe('keyboard navigation', () => {
         preventDefault: jest.fn(),
         stopPropagation: jest.fn(),
       };
+      isModal.mockReturnValue(false);
       handleGlobalKeyDown(event);
       expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(updateKeyScroll).toHaveBeenCalledWith({ down: 1 });
@@ -229,6 +231,7 @@ describe('keyboard navigation', () => {
         preventDefault: jest.fn(),
         stopPropagation: jest.fn(),
       };
+      isModal.mockReturnValue(false);
       handleGlobalKeyDown(event);
       expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(updateKeyScroll).toHaveBeenCalledWith({ up: 10 });
@@ -240,6 +243,7 @@ describe('keyboard navigation', () => {
         preventDefault: jest.fn(),
         stopPropagation: jest.fn(),
       };
+      isModal.mockReturnValue(false);
       handleGlobalKeyDown(event);
       expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(updateKeyScroll).toHaveBeenCalledWith({ down: 10 });
@@ -251,6 +255,7 @@ describe('keyboard navigation', () => {
         preventDefault: jest.fn(),
         stopPropagation: jest.fn(),
       };
+      isModal.mockReturnValue(false);
       handleGlobalKeyDown(event);
       expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(updateKeyScroll).toHaveBeenCalledWith({ scrollPosition: 'start' });
@@ -264,6 +269,7 @@ describe('keyboard navigation', () => {
         preventDefault: jest.fn(),
         stopPropagation: jest.fn(),
       };
+      isModal.mockReturnValue(false);
       handleGlobalKeyDown(event);
       expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(updateKeyScroll).toHaveBeenCalledWith({ scrollPosition: 'overflowStart' });
@@ -275,6 +281,7 @@ describe('keyboard navigation', () => {
         preventDefault: jest.fn(),
         stopPropagation: jest.fn(),
       };
+      isModal.mockReturnValue(false);
       handleGlobalKeyDown(event);
       expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(updateKeyScroll).toHaveBeenCalledWith({ scrollPosition: 'end' });
@@ -288,9 +295,24 @@ describe('keyboard navigation', () => {
         preventDefault: jest.fn(),
         stopPropagation: jest.fn(),
       };
+      isModal.mockReturnValue(false);
       handleGlobalKeyDown(event);
       expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(updateKeyScroll).toHaveBeenCalledWith({ scrollPosition: 'overflowEnd' });
+    });
+    test('should not update scroll on hover when CTRL+SHIFT+END is pressed and isModal = true', () => {
+      const event = {
+        currentTarget: createElement(0),
+        keyCode: KEYS.END,
+        ctrlKey: true,
+        shiftKey: true,
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+      };
+      isModal.mockReturnValue(true);
+      handleGlobalKeyDown(event);
+      expect(event.preventDefault).toHaveBeenCalledTimes(0);
+      expect(updateKeyScroll).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/apis/nucleus/src/components/listbox/interactions/keyboard-navigation/keyboard-nav-container.js
+++ b/apis/nucleus/src/components/listbox/interactions/keyboard-navigation/keyboard-nav-container.js
@@ -85,8 +85,14 @@ export default function getListboxContainerKeyboardNavigation({
     }
   };
 
+  const focusOnHoverDisabled = () => {
+    const selectNotAllowed = constraints?.select || constraints?.active;
+    const appInModal = isModal();
+    return selectNotAllowed || appInModal;
+  };
+
   const globalKeyDown = (event) => {
-    if (!hovering.current) {
+    if (!hovering.current || focusOnHoverDisabled()) {
       return;
     }
     const { keyCode, ctrlKey = false, shiftKey = false } = event;
@@ -116,16 +122,8 @@ export default function getListboxContainerKeyboardNavigation({
     event.preventDefault();
   };
 
-  const focusOnHoverDisabled = () => {
-    const selectNotAllowed = constraints?.select || constraints?.active;
-    const appInModal = isModal();
-    return selectNotAllowed || appInModal;
-  };
-
   const handleOnMouseEnter = () => {
-    if (!focusOnHoverDisabled()) {
-      hovering.current = true;
-    }
+    hovering.current = true;
   };
 
   const handleOnMouseLeave = () => {


### PR DESCRIPTION
To fix https://jira.qlikdev.com/browse/QB-25773.
The problem is that after entering the listbox and then open the search box, hover.current is still true.
To solve the problem either we need to set hover.current to false on the search box being opened, or in globalKeyDown we need to check if the search box is opened or not.
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
