### PR TITLE
chore: support 'anything' through nebula serve

### DIFF
--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -158,6 +158,7 @@ module.exports = async ({
             port: entryWatcher && entryWatcher.port,
           },
           flags: serveConfig.flags,
+          anything: serveConfig.anything,
           themes: themes.map((theme) => theme.id),
           types: serveConfig.types,
           keyboardNavigation: serveConfig.keyboardNavigation,

--- a/commands/serve/web/render-fixture.js
+++ b/commands/serve/web/render-fixture.js
@@ -11,7 +11,7 @@ const getDefaultGenericObject = ({ type }) => ({
   },
 });
 
-const getServeOptions = ({ themes = [], supernova = {}, flags }) => {
+const getServeOptions = ({ themes = [], supernova = {}, flags, anything }) => {
   const options = {
     instanceConfig: {
       themes: themes.map((t) => ({
@@ -22,6 +22,7 @@ const getServeOptions = ({ themes = [], supernova = {}, flags }) => {
         constraints: {},
       },
       flags,
+      anything,
     },
   };
   if (supernova.name) {


### PR DESCRIPTION
Support passing 'anything' object through nebula serve by adding it in nebula.config.js file. This is to help rendering tests which is run by using nebula serve.
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
