### PR TITLE
fix: disable portal for actions toolbar more menu

### DIFF
--- a/apis/nucleus/src/components/ActionsToolbarMore.jsx
+++ b/apis/nucleus/src/components/ActionsToolbarMore.jsx
@@ -58,6 +58,9 @@ const More = React.forwardRef(
           ref={ref}
           open={show}
           anchorEl={alignTo.current}
+          getContentAnchorEl={null}
+          container={alignTo.current}
+          disablePortal
           hideBackdrop
           transitionDuration={0}
           slotProps={{


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Reverting this fix https://github.com/qlik-oss/nebula.js/pull/1568.
It introduces a bigger problem for some use-cases, where clicking the menu is considered a click outside for the listbox popover, causing it to close. So for now we will have to reintroduce the overlap issue.

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
