### PR TITLE
fix: should not activate selection when selectDisabled is true

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -226,8 +226,7 @@ function ListBoxInline({ options, layout }) {
   const handleShowSearch = () => {
     const newValue = !showSearch;
     setShowSearch(newValue);
-    const shouldBeginSelection =
-      newValue && !isPopover && !selectionState.selectDisabled() && !selectionState.isModal();
+    const shouldBeginSelection = newValue && !isPopover && !selectionState.selectDisabled() && !selections.isModal();
     if (shouldBeginSelection) {
       selections.begin('/qListObjectDef');
     }

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -226,7 +226,9 @@ function ListBoxInline({ options, layout }) {
   const handleShowSearch = () => {
     const newValue = !showSearch;
     setShowSearch(newValue);
-    if (newValue && !isPopover && !selections.isActive()) {
+    const shouldBeginSelection =
+      newValue && !isPopover && !selectionState.selectDisabled() && !selectionState.isModal();
+    if (shouldBeginSelection) {
       selections.begin('/qListObjectDef');
     }
   };


### PR DESCRIPTION
## Motivation
in this [PR](0dea433ef1a3ee135d74f78f253904aaa7bf8fbf) the selection mode is activated eventhough `selectionState.selectionDisabled` is true.  

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
