### PR TITLE
feat(context-menu): new sheet experiment

### DIFF
--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -492,6 +492,11 @@ const Cell = forwardRef(
           const snapshot = await this.takeSnapshot(); // eslint-disable-line
           return halo.config.snapshot.capture(snapshot);
         },
+        async getContextMenu(menu, event, menuBuilder) {
+          if (state.sn?.component && typeof state.sn.component.onContextMenu === 'function') {
+            await state.sn.component.onContextMenu(menu, event, menuBuilder);
+          }
+        },
       }),
       [state.sn, contentRect, cellRect, layout, theme.name, appLayout]
     );

--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -492,10 +492,11 @@ const Cell = forwardRef(
           const snapshot = await this.takeSnapshot(); // eslint-disable-line
           return halo.config.snapshot.capture(snapshot);
         },
-        async getContextMenu(menu, event, menuBuilder) {
+        async getContextMenu(menu, event, menuBuilder, features, context) {
           if (state.sn?.component && typeof state.sn.component.onContextMenu === 'function') {
-            await state.sn.component.onContextMenu(menu, event, menuBuilder);
+            return state.sn.component.onContextMenu(menu, event, menuBuilder, features, context);
           }
+          return undefined;
         },
       }),
       [state.sn, contentRect, cellRect, layout, theme.name, appLayout]

--- a/apis/nucleus/src/viz.js
+++ b/apis/nucleus/src/viz.js
@@ -194,6 +194,9 @@ export default function viz({ model, halo, initialError, onDestroy = async () =>
         cellRef.current.setModel(newModel);
       }
     },
+    async getContextMenu(menu, event, menuBuilder) {
+      return cellRef.current.getContextMenu(menu, event, menuBuilder);
+    },
     /**
      * Listens to custom events from inside the visualization. See useEmitter
      * @param {string} eventName Event name to listen to

--- a/apis/nucleus/src/viz.js
+++ b/apis/nucleus/src/viz.js
@@ -194,8 +194,8 @@ export default function viz({ model, halo, initialError, onDestroy = async () =>
         cellRef.current.setModel(newModel);
       }
     },
-    async getContextMenu(menu, event, menuBuilder) {
-      return cellRef.current.getContextMenu(menu, event, menuBuilder);
+    async getContextMenu(menu, event, menuBuilder, features, context) {
+      return cellRef.current.getContextMenu(menu, event, menuBuilder, features, context);
     },
     /**
      * Listens to custom events from inside the visualization. See useEmitter

--- a/apis/supernova/src/creator.js
+++ b/apis/supernova/src/creator.js
@@ -211,8 +211,8 @@ function createWithHooks(generator, opts, galaxy) {
     setSnapshotData(layout) {
       return generator.component.runSnaps(this, layout);
     },
-    onContextMenu(menu, event, menuBuilder) {
-      return generator.component.runMenu(this, menu, event, menuBuilder);
+    onContextMenu(menu, event, menuBuilder, features, context) {
+      return generator.component.runMenu(this, menu, event, menuBuilder, features, context);
     },
     focus() {
       generator.component.focus(this);

--- a/apis/supernova/src/hooks.js
+++ b/apis/supernova/src/hooks.js
@@ -165,11 +165,11 @@ export function runSnaps(component, layout) {
   return Promise.resolve();
 }
 
-export function runMenu(component, menu, event, menuBuilder) {
+export function runMenu(component, menu, event, menuBuilder, features, context) {
   try {
-    return Promise.all(component.__hooks.menus.map((h) => Promise.resolve(h.fn(menu, event, menuBuilder)))).then(
-      (menus) => menus[menus.length - 1]
-    );
+    return Promise.all(
+      component.__hooks.menus.map((h) => Promise.resolve(h.fn(menu, event, menuBuilder, features, context)))
+    ).then((menus) => menus[menus.length - 1]);
   } catch (e) {
     console.error(e);
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Expose the `getContextMenu` function so we could use it in QmfeEmbed. This function take features as one of it's parameter and return a list of features that might have been modified by the chart.

Question:
- Should we called it something else to differentiate between the new and old one?

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
