### PR TITLE
feat: add direction to listboxPopover properties

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopover.jsx
@@ -50,6 +50,7 @@ export default function ListBoxPopover({
       qSortByLoadOrder: 1,
     },
   ],
+  direction = 'ltr',
 }) {
   const isMasterDim = Boolean(fieldName?.qLibraryId);
   const open = show && Boolean(alignTo.current);
@@ -153,9 +154,10 @@ export default function ListBoxPopover({
         },
       }}
       onKeyDown={(e) => (e.key === 'Enter' ? popoverClose(e) : undefined)}
+      direction={direction}
     >
       <Grid container direction="column" gap={0} ref={containerRef}>
-        <Grid item container style={{ padding: theme.spacing(1) }}>
+        <Grid item container style={{ direction, padding: theme.spacing(1) }}>
           <Grid item>
             {isLocked ? (
               <IconButton onClick={unlock} disabled={!isLocked} size="large">
@@ -210,6 +212,7 @@ export default function ListBoxPopover({
                 focusSelection: keyboard.focusSelection,
               }}
               autoFocus={autoFocus ?? true}
+              direction={direction}
             />
           </Grid>
           <ListBox
@@ -218,7 +221,7 @@ export default function ListBoxPopover({
             layout={layout}
             selections={selections}
             selectionState={selectionState}
-            direction="ltr"
+            direction={direction}
             onSetListCount={(c) => setListCount(c)}
             onCtrlF={onCtrlF}
             styles={styles}

--- a/apis/nucleus/src/components/listbox/ListBoxPopoverWrapper.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxPopoverWrapper.jsx
@@ -44,6 +44,7 @@ export default function ListBoxPopoverWrapper({ app, fieldIdentifier, stateName,
       autoFocus={options.autoFocus}
       components={options.components}
       sortCriteria={options.sortCriteria}
+      direction={options.direction}
     />
   );
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core


In this PR:
Regarding RTL improvement in sn-table, menu-list-search components should be reversed in RTL mode. To do so, direction as a new property has been added to ListboxPopover and the inner children such as Listbox.
The related PR in nebula-table can be found here: https://github.com/qlik-trial/nebula-tables/pull/897 
Feature Flag: CLIENT_IM_7150_TABLE_RTL. I have passed direction there to the Listboxpopover and without giving reference to that PR, you can't see the changes, so I attached a video to show how menu components are supposed to behave in RTL mode.

https://github.com/user-attachments/assets/6cf82793-9b1c-4378-9fa9-3bbe1c04e578
