### PR TITLE
fix(listbox): broken search

### DIFF
--- a/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxSearch.jsx
@@ -127,6 +127,10 @@ export default function ListBoxSearch({
     if (!searchValue.length) {
       return abortSearch();
     }
+    const shouldBeginSelection = !selections.isActive() && !selectionState.selectDisabled() && !selections.isModal();
+    if (shouldBeginSelection) {
+      selections.begin(['/qListObjectDef']);
+    }
     return model.searchListObjectFor(TREE_PATH, searchValue);
   };
 


### PR DESCRIPTION
After this [change](https://github.com/qlik-oss/nebula.js/pull/1531)  the search seems to stop working.
The solution is to start selection once user start typing in  the search input.
## Motivation

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
