### PR TITLE
fix: activate selection mode on show search input for expanded listbox

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -226,7 +226,7 @@ function ListBoxInline({ options, layout }) {
   const handleShowSearch = () => {
     const newValue = !showSearch;
     setShowSearch(newValue);
-    if (!isPopover && !selections.isActive()) {
+    if (newValue && !isPopover && !selections.isActive()) {
       selections.begin('/qListObjectDef');
     }
   };

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -226,6 +226,9 @@ function ListBoxInline({ options, layout }) {
   const handleShowSearch = () => {
     const newValue = !showSearch;
     setShowSearch(newValue);
+    if (!isPopover && !selections.isActive()) {
+      selections.begin('/qListObjectDef');
+    }
   };
 
   const onCtrlF = () => {


### PR DESCRIPTION

## Motivation
Recover the old behaviour of expanded listbox. Opening search input in expanded listbox should also activate selection mode.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
