### PR TITLE
feat: add host config to config and galaxy

### DIFF
--- a/apis/nucleus/src/__tests__/nucleus.test.js
+++ b/apis/nucleus/src/__tests__/nucleus.test.js
@@ -116,6 +116,7 @@ describe('nucleus', () => {
 
   test('should initiate types with a public galaxy interface', () => {
     Nuked('app', {
+      hostConfig: 'HOST',
       anything: {
         some: 'thing',
       },
@@ -127,6 +128,7 @@ describe('nucleus', () => {
       },
       flags: 'flags',
       deviceType: 'desktop',
+      hostConfig: 'HOST',
       translator,
     });
   });

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -184,7 +184,7 @@ const mergeConfigs = (base, c) => ({
   types: mergeArray(base.types, c.types),
   themes: mergeArray(base.themes, c.themes),
   flags: mergeObj(base.flags, c.flags),
-  hostConfig: mergeObj(base.hostConfig, c.hostConfig),
+  hostConfig: c.hostConfig || base.hostConfig,
   anything: mergeObj(base.anything, c.anything),
 });
 

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -88,7 +88,7 @@ const DEFAULT_SNAPSHOT_CONFIG = /** @lends SnapshotConfiguration */ {
  * @property {Context=} context Settings for the rendering instance
  * @property {Array<TypeInfo>=} types Visualization types to register
  * @property {Array<ThemeInfo>=} themes Themes to register
- * @property {object=} hostConfig a qlik api compatible host config, see https://github.com/qlik-oss/qlik-api-ts/blob/main/docs/authentication.md#the-host-config
+ * @property {object=} hostConfig Qlik api compatible host config, see https://github.com/qlik-oss/qlik-api-ts/blob/main/docs/authentication.md#the-host-config
  * @property {object=} anything
  * @example
  * import { embed } from '@nebula.js/stardust'

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -88,6 +88,7 @@ const DEFAULT_SNAPSHOT_CONFIG = /** @lends SnapshotConfiguration */ {
  * @property {Context=} context Settings for the rendering instance
  * @property {Array<TypeInfo>=} types Visualization types to register
  * @property {Array<ThemeInfo>=} themes Themes to register
+ * @property {object=} hostConfig a qlik api compatible host config, see https://github.com/qlik-oss/qlik-api-ts/blob/main/docs/authentication.md#the-host-config
  * @property {object=} anything
  * @example
  * import { embed } from '@nebula.js/stardust'
@@ -242,6 +243,8 @@ function nuked(configuration = {}) {
         flags: flagsFn(configuration.flags),
         /** @type {string} */
         deviceType: deviceTypeFn(configuration.context.deviceType),
+        /** @type {object} */
+        hostConfig: configuration.hostConfig,
         /** @type {object} */
         anything: configuration.anything,
       },

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -184,6 +184,7 @@ const mergeConfigs = (base, c) => ({
   types: mergeArray(base.types, c.types),
   themes: mergeArray(base.themes, c.themes),
   flags: mergeObj(base.flags, c.flags),
+  hostConfig: mergeObj(base.hostConfig, c.hostConfig),
   anything: mergeObj(base.anything, c.anything),
 });
 

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -706,6 +706,11 @@
             "type": "#/definitions/ThemeInfo"
           }
         },
+        "hostConfig": {
+          "description": "a qlik api compatible host config, see https://github.com/qlik-oss/qlik-api-ts/blob/main/docs/authentication.md#the-host-config",
+          "optional": true,
+          "type": "object"
+        },
         "anything": {
           "optional": true,
           "type": "object"
@@ -773,6 +778,9 @@
         },
         "deviceType": {
           "type": "string"
+        },
+        "hostConfig": {
+          "type": "object"
         },
         "anything": {
           "type": "object"

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -247,6 +247,7 @@ declare namespace stardust {
         context?: stardust.Context;
         types?: stardust.TypeInfo[];
         themes?: stardust.ThemeInfo[];
+        hostConfig?: object;
         anything?: object;
     }
 
@@ -265,6 +266,7 @@ declare namespace stardust {
         translator: stardust.Translator;
         flags: stardust.Flags;
         deviceType: string;
+        hostConfig: object;
         anything: object;
     }
 

--- a/commands/build/lib/systemjs.js
+++ b/commands/build/lib/systemjs.js
@@ -1,6 +1,13 @@
 const systemjsBehaviours = {
   getExternal: ({ config: cfg }) => {
-    const defaultExternal = ['@nebula.js/stardust', 'picasso.js', 'picasso-plugin-q', 'react', 'react-dom', 'qmfe-api'];
+    const defaultExternal = [
+      '@nebula.js/stardust',
+      'picasso.js',
+      'picasso-plugin-q',
+      'react',
+      'react-dom',
+      '@qlik-trial/qmfe-api',
+    ];
     const { external } = cfg.systemjs || {};
     return Array.isArray(external) ? external : defaultExternal;
   },

--- a/commands/build/lib/systemjs.js
+++ b/commands/build/lib/systemjs.js
@@ -7,6 +7,7 @@ const systemjsBehaviours = {
       'react',
       'react-dom',
       '@qlik-trial/qmfe-api',
+      '@qlik/api',
     ];
     const { external } = cfg.systemjs || {};
     return Array.isArray(external) ? external : defaultExternal;

--- a/commands/build/lib/systemjs.js
+++ b/commands/build/lib/systemjs.js
@@ -1,6 +1,6 @@
 const systemjsBehaviours = {
   getExternal: ({ config: cfg }) => {
-    const defaultExternal = ['@nebula.js/stardust', 'picasso.js', 'picasso-plugin-q', 'react', 'react-dom'];
+    const defaultExternal = ['@nebula.js/stardust', 'picasso.js', 'picasso-plugin-q', 'react', 'react-dom', 'qmfe-api'];
     const { external } = cfg.systemjs || {};
     return Array.isArray(external) ? external : defaultExternal;
   },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Adds the possibility to pass a hostConfig into Nebula, making it available on the Galaxy env parameter for use in charts.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
