### PR TITLE
feat: listbox popover sorting option

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -43,6 +43,14 @@ export default function ListBoxPopover({
   checkboxes: checkboxesOption,
   selectDisabled = () => false,
   flags,
+  sortCriteria = [
+    {
+      qSortByState: 1,
+      qSortByAscii: 1,
+      qSortByNumeric: 1,
+      qSortByLoadOrder: 1,
+    },
+  ],
 }) {
   const isMasterDim = Boolean(fieldName?.qLibraryId);
   const open = show && Boolean(alignTo.current);
@@ -66,14 +74,7 @@ export default function ListBoxPopover({
           },
         ],
         qDef: {
-          qSortCriterias: [
-            {
-              qSortByState: 1,
-              qSortByAscii: 1,
-              qSortByNumeric: 1,
-              qSortByLoadOrder: 1,
-            },
-          ],
+          qSortCriterias: sortCriteria,
           qFieldDefs: isMasterDim ? undefined : [fieldName],
         },
         qLibraryId: isMasterDim ? fieldName.qLibraryId : undefined,

--- a/apis/nucleus/src/components/listbox/ListBoxPopoverWrapper.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopoverWrapper.jsx
@@ -44,6 +44,7 @@ export default function ListBoxPopoverWrapper({ app, fieldIdentifier, stateName,
       autoFocus={options.autoFocus}
       components={options.components}
       flags={flags}
+      sortCriteria={options.sortCriteria}
     />
   );
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Adds the ability to customize the sort order for a field in the listbox popover. It is needed in the "Sorting in search" feature in the pivot table, as that requires the sort order for the field in the listbox to match that of the dimension in the pivot table.

I could not find any test for the listbox popover, so no tests added either.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
