### PR TITLE
fix: make browser the default target

### DIFF
--- a/commands/build/lib/config.js
+++ b/commands/build/lib/config.js
@@ -61,7 +61,7 @@ const config = ({
   mode = 'production',
   format = 'umd',
   cwd = process.cwd(),
-  argv = { sourcemap: true, codeSplit: false, browser: true },
+  argv = { sourcemap: true, codeSplit: false },
   core,
   behaviours: {
     getExternal = getExternalDefault,

--- a/commands/build/lib/config.js
+++ b/commands/build/lib/config.js
@@ -61,7 +61,7 @@ const config = ({
   mode = 'production',
   format = 'umd',
   cwd = process.cwd(),
-  argv = { sourcemap: true, codeSplit: false },
+  argv = { sourcemap: true, codeSplit: false, browser: true },
   core,
   behaviours: {
     getExternal = getExternalDefault,

--- a/commands/build/lib/config.js
+++ b/commands/build/lib/config.js
@@ -54,15 +54,7 @@ const getExternalDefault = ({ pkg }) => {
 };
 
 const getExternalCore = ({ pkg }) => {
-  const defaultExternal = [
-    '@nebula.js/stardust',
-    'picasso.js',
-    'picasso-plugin-q',
-    'react',
-    'react-dom',
-    /^(?!@qlik-trial\/qmfe-data-client-parcels)(@qlik-trial\/qmfe-)/,
-    /^@qlik\/api\//,
-  ];
+  const defaultExternal = ['@nebula.js/stardust', /^@qlik\/api\//];
   const peers = Object.keys(pkg.peerDependencies || {});
   return [...defaultExternal, ...peers];
 };

--- a/commands/build/lib/config.js
+++ b/commands/build/lib/config.js
@@ -53,6 +53,20 @@ const getExternalDefault = ({ pkg }) => {
   return Object.keys(peers);
 };
 
+const getExternalCore = ({ pkg }) => {
+  const defaultExternal = [
+    '@nebula.js/stardust',
+    'picasso.js',
+    'picasso-plugin-q',
+    'react',
+    'react-dom',
+    /^(?!@qlik-trial\/qmfe-data-client-parcels)(@qlik-trial\/qmfe-)/,
+    /^@qlik\/api\//,
+  ];
+  const peers = Object.keys(pkg.peerDependencies || {});
+  return [...defaultExternal, ...peers];
+};
+
 const getOutputFileDefault = ({ pkg }) => pkg.main;
 
 const getOutputNameDefault = ({ pkg }) => pkg.name.split('/').reverse()[0];
@@ -105,7 +119,7 @@ const config = ({
     }
   }
 
-  const external = getExternal({ pkg, config: argv });
+  const external = core ? getExternalCore({ pkg }) : getExternal({ pkg, config: argv });
   // stardust should always be external
   if (external.indexOf('@nebula.js/stardust') === -1) {
     // eslint-disable-next-line no-console
@@ -128,7 +142,7 @@ const config = ({
     } else {
       outputConfig.dir = path.resolve(dir, outputFile.split('/')[0]);
     }
-    if (argv.codeSplit && format === 'umd') {
+    if (format === 'umd') {
       outputConfig.inlineDynamicImports = true;
     }
     return outputConfig;

--- a/commands/build/lib/init-config.js
+++ b/commands/build/lib/init-config.js
@@ -52,7 +52,7 @@ const options = {
     description:
       'In Rollup, the browser option is a configuration option that specifies whether the bundle is intended to run in a browser environment.',
     type: 'boolean',
-    default: false,
+    default: true,
   },
   codeSplit: {
     description:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Browser should be the default target of the nebula build, but it turned out to be set to false.

Also fixes regex imports for default externals for core builds

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
