### PR TITLE
refactor: generalize selection styling logic

### DIFF
--- a/apis/nucleus/src/components/listbox/assets/__tests__/styling.test.js
+++ b/apis/nucleus/src/components/listbox/assets/__tests__/styling.test.js
@@ -212,9 +212,9 @@ describe('styling', () => {
       let inst;
       let selections;
 
-      // inst = getStyling({ app, themeApi, theme, components: [] });
-      // selections = inst.selections;
-      // expect(selections.selected).toEqual('selected-from-theme');
+      inst = getStyling({ app, themeApi, theme, components: [] });
+      selections = inst.selections;
+      expect(selections.selected).toEqual('selected-from-theme');
 
       inst = getStyling({ app, themeApi, theme, components });
       selections = inst.selections;

--- a/apis/nucleus/src/components/listbox/assets/__tests__/styling.test.js
+++ b/apis/nucleus/src/components/listbox/assets/__tests__/styling.test.js
@@ -212,9 +212,9 @@ describe('styling', () => {
       let inst;
       let selections;
 
-      inst = getStyling({ app, themeApi, theme, components: [] });
-      selections = inst.selections;
-      expect(selections.selected).toEqual('selected-from-theme');
+      // inst = getStyling({ app, themeApi, theme, components: [] });
+      // selections = inst.selections;
+      // expect(selections.selected).toEqual('selected-from-theme');
 
       inst = getStyling({ app, themeApi, theme, components });
       selections = inst.selections;

--- a/apis/nucleus/src/components/listbox/assets/styling.js
+++ b/apis/nucleus/src/components/listbox/assets/styling.js
@@ -83,8 +83,6 @@ function getSelectionColors({ getColorPickerColor, theme, getListboxStyle, overr
 
   const componentSelectionColors = overrides.selections?.colors || {};
 
-  console.log(componentSelectionColors);
-
   const getSelectionStateColors = (state) => {
     const paletteState = state === 'selected' ? 'main' : state;
     const contrastState = `${state}Contrast`;

--- a/apis/nucleus/src/components/listbox/assets/styling.js
+++ b/apis/nucleus/src/components/listbox/assets/styling.js
@@ -89,6 +89,7 @@ function getSelectionColors({ getColorPickerColor, theme, getListboxStyle, overr
     // color priority: layout.component > sprout > hardcoded default
     const color =
       getColorPickerColor(componentSelectionColors[state]) ||
+      (state === 'possible' && getListboxStyle('', 'backgroundColor')) ||
       theme.palette?.selected[paletteState] ||
       DEFAULT_SELECTION_COLORS[state];
 

--- a/apis/nucleus/src/components/listbox/assets/styling.js
+++ b/apis/nucleus/src/components/listbox/assets/styling.js
@@ -83,8 +83,10 @@ function getSelectionColors({ getColorPickerColor, theme, getListboxStyle, overr
 
   const componentSelectionColors = overrides.selections?.colors || {};
 
+  console.log(componentSelectionColors);
+
   const getSelectionStateColors = (state) => {
-    const paletteState = state === 'selection' ? 'main' : state;
+    const paletteState = state === 'selected' ? 'main' : state;
     const contrastState = `${state}Contrast`;
     // color priority: layout.component > sprout > hardcoded default
     const color =


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation
I'm working on adding theme support for selection colors in listbox.
Given that there will be even more logic to get the correct background and font colors, I have "prefactored" the logic to be more general. All 5 different selection states maps really well to the prop names on sprout, the layout, and the theme (except for palette.selected.main...) 

To me this is as readable as before, but more compact and easier to change the logic later.

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
