### PR TITLE
chore: deprecate plugins

### DIFF
--- a/apis/nucleus/src/object/create-session-object.js
+++ b/apis/nucleus/src/object/create-session-object.js
@@ -10,7 +10,7 @@ import init from './initiate';
  * @description Configuration for rendering a visualisation, either creating or fetching an existing object.
  * @property {HTMLElement} element Target html element to render in to
  * @property {object=} options Options passed into the visualisation
- * @property {Plugin[]} [plugins] plugins passed into the visualisation
+ * @property {Plugin[]} [plugins] Deprecated: plugins passed into the visualisation
  * @property {string=} id For existing objects: Engine identifier of object to render
  * @property {string=} type For creating objects: Type of visualisation to render
  * @property {string=} version For creating objects: Version of visualization to render

--- a/apis/nucleus/src/plugins/plugins.js
+++ b/apis/nucleus/src/plugins/plugins.js
@@ -4,7 +4,8 @@
  * @property {object} info Object that can hold various meta info about the plugin
  * @property {string} info.name The name of the plugin
  * @property {function} fn The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.
- * @experimental
+ * @experimental since 5.5.0
+ * @deprecated
  * @since 1.2.0
  * @example
  * const plugin = {

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1818,7 +1818,8 @@
       "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
       "stability": "experimental",
       "availability": {
-        "since": "1.2.0"
+        "since": "1.2.0",
+        "deprecated": true
       },
       "kind": "interface",
       "entries": {

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -577,6 +577,7 @@ declare namespace stardust {
 
     /**
      * An object literal containing meta information about the plugin and a function containing the plugin implementation.
+     * @deprecated
      */
     interface Plugin {
         info: {

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -790,6 +790,7 @@ export function useNavigation() {
 /**
  * Gets the array of plugins provided when rendering the visualization.
  * @entry
+ * @deprecated since 5.5.0
  * @returns {Plugin[]} array of plugins.
  * @example
  * // provide plugins that can be used when rendering


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Plugins are not used at all internally and the support is lacking, better deprecate it and not lead anyone on that updates will come.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
