### PR TITLE
fix(QB-27479): Tab key navigation on popover listbox

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -220,7 +220,7 @@ export default function ListBoxPopover({
             onSetListCount={(c) => setListCount(c)}
             onCtrlF={onCtrlF}
             styles={styles}
-            keyboard={{ isEnabled: true }}
+            keyboard={keyboard}
           />
         </Grid>
       </Grid>

--- a/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -21,6 +21,7 @@ import useObjectSelections from '../../hooks/useObjectSelections';
 import createSelectionState from './hooks/selections/selectionState';
 import getHasSelections from './assets/has-selections';
 import getStyles from './assets/styling';
+import useTempKeyboard from './components/useTempKeyboard';
 
 export default function ListBoxPopover({
   alignTo,
@@ -94,9 +95,11 @@ export default function ListBoxPopover({
   const { translator, themeApi } = useContext(InstanceContext);
   const moreAlignTo = useRef();
   const containerRef = useRef();
+  const listBoxRef = useRef();
   const [selections] = useObjectSelections(app, model, containerRef);
   const [layout] = useLayout(model);
   const [selectionState] = useState(() => createSelectionState({ selectDisabled }));
+  const keyboard = useTempKeyboard({ listBoxRef, enabled: true });
   const { checkboxes = checkboxesOption } = layout || {};
 
   const themeSelectionColorsEnabled = flags?.isEnabled('PS_22149_THEME_SELECTION_COLORS');
@@ -207,6 +210,7 @@ export default function ListBoxPopover({
             />
           </Grid>
           <ListBox
+            ref={listBoxRef}
             model={model}
             app={app}
             layout={layout}
@@ -216,6 +220,7 @@ export default function ListBoxPopover({
             onSetListCount={(c) => setListCount(c)}
             onCtrlF={onCtrlF}
             styles={styles}
+            keyboard={{ isEnabled: true }}
           />
         </Grid>
       </Grid>

--- a/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -138,6 +138,7 @@ export default function ListBoxPopover({
 
   return (
     <Popover
+      className="listbox-container"
       open={open}
       onClose={popoverClose}
       anchorEl={alignTo.current}

--- a/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -92,15 +92,13 @@ export default function ListBoxPopover({
     model.unlock('/qListObjectDef');
   }, [model]);
 
-  const { translator, themeApi } = useContext(InstanceContext);
+  const { translator, themeApi, keyboardNavigation } = useContext(InstanceContext);
   const moreAlignTo = useRef();
   const containerRef = useRef();
-  const listBoxRef = useRef();
   const [selections] = useObjectSelections(app, model, containerRef);
   const [layout] = useLayout(model);
   const [selectionState] = useState(() => createSelectionState({ selectDisabled }));
-  const keyboardListbox = useTempKeyboard({ listBoxRef, enabled: true });
-  const keyboardSearch = useTempKeyboard({ searchContainerRef, enabled: false });
+  const keyboard = useTempKeyboard({ containerRef, enabled: keyboardNavigation });
   const { checkboxes = checkboxesOption } = layout || {};
 
   const themeSelectionColorsEnabled = flags?.isEnabled('PS_22149_THEME_SELECTION_COLORS');
@@ -131,6 +129,7 @@ export default function ListBoxPopover({
     model,
     translator,
     selectionState,
+    selections,
   });
 
   const onCtrlF = () => {
@@ -206,13 +205,15 @@ export default function ListBoxPopover({
               listCount={listCount}
               selections={selections}
               selectionState={selectionState}
-              keyboard={keyboardSearch}
+              keyboard={{
+                enabled: false,
+                innerTabStops: true,
+                focusSelection: keyboard.focusSelection,
+              }}
               autoFocus={autoFocus ?? true}
-              tabIndex={0}
             />
           </Grid>
           <ListBox
-            ref={listBoxRef}
             model={model}
             app={app}
             layout={layout}
@@ -222,7 +223,7 @@ export default function ListBoxPopover({
             onSetListCount={(c) => setListCount(c)}
             onCtrlF={onCtrlF}
             styles={styles}
-            keyboard={keyboardListbox}
+            keyboard={keyboard}
           />
         </Grid>
       </Grid>

--- a/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -99,7 +99,8 @@ export default function ListBoxPopover({
   const [selections] = useObjectSelections(app, model, containerRef);
   const [layout] = useLayout(model);
   const [selectionState] = useState(() => createSelectionState({ selectDisabled }));
-  const keyboard = useTempKeyboard({ listBoxRef, enabled: true });
+  const keyboardListbox = useTempKeyboard({ listBoxRef, enabled: true });
+  const keyboardSearch = useTempKeyboard({ searchContainerRef, enabled: false });
   const { checkboxes = checkboxesOption } = layout || {};
 
   const themeSelectionColorsEnabled = flags?.isEnabled('PS_22149_THEME_SELECTION_COLORS');
@@ -205,8 +206,9 @@ export default function ListBoxPopover({
               listCount={listCount}
               selections={selections}
               selectionState={selectionState}
-              keyboard={{ enabled: false }}
+              keyboard={keyboardSearch}
               autoFocus={autoFocus ?? true}
+              tabIndex={0}
             />
           </Grid>
           <ListBox
@@ -220,7 +222,7 @@ export default function ListBoxPopover({
             onSetListCount={(c) => setListCount(c)}
             onCtrlF={onCtrlF}
             styles={styles}
-            keyboard={keyboard}
+            keyboard={keyboardListbox}
           />
         </Grid>
       </Grid>

--- a/apis/nucleus/src/components/listbox/interactions/keyboard-navigation/keyboard-nav-rows.js
+++ b/apis/nucleus/src/components/listbox/interactions/keyboard-navigation/keyboard-nav-rows.js
@@ -58,7 +58,7 @@ export default function getRowsKeyboardNavigation({
       case KEYS.TAB: {
         // Try to focus search field, otherwise confirm button.
         const container = currentTarget.closest('.listbox-container');
-        const inSelection = isModal();
+        const inSelection = typeof isModal !== 'undefined' ? isModal() : undefined;
         // TODO: use a store to keep track of this row.
         currentTarget.classList.add('last-focused'); // so that we can go back here when we tab back
 


### PR DESCRIPTION
With this fix, it is possible to navigate through the listbox by TAB key when the popover list box is open on the other chart than filterpane. Multiple tabbing moves the tab to the confirmation button and returns it to the searchbox.

https://github.com/user-attachments/assets/3f7b05f2-089f-49d6-b967-e32064d6028d