### PR TITLE
feat: update listbox options

### DIFF
--- a/apis/nucleus/src/components/listbox/__tests__/list-box-portal.test.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box-portal.test.jsx
@@ -67,7 +67,7 @@ describe('ListBoxPortal', () => {
     test('should get object from app and use as model', async () => {
       const qId = '1337';
       const app = {};
-      const elem = ListBoxPortal({ app, qId });
+      const [elem] = ListBoxPortal({ app, qId });
       await render(elem);
       expect(useExistingModel).toHaveBeenCalledWith({
         app,
@@ -81,7 +81,7 @@ describe('ListBoxPortal', () => {
     test('should use provided "sessionModel"', async () => {
       const app = {};
       const options = { sessionModel: {} };
-      const elem = ListBoxPortal({ app, options });
+      const [elem] = ListBoxPortal({ app, options });
       await render(elem);
       expect(useExistingModel).toHaveBeenCalledWith({
         app,
@@ -95,7 +95,7 @@ describe('ListBoxPortal', () => {
     test('should create session model when providing field name', async () => {
       const fieldIdentifier = 'Alpha';
       const app = {};
-      const elem = ListBoxPortal({ app, fieldIdentifier });
+      const [elem] = ListBoxPortal({ app, fieldIdentifier });
       await render(elem);
       expect(useOnTheFlyModelMock).toHaveBeenCalledWith({
         app,
@@ -110,7 +110,7 @@ describe('ListBoxPortal', () => {
     test('should create session model when providing qLibraryId', async () => {
       const fieldIdentifier = { qLibraryId: '123' };
       const app = {};
-      const elem = ListBoxPortal({ app, fieldIdentifier });
+      const [elem] = ListBoxPortal({ app, fieldIdentifier });
       await render(elem);
       expect(useOnTheFlyModelMock).toHaveBeenCalledWith({
         app,
@@ -131,7 +131,7 @@ describe('ListBoxPortal', () => {
       const elementRef = {
         current: undefined,
       };
-      const elem = ListBoxPortal({ app, fieldIdentifier, options });
+      const [elem] = ListBoxPortal({ app, fieldIdentifier, options });
       await render(elem);
       expect(useObjectSelectionsMock).toHaveBeenCalledWith(
         app,
@@ -155,7 +155,7 @@ describe('ListBoxPortal', () => {
         model: {},
         selections: notUsedSelectionsApi,
       };
-      const elem = ListBoxPortal({ app, fieldIdentifier, options });
+      const [elem] = ListBoxPortal({ app, fieldIdentifier, options });
       await render(elem);
       expect(ListBoxInlineMock).toHaveBeenCalledWith(
         {
@@ -220,7 +220,7 @@ describe('ListBoxPortal', () => {
         model: {},
         frequencyMode: 'percent',
       };
-      const elem = ListBoxPortal({ app, fieldIdentifier, options });
+      const [elem] = ListBoxPortal({ app, fieldIdentifier, options });
       await render(elem);
       expect(ListBoxInlineMock.mock.calls[0][0]).toMatchObject(
         {

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -550,7 +550,7 @@ function nuked(configuration = {}) {
             const onSelectionDeactivated = () => fieldSels.emit('selectionDeactivated');
 
             return new Promise((resolve) => {
-              this._instance = ListBoxPortal({
+              [this._instance, this._ref] = ListBoxPortal({
                 element,
                 app,
                 fieldIdentifier,
@@ -578,6 +578,19 @@ function nuked(configuration = {}) {
             if (this._instance) {
               root.remove(this._instance);
               this._instance = null;
+              this._ref = null;
+            }
+          },
+          options(opts) {
+            const onSelectionActivated = () => fieldSels.emit('selectionActivated');
+            const onSelectionDeactivated = () => fieldSels.emit('selectionDeactivated');
+            if (this._ref?.current) {
+              const options = getListboxPortalOptions({
+                onSelectionActivated,
+                onSelectionDeactivated,
+                ...opts,
+              });
+              this._ref.current.setOptions(options);
             }
           },
         };


### PR DESCRIPTION
add method for updating options on a listbox/field similar to already existing method on viz

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

to be used in filter pane to update components options (styling) when changed (without delete and create a new listbox)

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
