### PR TITLE
feat: add sheet navigation

### DIFF
--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -268,6 +268,7 @@ const loadType = async ({
   focusHandler,
   emitter,
   onMount,
+  navigation,
 }) => {
   try {
     const snType = await getType({ types, name: visualization, version });
@@ -278,6 +279,7 @@ const loadType = async ({
       nebbie,
       focusHandler,
       emitter,
+      navigation,
     });
 
     if (sn) {
@@ -300,7 +302,20 @@ const loadType = async ({
 };
 
 const Cell = forwardRef(
-  ({ halo, model: inputModel, initialSnOptions, initialSnPlugins, initialError, onMount, currentId, emitter }, ref) => {
+  (
+    {
+      halo,
+      model: inputModel,
+      initialSnOptions,
+      initialSnPlugins,
+      initialError,
+      onMount,
+      currentId,
+      emitter,
+      navigation,
+    },
+    ref
+  ) => {
     const { app, types } = halo;
     const { nebbie } = halo.public;
     const {
@@ -411,6 +426,7 @@ const Cell = forwardRef(
           focusHandler: focusHandler.current,
           emitter,
           onMount,
+          navigation,
         });
       };
 

--- a/apis/nucleus/src/components/Sheet.jsx
+++ b/apis/nucleus/src/components/Sheet.jsx
@@ -20,7 +20,10 @@ const SheetElement = {
 function getCellRenderer(cell, halo, initialSnOptions, initialSnPlugins, initialError, onMount, navigation) {
   const { x, y, width, height } = cell.bounds;
   return (
-    <div style={{ left: `${x}%`, top: `${y}%`, width: `${width}%`, height: `${height}%`, position: 'absolute' }}>
+    <div
+      style={{ left: `${x}%`, top: `${y}%`, width: `${width}%`, height: `${height}%`, position: 'absolute' }}
+      key={cell.model.id}
+    >
       <Cell
         ref={cell.cellRef}
         halo={halo}

--- a/apis/nucleus/src/components/Sheet.jsx
+++ b/apis/nucleus/src/components/Sheet.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext, useMemo } from 'react';
+import React, { useEffect, useState, useContext, useMemo, forwardRef, useImperativeHandle } from 'react';
 import useLayout from '../hooks/useLayout';
 import getObject from '../object/get-object';
 import Cell from './Cell';
@@ -17,7 +17,7 @@ const SheetElement = {
   className: 'njs-sheet',
 };
 
-function getCellRenderer(cell, halo, initialSnOptions, initialSnPlugins, initialError, onMount) {
+function getCellRenderer(cell, halo, initialSnOptions, initialSnPlugins, initialError, onMount, navigation) {
   const { x, y, width, height } = cell.bounds;
   return (
     <div style={{ left: `${x}%`, top: `${y}%`, width: `${width}%`, height: `${height}%`, position: 'absolute' }}>
@@ -30,6 +30,7 @@ function getCellRenderer(cell, halo, initialSnOptions, initialSnPlugins, initial
         initialSnPlugins={initialSnPlugins}
         initialError={initialError}
         onMount={onMount}
+        navigation={navigation}
       />
     </div>
   );
@@ -47,115 +48,129 @@ function getBounds(pos, columns, rows) {
   };
 }
 
-function Sheet({ model, halo, initialSnOptions, initialSnPlugins, initialError, onMount }) {
-  const { root } = halo;
-  const [layout] = useLayout(model);
-  const { theme: themeName, modelStore } = useContext(InstanceContext);
-  const [cells, setCells] = useState([]);
-  const [bgColor, setBgColor] = useState(undefined);
-  const [bgImage, setBgImage] = useState(undefined);
-  const [deepHash, setDeepHash] = useState('');
-
-  /// For each object
-  useEffect(() => {
-    if (layout) {
-      const hash = JSON.stringify(layout.cells);
-      if (hash === deepHash) {
-        return;
-      }
-      setDeepHash(hash);
-      const fetchObjects = async () => {
-        /*
+const Sheet = forwardRef(
+  ({ model: inputModel, halo, initialSnOptions, initialSnPlugins, initialError, onMount, navigation }, ref) => {
+    const { root } = halo;
+    const [model, setModel] = useState(inputModel);
+    const [layout] = useLayout(model);
+    const { theme: themeName, modelStore } = useContext(InstanceContext);
+    const [cells, setCells] = useState([]);
+    const [bgColor, setBgColor] = useState(undefined);
+    const [bgImage, setBgImage] = useState(undefined);
+    const [deepHash, setDeepHash] = useState('');
+    navigation?.setCurrentSheetId?.(model.id);
+    /// For each object
+    useEffect(() => {
+      if (layout) {
+        const hash = JSON.stringify(layout.cells);
+        if (hash === deepHash) {
+          return;
+        }
+        setDeepHash(hash);
+        const fetchObjects = async () => {
+          /*
           Need to always fetch and evaluate everything as the sheet need to support multiple instances of the same object?
           No, there is no way to add the same chart twice, so the optimization should be worth it.
         */
 
-        // Clear the cell list
-        cells.forEach((c) => {
-          root.removeCell(c.currentId);
-        });
+          // Clear the cell list
+          cells.forEach((c) => {
+            root.removeCell(c.currentId);
+          });
 
-        const lCells = layout.cells;
-        const { columns, rows } = layout;
-        // TODO - should try reuse existing objects on subsequent renders
-        // Non-id updates should only change the "css"
-        const cs = await Promise.all(
-          lCells.map(async (c) => {
-            let mounted;
-            const mountedPromise = new Promise((resolve) => {
-              mounted = resolve;
-            });
+          const lCells = layout.cells;
+          const { columns, rows } = layout;
+          // TODO - should try reuse existing objects on subsequent renders
+          // Non-id updates should only change the "css"
+          const cs = await Promise.all(
+            lCells.map(async (c) => {
+              let mounted;
+              const mountedPromise = new Promise((resolve) => {
+                mounted = resolve;
+              });
 
-            const cell = cells.find((ce) => ce.id === c.name);
-            if (cell) {
-              cell.bounds = getBounds(c, columns, rows);
-              delete cell.mountedPromise;
-              return cell;
-            }
-            const vs = await getObject({ id: c.name }, halo, modelStore);
-            return {
-              model: vs.model,
-              id: c.name,
-              bounds: getBounds(c, columns, rows),
-              cellRef: React.createRef(),
-              currentId: uid(),
-              mounted,
-              mountedPromise,
-            };
-          })
-        );
-        cs.forEach((c) => root.addCell(c.currentId, c.cellRef));
-        setCells(cs);
-      };
-      fetchObjects();
-    }
-  }, [layout]);
+              const cell = cells.find((ce) => ce.id === c.name);
+              if (cell) {
+                cell.bounds = getBounds(c, columns, rows);
+                delete cell.mountedPromise;
+                return cell;
+              }
+              const vs = await getObject({ id: c.name }, halo, modelStore);
+              return {
+                model: vs.model,
+                id: c.name,
+                bounds: getBounds(c, columns, rows),
+                cellRef: React.createRef(),
+                currentId: uid(),
+                mounted,
+                mountedPromise,
+              };
+            })
+          );
+          cs.forEach((c) => root.addCell(c.currentId, c.cellRef));
+          setCells(cs);
+        };
+        fetchObjects();
+      }
+    }, [layout]);
 
-  const cellRenderers = useMemo(
-    () =>
-      cells
-        ? cells.map((c) => getCellRenderer(c, halo, initialSnOptions, initialSnPlugins, initialError, c.mounted))
-        : [],
-    [cells]
-  );
+    const cellRenderers = useMemo(
+      () =>
+        cells
+          ? cells.map((c) =>
+              getCellRenderer(c, halo, initialSnOptions, initialSnPlugins, initialError, c.mounted, navigation)
+            )
+          : [],
+      [cells]
+    );
 
-  useEffect(() => {
-    const bgComp = layout?.components ? layout.components.find((comp) => comp.key === 'general') : null;
-    setBgColor(resolveBgColor(bgComp, halo.public.theme));
-    setBgImage(resolveBgImage(bgComp, halo.app));
-  }, [layout, halo.public.theme, halo.app, themeName]);
+    useEffect(() => {
+      const bgComp = layout?.components ? layout.components.find((comp) => comp.key === 'general') : null;
+      setBgColor(resolveBgColor(bgComp, halo.public.theme));
+      setBgImage(resolveBgImage(bgComp, halo.app));
+    }, [layout, halo.public.theme, halo.app, themeName]);
 
-  /* TODO
+    // Expose sheet ref api
+    useImperativeHandle(
+      ref,
+      () => ({
+        setModel,
+      }),
+      []
+    );
+
+    /* TODO
     - sheet title + bg + logo etc + as option
     - sheet exposed classnames for theming
   */
 
-  const height = !layout || Number.isNaN(layout.height) ? '100%' : `${Number(layout.height)}%`;
-  const promises = cells.map((c) => c.mountedPromise);
-  const ps = promises.filter((p) => !!p);
-  if (ps.length) {
-    Promise.all(promises).then(() => {
-      // TODO - correct? Currently called each time a new cell is mounted?
-      onMount();
-    });
+    const height = !layout || Number.isNaN(layout.height) ? '100%' : `${Number(layout.height)}%`;
+    const promises = cells.map((c) => c.mountedPromise);
+    const ps = promises.filter((p) => !!p);
+    if (ps.length) {
+      Promise.all(promises).then(() => {
+        // TODO - correct? Currently called each time a new cell is mounted?
+        onMount();
+      });
+    }
+    return (
+      <div
+        className={SheetElement.className}
+        style={{
+          width: `100%`,
+          height,
+          position: 'relative',
+          backgroundColor: bgColor,
+          backgroundImage: bgImage && bgImage.url ? `url(${bgImage.url})` : undefined,
+          backgroundRepeat: 'no-repeat',
+          backgroundSize: bgImage && bgImage.size,
+          backgroundPosition: bgImage && bgImage.pos,
+        }}
+      >
+        {cellRenderers}
+      </div>
+    );
   }
-  return (
-    <div
-      className={SheetElement.className}
-      style={{
-        width: `100%`,
-        height,
-        position: 'relative',
-        backgroundColor: bgColor,
-        backgroundImage: bgImage && bgImage.url ? `url(${bgImage.url})` : undefined,
-        backgroundRepeat: 'no-repeat',
-        backgroundSize: bgImage && bgImage.size,
-        backgroundPosition: bgImage && bgImage.pos,
-      }}
-    >
-      {cellRenderers}
-    </div>
-  );
-}
+);
 
 export default Sheet;

--- a/apis/nucleus/src/components/Sheet.jsx
+++ b/apis/nucleus/src/components/Sheet.jsx
@@ -52,7 +52,10 @@ function getBounds(pos, columns, rows) {
 }
 
 const Sheet = forwardRef(
-  ({ model: inputModel, halo, initialSnOptions, initialSnPlugins, initialError, onMount, navigation }, ref) => {
+  (
+    { model: inputModel, halo, initialSnOptions, initialSnPlugins, initialError, onMount, unmount, navigation },
+    ref
+  ) => {
     const { root } = halo;
     const [model, setModel] = useState(inputModel);
     const [layout] = useLayout(model);
@@ -116,6 +119,15 @@ const Sheet = forwardRef(
         fetchObjects();
       }
     }, [layout]);
+
+    useEffect(() => {
+      const onModelClose = () => {
+        model.removeListener('closed', onModelClose);
+        unmount();
+      };
+      model.on('closed', onModelClose);
+      return () => model.removeListener('closed', onModelClose);
+    }, [model]);
 
     const cellRenderers = useMemo(
       () =>

--- a/apis/nucleus/src/components/glue.jsx
+++ b/apis/nucleus/src/components/glue.jsx
@@ -12,6 +12,7 @@ export default function glue({
   onMount,
   emitter,
   initialError,
+  navigation,
 }) {
   const { root } = halo;
   const cellRef = React.createRef();
@@ -27,6 +28,7 @@ export default function glue({
       initialError={initialError}
       onMount={onMount}
       emitter={emitter}
+      navigation={navigation}
     />,
     element,
     currentId

--- a/apis/nucleus/src/components/sheetGlue.jsx
+++ b/apis/nucleus/src/components/sheetGlue.jsx
@@ -2,7 +2,16 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Sheet from './Sheet';
 
-export default function glue({ halo, element, model, initialSnOptions, initialSnPlugins, onMount, initialError }) {
+export default function glue({
+  halo,
+  element,
+  model,
+  initialSnOptions,
+  initialSnPlugins,
+  onMount,
+  initialError,
+  navigation,
+}) {
   const { root } = halo;
   const sheetRef = React.createRef();
   const portal = ReactDOM.createPortal(
@@ -14,10 +23,12 @@ export default function glue({ halo, element, model, initialSnOptions, initialSn
       initialSnPlugins={initialSnPlugins}
       initialError={initialError}
       onMount={onMount}
+      navigation={navigation}
     />,
     element,
     model.id
   );
+  navigation.setSheetRef(sheetRef);
 
   const unmount = () => {
     root.remove(portal);

--- a/apis/nucleus/src/components/sheetGlue.jsx
+++ b/apis/nucleus/src/components/sheetGlue.jsx
@@ -14,7 +14,11 @@ export default function glue({
 }) {
   const { root } = halo;
   const sheetRef = React.createRef();
-  const portal = ReactDOM.createPortal(
+  let portal;
+  const unmount = () => {
+    root.remove(portal);
+  };
+  portal = ReactDOM.createPortal(
     <Sheet
       ref={sheetRef}
       halo={halo}
@@ -23,19 +27,13 @@ export default function glue({
       initialSnPlugins={initialSnPlugins}
       initialError={initialError}
       onMount={onMount}
+      unmount={unmount}
       navigation={navigation}
     />,
     element,
     model.id
   );
   navigation.setSheetRef(sheetRef);
-
-  const unmount = () => {
-    root.remove(portal);
-    model.removeListener('closed', unmount);
-  };
-
-  model.on('closed', unmount);
 
   root.add(portal);
   return [unmount, sheetRef];

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -84,6 +84,7 @@ const DEFAULT_SNAPSHOT_CONFIG = /** @lends SnapshotConfiguration */ {
  * @property {Array<TypeInfo>=} types Visualization types to register
  * @property {Array<ThemeInfo>=} themes Themes to register
  * @property {object=} anything
+ * @property {object=} flags
  * @example
  * import { embed } from '@nebula.js/stardust'
  * n = embed(app, {

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -84,7 +84,6 @@ const DEFAULT_SNAPSHOT_CONFIG = /** @lends SnapshotConfiguration */ {
  * @property {Array<TypeInfo>=} types Visualization types to register
  * @property {Array<ThemeInfo>=} themes Themes to register
  * @property {object=} anything
- * @property {object=} flags
  * @example
  * import { embed } from '@nebula.js/stardust'
  * n = embed(app, {

--- a/apis/nucleus/src/object/__tests__/create-session-object.test.js
+++ b/apis/nucleus/src/object/__tests__/create-session-object.test.js
@@ -109,6 +109,23 @@ describe('create-session-object', () => {
       objectModel,
       { options: 'a', plugins: [], element: undefined },
       halo,
+      undefined,
+      undefined,
+      expect.any(Function)
+    );
+  });
+
+  test('should call init with navigation', async () => {
+    const ret = await create(
+      { type: 't', version: 'v', fields: 'f', properties: 'props', options: 'a', plugins: [], navigation },
+      halo,
+      modelStore
+    );
+    expect(ret).toBe('api');
+    expect(init).toHaveBeenCalledWith(
+      objectModel,
+      { options: 'a', plugins: [], element: undefined },
+      halo,
       navigation,
       undefined,
       expect.any(Function)
@@ -120,6 +137,22 @@ describe('create-session-object', () => {
     types.get.mockReturnValue(err);
     const optional = { properties: 'props', element: 'el', options: 'opts' };
     const ret = await create({ type: 't', ...optional }, halo, modelStore);
+    expect(ret).toBe('api');
+    expect(init).toHaveBeenCalledWith(
+      objectModel,
+      { options: 'opts', plugins: undefined, element: 'el' },
+      halo,
+      undefined,
+      expect.objectContaining(err),
+      expect.any(Function)
+    );
+  });
+
+  test('should catch and pass error when navigation is passed', async () => {
+    const err = new Error('oops');
+    types.get.mockReturnValue(err);
+    const optional = { properties: 'props', element: 'el', options: 'opts' };
+    const ret = await create({ type: 't', ...optional, navigation }, halo, modelStore);
     expect(ret).toBe('api');
     expect(init).toHaveBeenCalledWith(
       objectModel,

--- a/apis/nucleus/src/object/__tests__/create-session-object.test.js
+++ b/apis/nucleus/src/object/__tests__/create-session-object.test.js
@@ -1,5 +1,6 @@
 import * as populatorModule from '../populator';
 import * as initiateModule from '../initiate';
+import * as createNavigationApiModule from '../navigation/navigation';
 import create from '../create-session-object';
 import initializeStores from '../../stores/new-model-store';
 
@@ -11,14 +12,21 @@ describe('create-session-object', () => {
   let populator;
   let init;
   let objectModel;
+  let createNavigationApi;
+  let navigation;
   const modelStore = initializeStores('app');
 
   beforeEach(() => {
     populator = jest.fn();
     init = jest.fn();
+    navigation = {
+      goToSheet: jest.fn(),
+    };
+    createNavigationApi = jest.fn().mockReturnValue(navigation);
 
     jest.spyOn(populatorModule, 'default').mockImplementation(populator);
     jest.spyOn(initiateModule, 'default').mockImplementation(init);
+    jest.spyOn(createNavigationApiModule, 'default').mockImplementation(createNavigationApi);
     objectModel = { id: 'id', on: () => {}, once: () => {} };
     types = {
       get: jest.fn(),
@@ -101,6 +109,7 @@ describe('create-session-object', () => {
       objectModel,
       { options: 'a', plugins: [], element: undefined },
       halo,
+      navigation,
       undefined,
       expect.any(Function)
     );
@@ -116,6 +125,7 @@ describe('create-session-object', () => {
       objectModel,
       { options: 'opts', plugins: undefined, element: 'el' },
       halo,
+      navigation,
       expect.objectContaining(err),
       expect.any(Function)
     );

--- a/apis/nucleus/src/object/__tests__/initiate.test.js
+++ b/apis/nucleus/src/object/__tests__/initiate.test.js
@@ -6,6 +6,7 @@ describe('initiate api', () => {
   const optional = 'optional';
   const halo = 'halo';
   const model = 'model';
+  const navigation = 'navigation';
   let viz;
   let api;
 
@@ -30,8 +31,8 @@ describe('initiate api', () => {
   test('should call viz api', async () => {
     const initialError = 'err';
     const onDestroy = () => {};
-    const ret = await create(model, optional, halo, initialError, onDestroy);
-    expect(viz).toHaveBeenCalledWith({ model, halo, initialError, onDestroy });
+    const ret = await create(model, optional, halo, navigation, initialError, onDestroy);
+    expect(viz).toHaveBeenCalledWith({ model, halo, navigation, initialError, onDestroy });
     expect(ret).toEqual(api);
   });
 

--- a/apis/nucleus/src/object/create-session-object.js
+++ b/apis/nucleus/src/object/create-session-object.js
@@ -39,7 +39,7 @@ import init from './initiate';
  * nebbie.render(createConfig);
  */
 export default async function createSessionObject(
-  { type, version, fields, properties, options, plugins, element, extendProperties, navigation: inputNavigation },
+  { type, version, fields, properties, options, plugins, element, extendProperties, navigation },
   halo,
   store
 ) {
@@ -47,7 +47,6 @@ export default async function createSessionObject(
   const children = [];
   const { modelStore, subscribe } = store;
   let error;
-  const navigation = inputNavigation;
   try {
     const t = halo.types.get({ name: type, version });
     mergedProps = await t.initialProperties(properties, extendProperties);

--- a/apis/nucleus/src/object/create-session-object.js
+++ b/apis/nucleus/src/object/create-session-object.js
@@ -1,6 +1,5 @@
 import populateData from './populator';
 import init from './initiate';
-import createNavigationApi from './navigation/navigation';
 
 /**
  * @typedef {string | qix.NxDimension | qix.NxMeasure | LibraryField} Field
@@ -48,7 +47,7 @@ export default async function createSessionObject(
   const children = [];
   const { modelStore, subscribe } = store;
   let error;
-  const navigation = inputNavigation || createNavigationApi(halo, store);
+  const navigation = inputNavigation;
   try {
     const t = halo.types.get({ name: type, version });
     mergedProps = await t.initialProperties(properties, extendProperties);

--- a/apis/nucleus/src/object/create-session-object.js
+++ b/apis/nucleus/src/object/create-session-object.js
@@ -1,5 +1,6 @@
 import populateData from './populator';
 import init from './initiate';
+import createNavigationApi from './navigation/navigation';
 
 /**
  * @typedef {string | qix.NxDimension | qix.NxMeasure | LibraryField} Field
@@ -39,7 +40,7 @@ import init from './initiate';
  * nebbie.render(createConfig);
  */
 export default async function createSessionObject(
-  { type, version, fields, properties, options, plugins, element, extendProperties },
+  { type, version, fields, properties, options, plugins, element, extendProperties, navigation: inputNavigation },
   halo,
   store
 ) {
@@ -47,6 +48,7 @@ export default async function createSessionObject(
   const children = [];
   const { modelStore, subscribe } = store;
   let error;
+  const navigation = inputNavigation || createNavigationApi(halo, store);
   try {
     const t = halo.types.get({ name: type, version });
     mergedProps = await t.initialProperties(properties, extendProperties);
@@ -90,5 +92,5 @@ export default async function createSessionObject(
     await halo.app.destroySessionObject(model.id);
     unsubscribe();
   };
-  return init(model, { options, plugins, element }, halo, error, onDestroy);
+  return init(model, { options, plugins, element }, halo, navigation, error, onDestroy);
 }

--- a/apis/nucleus/src/object/get-generic-object.js
+++ b/apis/nucleus/src/object/get-generic-object.js
@@ -12,7 +12,7 @@ export default async function getObject({ id, options, plugins, element, navigat
   }
   const model = await rpc;
   modelStore.set(key, model);
-  const navigation = inputNavigation || createNavigationApi(halo, store);
+  const navigation = inputNavigation || (model.genericType === 'sheet' ? createNavigationApi(halo, store) : undefined);
   if (model.genericType === 'sheet') {
     return initSheet(model, { options, plugins, element }, halo, navigation);
   }

--- a/apis/nucleus/src/object/get-generic-object.js
+++ b/apis/nucleus/src/object/get-generic-object.js
@@ -12,7 +12,8 @@ export default async function getObject({ id, options, plugins, element, navigat
   }
   const model = await rpc;
   modelStore.set(key, model);
-  const navigation = inputNavigation || (model.genericType === 'sheet' ? createNavigationApi(halo, store) : undefined);
+  const navigation =
+    inputNavigation || (model.genericType === 'sheet' ? createNavigationApi(halo, store, model) : undefined);
   if (model.genericType === 'sheet') {
     return initSheet(model, { options, plugins, element }, halo, navigation);
   }

--- a/apis/nucleus/src/object/get-generic-object.js
+++ b/apis/nucleus/src/object/get-generic-object.js
@@ -2,7 +2,7 @@ import init from './initiate';
 import initSheet from './initiate-sheet';
 import createNavigationApi from './navigation/navigation';
 
-export default async function getObject({ id, options, plugins, element }, halo, store) {
+export default async function getObject({ id, options, plugins, element, navigation: inputNavigation }, halo, store) {
   const { modelStore, rpcRequestModelStore } = store;
   const key = `${id}`;
   let rpc = rpcRequestModelStore.get(key);
@@ -12,7 +12,7 @@ export default async function getObject({ id, options, plugins, element }, halo,
   }
   const model = await rpc;
   modelStore.set(key, model);
-  const navigation = createNavigationApi(halo, store);
+  const navigation = inputNavigation || createNavigationApi(halo, store);
   if (model.genericType === 'sheet') {
     return initSheet(model, { options, plugins, element }, halo, navigation);
   }

--- a/apis/nucleus/src/object/get-generic-object.js
+++ b/apis/nucleus/src/object/get-generic-object.js
@@ -13,7 +13,7 @@ export default async function getObject({ id, options, plugins, element }, halo,
   modelStore.set(key, model);
 
   if (model.genericType === 'sheet') {
-    return initSheet(model, { options, plugins, element }, halo);
+    return initSheet(model, { options, plugins, element }, halo, store);
   }
 
   return init(model, { options, plugins, element }, halo);

--- a/apis/nucleus/src/object/get-generic-object.js
+++ b/apis/nucleus/src/object/get-generic-object.js
@@ -1,5 +1,6 @@
 import init from './initiate';
 import initSheet from './initiate-sheet';
+import createNavigationApi from './navigation/navigation';
 
 export default async function getObject({ id, options, plugins, element }, halo, store) {
   const { modelStore, rpcRequestModelStore } = store;
@@ -11,10 +12,10 @@ export default async function getObject({ id, options, plugins, element }, halo,
   }
   const model = await rpc;
   modelStore.set(key, model);
-
+  const navigation = createNavigationApi(halo, store);
   if (model.genericType === 'sheet') {
-    return initSheet(model, { options, plugins, element }, halo, store);
+    return initSheet(model, { options, plugins, element }, halo, navigation);
   }
 
-  return init(model, { options, plugins, element }, halo);
+  return init(model, { options, plugins, element }, halo, navigation);
 }

--- a/apis/nucleus/src/object/initiate-sheet.js
+++ b/apis/nucleus/src/object/initiate-sheet.js
@@ -3,9 +3,11 @@ import sheetAPI from '../sheet';
 import createNavigationApi from './navigation/navigation';
 
 export default async function initSheet(model, optional, halo, store, initialError, onDestroy = async () => {}) {
+  const navigation = createNavigationApi(halo, store);
   const api = sheetAPI({
     model,
     halo,
+    navigation,
     initialError,
     onDestroy,
   });
@@ -16,8 +18,7 @@ export default async function initSheet(model, optional, halo, store, initialErr
     api.__DO_NOT_USE__.plugins(optional.plugins);
   }
   if (optional.element) {
-    const navigation = createNavigationApi(halo, store);
-    await api.__DO_NOT_USE__.mount(optional.element, navigation);
+    await api.__DO_NOT_USE__.mount(optional.element);
   }
 
   return api;

--- a/apis/nucleus/src/object/initiate-sheet.js
+++ b/apis/nucleus/src/object/initiate-sheet.js
@@ -1,14 +1,14 @@
 /* eslint no-underscore-dangle:0 */
 import sheetAPI from '../sheet';
+import createNavigationApi from './navigation/navigation';
 
-export default async function initSheet(model, optional, halo, initialError, onDestroy = async () => {}) {
+export default async function initSheet(model, optional, halo, store, initialError, onDestroy = async () => {}) {
   const api = sheetAPI({
     model,
     halo,
     initialError,
     onDestroy,
   });
-
   if (optional.options) {
     api.__DO_NOT_USE__.options(optional.options);
   }
@@ -16,7 +16,8 @@ export default async function initSheet(model, optional, halo, initialError, onD
     api.__DO_NOT_USE__.plugins(optional.plugins);
   }
   if (optional.element) {
-    await api.__DO_NOT_USE__.mount(optional.element);
+    const navigation = createNavigationApi(halo, store);
+    await api.__DO_NOT_USE__.mount(optional.element, navigation);
   }
 
   return api;

--- a/apis/nucleus/src/object/initiate-sheet.js
+++ b/apis/nucleus/src/object/initiate-sheet.js
@@ -1,9 +1,7 @@
 /* eslint no-underscore-dangle:0 */
 import sheetAPI from '../sheet';
-import createNavigationApi from './navigation/navigation';
 
-export default async function initSheet(model, optional, halo, store, initialError, onDestroy = async () => {}) {
-  const navigation = createNavigationApi(halo, store);
+export default async function initSheet(model, optional, halo, navigation, initialError, onDestroy = async () => {}) {
   const api = sheetAPI({
     model,
     halo,

--- a/apis/nucleus/src/object/initiate.js
+++ b/apis/nucleus/src/object/initiate.js
@@ -1,10 +1,11 @@
 /* eslint no-underscore-dangle:0 */
 import vizualizationAPI from '../viz';
 
-export default async function init(model, optional, halo, initialError, onDestroy = async () => {}) {
+export default async function init(model, optional, halo, navigation, initialError, onDestroy = async () => {}) {
   const api = vizualizationAPI({
     model,
     halo,
+    navigation,
     initialError,
     onDestroy,
   });

--- a/apis/nucleus/src/object/navigation/navigation.js
+++ b/apis/nucleus/src/object/navigation/navigation.js
@@ -1,0 +1,58 @@
+/**
+ * Navigation API
+ * Allows extensions to access navigation functionality
+ * */
+
+const createNavigationApi = (halo, store) => {
+  const { galaxy } = halo.public;
+  if (galaxy.anything?.sense?.navigation) {
+    return galaxy.anything?.sense?.navigation;
+  }
+  const State = {};
+
+  const navigationAPI = {
+    /**
+     * Navigate to the supplied sheet
+     * @param {string} sheetId Id of the sheet to navigate to
+     */
+    goToSheet: async (sheetId) => {
+      const { modelStore, rpcRequestModelStore } = store;
+      const key = `${sheetId}`;
+      let rpc = rpcRequestModelStore.get(key);
+      if (!rpc) {
+        rpc = halo.app.getObject(sheetId);
+        rpcRequestModelStore.set(key, rpc);
+      }
+      const model = await rpc;
+      modelStore.set(key, model);
+      State.sheetRef?.current?.setModel?.(model);
+    },
+    /**
+     * Set the current sheet id
+     * @param {string} sheetId Id of the current sheet
+     */
+    setCurrentSheetId: (sheetId) => {
+      State.sheetId = sheetId;
+    },
+    /**
+     * Set the sheet ref
+     * @param {object} sheetRef sheet ref object
+     */
+    setSheetRef: (sheetRef) => {
+      State.sheetRef = sheetRef;
+    },
+    /**
+     * Return the current sheet id
+     * @returns {string|false}
+     */
+    getCurrentSheetId: () => {
+      if (State.sheetId) {
+        return State.sheetId;
+      }
+      return false;
+    },
+  };
+  return navigationAPI;
+};
+
+export default createNavigationApi;

--- a/apis/nucleus/src/object/navigation/navigation.js
+++ b/apis/nucleus/src/object/navigation/navigation.js
@@ -1,7 +1,12 @@
 import eventmixin from '../../selections/event-mixin';
 
-export default function createNavigationApi(halo, store) {
-  const State = {};
+export default function createNavigationApi(halo, store, model) {
+  const { galaxy } = halo.public;
+  if (galaxy.anything?.sense?.navigation) {
+    return galaxy.anything?.sense?.navigation;
+  }
+
+  const State = { model };
 
   /**
    * @class Navigation
@@ -22,29 +27,19 @@ export default function createNavigationApi(halo, store) {
         rpc = halo.app.getObject(sheetId);
         rpcRequestModelStore.set(key, rpc);
       }
-      let model;
+      let newModel;
       try {
-        model = await rpc;
-        if (model.genericType !== 'sheet') {
+        newModel = await rpc;
+        if (newModel.genericType !== 'sheet') {
           return;
         }
       } catch (e) {
         return;
       }
-      modelStore.set(key, model);
-      State.sheetRef?.current?.setModel?.(model);
-    },
-    /**
-     * @private
-     * Set the current sheet id
-     * @param {string} sheetId Id of the current sheet
-     */
-    setCurrentSheetId: (sheetId) => {
-      if (State.sheetId === sheetId) {
-        return;
-      }
-      State.sheetId = sheetId;
-      navigationAPI.emit('currentSheetIdChange');
+      modelStore.set(key, newModel);
+      State.sheetRef?.current?.setModel?.(newModel);
+      State.model = newModel;
+      navigationAPI.emit('sheetChanged');
     },
     /**
      * @private
@@ -59,8 +54,8 @@ export default function createNavigationApi(halo, store) {
      * @returns {string|false}
      */
     getCurrentSheetId: () => {
-      if (State.sheetId) {
-        return State.sheetId;
+      if (State.model) {
+        return State.model.id;
       }
       return false;
     },

--- a/apis/nucleus/src/object/navigation/navigation.js
+++ b/apis/nucleus/src/object/navigation/navigation.js
@@ -14,6 +14,9 @@ export default function createNavigationApi(halo, store) {
      * @param {string} sheetId Id of the sheet to navigate to
      */
     goToSheet: async (sheetId) => {
+      if (!State.sheetRef) {
+        return;
+      }
       const { modelStore, rpcRequestModelStore } = store;
       const key = `${sheetId}`;
       let rpc = rpcRequestModelStore.get(key);

--- a/apis/nucleus/src/object/navigation/navigation.js
+++ b/apis/nucleus/src/object/navigation/navigation.js
@@ -1,16 +1,14 @@
-/**
- * Navigation API
- * Allows extensions to access navigation functionality
- * */
-
-const createNavigationApi = (halo, store) => {
+export default function createNavigationApi(halo, store) {
   const { galaxy } = halo.public;
   if (galaxy.anything?.sense?.navigation) {
     return galaxy.anything?.sense?.navigation;
   }
   const State = {};
 
-  const navigationAPI = {
+  /**
+   * @class Navigation
+   */
+  const navigationAPI = /** @lends Navigation# */ {
     /**
      * Navigate to the supplied sheet
      * @param {string} sheetId Id of the sheet to navigate to
@@ -53,6 +51,4 @@ const createNavigationApi = (halo, store) => {
     },
   };
   return navigationAPI;
-};
-
-export default createNavigationApi;
+}

--- a/apis/nucleus/src/object/navigation/navigation.js
+++ b/apis/nucleus/src/object/navigation/navigation.js
@@ -1,8 +1,6 @@
+import eventmixin from '../../selections/event-mixin';
+
 export default function createNavigationApi(halo, store) {
-  const { galaxy } = halo.public;
-  if (galaxy.anything?.sense?.navigation) {
-    return galaxy.anything?.sense?.navigation;
-  }
   const State = {};
 
   /**
@@ -42,7 +40,11 @@ export default function createNavigationApi(halo, store) {
      * @param {string} sheetId Id of the current sheet
      */
     setCurrentSheetId: (sheetId) => {
+      if (State.sheetId === sheetId) {
+        return;
+      }
       State.sheetId = sheetId;
+      navigationAPI.emit('currentSheetIdChange');
     },
     /**
      * @private
@@ -63,5 +65,6 @@ export default function createNavigationApi(halo, store) {
       return false;
     },
   };
+  eventmixin(navigationAPI);
   return navigationAPI;
 }

--- a/apis/nucleus/src/object/navigation/navigation.js
+++ b/apis/nucleus/src/object/navigation/navigation.js
@@ -24,11 +24,20 @@ export default function createNavigationApi(halo, store) {
         rpc = halo.app.getObject(sheetId);
         rpcRequestModelStore.set(key, rpc);
       }
-      const model = await rpc;
+      let model;
+      try {
+        model = await rpc;
+        if (model.genericType !== 'sheet') {
+          return;
+        }
+      } catch (e) {
+        return;
+      }
       modelStore.set(key, model);
       State.sheetRef?.current?.setModel?.(model);
     },
     /**
+     * @private
      * Set the current sheet id
      * @param {string} sheetId Id of the current sheet
      */
@@ -36,6 +45,7 @@ export default function createNavigationApi(halo, store) {
       State.sheetId = sheetId;
     },
     /**
+     * @private
      * Set the sheet ref
      * @param {object} sheetRef sheet ref object
      */

--- a/apis/nucleus/src/sheet.js
+++ b/apis/nucleus/src/sheet.js
@@ -5,7 +5,7 @@ import getPatches from './utils/patcher';
 
 const noopi = () => {};
 
-export default function sheet({ model, halo, initialError, onDestroy = async () => {} } = {}) {
+export default function sheet({ model, halo, navigation, initialError, onDestroy = async () => {} } = {}) {
   let unmountSheet = noopi;
   let sheetRef = null;
   let mountedReference = null;
@@ -88,7 +88,7 @@ export default function sheet({ model, halo, initialError, onDestroy = async () 
     },
     // ===== unexposed experimental API - use at own risk ======
     __DO_NOT_USE__: {
-      mount(element, navigation) {
+      mount(element) {
         if (mountedReference) {
           throw new Error('Already mounted');
         }

--- a/apis/nucleus/src/sheet.js
+++ b/apis/nucleus/src/sheet.js
@@ -73,8 +73,8 @@ export default function sheet({ model, halo, navigation, initialError, onDestroy
      */
     model,
     /**
-     * The id of this sheets's generic object.
-     * @type {string}
+     * The navigation api to control sheet navigation.
+     * @type {Navigation}
      */
     navigation,
     /**

--- a/apis/nucleus/src/sheet.js
+++ b/apis/nucleus/src/sheet.js
@@ -75,7 +75,7 @@ export default function sheet({ model, halo, navigation, initialError, onDestroy
     /**
      * The navigation api to control sheet navigation.
      * @experimental
-     * @since 5.3.1
+     * @since 5.4.0
      * @type {Navigation}
      */
     navigation,

--- a/apis/nucleus/src/sheet.js
+++ b/apis/nucleus/src/sheet.js
@@ -88,7 +88,7 @@ export default function sheet({ model, halo, initialError, onDestroy = async () 
     },
     // ===== unexposed experimental API - use at own risk ======
     __DO_NOT_USE__: {
-      mount(element) {
+      mount(element, navigation) {
         if (mountedReference) {
           throw new Error('Already mounted');
         }
@@ -104,6 +104,7 @@ export default function sheet({ model, halo, initialError, onDestroy = async () 
           initialSnPlugins,
           initialError,
           onMount,
+          navigation,
         });
         return mounted;
       },

--- a/apis/nucleus/src/sheet.js
+++ b/apis/nucleus/src/sheet.js
@@ -74,6 +74,8 @@ export default function sheet({ model, halo, navigation, initialError, onDestroy
     model,
     /**
      * The navigation api to control sheet navigation.
+     * @experimental
+     * @since 5.4.0
      * @type {Navigation}
      */
     navigation,

--- a/apis/nucleus/src/sheet.js
+++ b/apis/nucleus/src/sheet.js
@@ -73,6 +73,11 @@ export default function sheet({ model, halo, navigation, initialError, onDestroy
      */
     model,
     /**
+     * The id of this sheets's generic object.
+     * @type {string}
+     */
+    navigation,
+    /**
      * Destroys the sheet and removes it from the the DOM.
      * @example
      * const sheet = await embed(app).render({

--- a/apis/nucleus/src/sheet.js
+++ b/apis/nucleus/src/sheet.js
@@ -75,7 +75,7 @@ export default function sheet({ model, halo, navigation, initialError, onDestroy
     /**
      * The navigation api to control sheet navigation.
      * @experimental
-     * @since 5.4.0
+     * @since 5.3.1
      * @type {Navigation}
      */
     navigation,

--- a/apis/nucleus/src/viz.js
+++ b/apis/nucleus/src/viz.js
@@ -10,7 +10,7 @@ import saveSoftProperties from './utils/save-soft-properties';
 
 const noopi = () => {};
 
-export default function viz({ model, halo, initialError, onDestroy = async () => {} } = {}) {
+export default function viz({ model, halo, navigation, initialError, onDestroy = async () => {} } = {}) {
   let unmountCell = noopi;
   let cellRef = null;
   let mountedReference = null;
@@ -247,6 +247,7 @@ export default function viz({ model, halo, initialError, onDestroy = async () =>
           initialError,
           onMount,
           emitter,
+          navigation,
         });
         return mounted;
       },

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -383,6 +383,19 @@
         "import { useDeviceType } from '@nebula.js/stardust';\n// ...\nconst deviceType = useDeviceType();\nif (deviceType === 'touch') { ... };"
       ]
     },
+    "useNavigation": {
+      "description": "Gets the navigation api to control sheet navigation",
+      "kind": "function",
+      "params": [],
+      "returns": {
+        "description": "navigation api.",
+        "type": "#/definitions/Navigation"
+      },
+      "examples": [
+        "// Render a sheet\nconst nebbie = embed(app);\nconst sheetRender = await nebbie.render({\n  element: sheetElement\n  id: 'sheetId',\n});",
+        "// Use a navigation object to control sheet navigation\nconst plugins = usePlugins();\nconst navigationRender = await nebbie.render({\n  element: navigationElement\n  id: 'navigationId',\n  navigation: sheetRender.navigation\n});"
+      ]
+    },
     "usePlugins": {
       "description": "Gets the array of plugins provided when rendering the visualization.",
       "kind": "function",
@@ -1251,6 +1264,10 @@
           "description": "This sheets Enigma model, a representation of the generic object.",
           "type": "string"
         },
+        "navigation": {
+          "description": "The navigation api to control sheet navigation.",
+          "type": "#/definitions/Navigation"
+        },
         "destroy": {
           "description": "Destroys the sheet and removes it from the the DOM.",
           "kind": "function",
@@ -1862,6 +1879,65 @@
         "meta": {
           "optional": true,
           "type": "object"
+        }
+      }
+    },
+    "Navigation": {
+      "kind": "class",
+      "constructor": {
+        "kind": "function",
+        "params": []
+      },
+      "entries": {
+        "goToSheet": {
+          "description": "Navigate to the supplied sheet",
+          "kind": "function",
+          "params": [
+            {
+              "name": "sheetId",
+              "description": "Id of the sheet to navigate to",
+              "type": "string"
+            }
+          ]
+        },
+        "setCurrentSheetId": {
+          "description": "Set the current sheet id",
+          "kind": "function",
+          "params": [
+            {
+              "name": "sheetId",
+              "description": "Id of the current sheet",
+              "type": "string"
+            }
+          ]
+        },
+        "setSheetRef": {
+          "description": "Set the sheet ref",
+          "kind": "function",
+          "params": [
+            {
+              "name": "sheetRef",
+              "description": "sheet ref object",
+              "type": "object"
+            }
+          ]
+        },
+        "getCurrentSheetId": {
+          "description": "Return the current sheet id",
+          "kind": "function",
+          "params": [],
+          "returns": {
+            "kind": "union",
+            "items": [
+              {
+                "type": "string"
+              },
+              {
+                "kind": "literal",
+                "value": "false"
+              }
+            ]
+          }
         }
       }
     },

--- a/apis/stardust/src/index.js
+++ b/apis/stardust/src/index.js
@@ -31,6 +31,7 @@ export {
   useAppLayout,
   useTranslator,
   useDeviceType,
+  useNavigation,
   usePlugins,
   useConstraints,
   useInteractionState,

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -123,6 +123,11 @@ export function useTranslator(): stardust.Translator;
 export function useDeviceType(): string;
 
 /**
+ * Gets the navigation api.
+ */
+export function useNavigation(): object;
+
+/**
  * Gets the array of plugins provided when rendering the visualization.
  */
 export function usePlugins(): stardust.Plugin[];

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -123,9 +123,9 @@ export function useTranslator(): stardust.Translator;
 export function useDeviceType(): string;
 
 /**
- * Gets the navigation api.
+ * Gets the navigation api to control sheet navigation
  */
-export function useNavigation(): object;
+export function useNavigation(): stardust.Navigation;
 
 /**
  * Gets the array of plugins provided when rendering the visualization.
@@ -394,6 +394,8 @@ declare namespace stardust {
 
         model: string;
 
+        navigation: stardust.Navigation;
+
         /**
          * Destroys the sheet and removes it from the the DOM.
          */
@@ -595,6 +597,34 @@ declare namespace stardust {
         version?: string;
         load: stardust.LoadType;
         meta?: object;
+    }
+
+    class Navigation {
+        constructor();
+
+        /**
+         * Navigate to the supplied sheet
+         * @param sheetId Id of the sheet to navigate to
+         */
+        goToSheet(sheetId: string): void;
+
+        /**
+         * Set the current sheet id
+         * @param sheetId Id of the current sheet
+         */
+        setCurrentSheetId(sheetId: string): void;
+
+        /**
+         * Set the sheet ref
+         * @param sheetRef sheet ref object
+         */
+        setSheetRef(sheetRef: object): void;
+
+        /**
+         * Return the current sheet id
+         */
+        getCurrentSheetId(): string | "false";
+
     }
 
     interface ActionToolbarElement extends HTMLElement{

--- a/apis/supernova/src/creator.js
+++ b/apis/supernova/src/creator.js
@@ -77,6 +77,7 @@ function createWithHooks(generator, opts, galaxy) {
       deviceType: galaxy.deviceType,
       theme: undefined,
       translator: galaxy.translator,
+      navigation: opts.navigation,
       // --- dynamic values ---
       layout: {},
       appLayout: {},

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -772,6 +772,27 @@ export function useDeviceType() {
   return useInternalContext('deviceType');
 }
 
+/**
+ * Gets the navigation api to control sheet navigation
+ * @entry
+ * @returns {Navigation} navigation api.
+ * @example
+ * // Render a sheet
+ * const nebbie = embed(app);
+ * const sheetRender = await nebbie.render({
+ *   element: sheetElement
+ *   id: 'sheetId',
+ * });
+ *
+ * @example
+ * // Use a navigation object to control sheet navigation
+ * const plugins = usePlugins();
+ * const navigationRender = await nebbie.render({
+ *   element: navigationElement
+ *   id: 'navigationId',
+ *   navigation: sheetRender.navigation
+ * });
+ */
 export function useNavigation() {
   return useInternalContext('navigation');
 }

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -772,6 +772,10 @@ export function useDeviceType() {
   return useInternalContext('deviceType');
 }
 
+export function useNavigation() {
+  return useInternalContext('navigation');
+}
+
 /**
  * Gets the array of plugins provided when rendering the visualization.
  * @entry

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -777,21 +777,10 @@ export function useDeviceType() {
  * @entry
  * @returns {Navigation} navigation api.
  * @example
- * // Render a sheet
- * const nebbie = embed(app);
- * const sheetRender = await nebbie.render({
- *   element: sheetElement
- *   id: 'sheetId',
- * });
- *
- * @example
- * // Use a navigation object to control sheet navigation
- * const plugins = usePlugins();
- * const navigationRender = await nebbie.render({
- *   element: navigationElement
- *   id: 'navigationId',
- *   navigation: sheetRender.navigation
- * });
+ * import { useNavigation } from "@nebula.js/stardust";
+ * // ...
+ * const navigation = useNavigation();
+ * const [activeSheetId, setActiveSheetId] = useState(navigation?.getCurrentSheetId() || "");
  */
 export function useNavigation() {
   return useInternalContext('navigation');

--- a/apis/supernova/src/index.js
+++ b/apis/supernova/src/index.js
@@ -22,6 +22,7 @@ export {
   useAppLayout,
   useTranslator,
   useDeviceType,
+  useNavigation,
   usePlugins,
   useConstraints,
   useInteractionState,


### PR DESCRIPTION
This PR is to add sheet navigation capability to support using sn-nav-menu in a mashup using qlik-embed to embed a sheet. The main idea is to create a navigation api for each sheet rendering to avoid the case when there are more than one sheet is rendered.
The navigation api needs to know the sheet to update the sheet based on new sheet ID.
The navigation api is passed to each chart context.

https://github.com/user-attachments/assets/e29414c0-3cba-48e5-86f1-6bc9d261c5d9


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
