### PR TITLE
fix: prefix from app list

### DIFF
--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -33,7 +33,7 @@ module.exports = async ({
 }) => {
   let config;
   let contentBase;
-  const HTTPS = serveConfig.mfe;
+  const HTTPS = serveConfig.mfe || serveConfig.https;
   const url = `${HTTPS ? 'https' : 'http'}://${host}:${port}`;
 
   if (HTTPS) {

--- a/commands/serve/web/__tests__/connect.test.js
+++ b/commands/serve/web/__tests__/connect.test.js
@@ -465,7 +465,7 @@ describe('connect.js', () => {
           appId: 'SOME_APP_ID/', // since there is an appid in link
           prefix: undefined,
         }),
-        engineUrl: expect.any(String),
+        engineUrl: `engine_url=wss://${authConfig.host}`,
         appUrl: url,
       });
     });
@@ -481,7 +481,7 @@ describe('connect.js', () => {
           appId: undefined,
           prefix: 'prefix',
         }),
-        engineUrl: expect.any(String),
+        engineUrl: `engine_url=wss://${authConfig.host}/prefix`,
         appUrl: undefined,
       });
     });
@@ -512,6 +512,38 @@ describe('connect.js', () => {
           prefix: undefined,
         }),
         engineUrl: expect.any(String),
+        appUrl: url,
+      });
+    });
+
+    test('should match localhost app correctly with prefix and port', () => {
+      url = `wss://localhost:4455/prefix/app/SOME_APP_ID/`;
+      const result2 = parseEngineURL(url);
+      expect(result2).toMatchObject({
+        enigma: expect.objectContaining({
+          secure: expect.any(Boolean),
+          host: expect.any(String),
+          port: '4455', // because of providing a link
+          appId: 'SOME_APP_ID/', // since there is an appid in link
+          prefix: 'prefix',
+        }),
+        engineUrl: `wss://localhost:4455/prefix`,
+        appUrl: url,
+      });
+    });
+
+    test('should match localhost app correctly with prefix and no port', () => {
+      url = `wss://localhost/prefix/app/SOME_APP_ID/`;
+      const result2 = parseEngineURL(url);
+      expect(result2).toMatchObject({
+        enigma: expect.objectContaining({
+          secure: expect.any(Boolean),
+          host: expect.any(String),
+          port: undefined, // because of providing a link
+          appId: 'SOME_APP_ID/', // since there is an appid in link
+          prefix: 'prefix',
+        }),
+        engineUrl: `wss://localhost/prefix`,
         appUrl: url,
       });
     });

--- a/commands/serve/web/utils/__tests__/appLinkManager.test.js
+++ b/commands/serve/web/utils/__tests__/appLinkManager.test.js
@@ -27,6 +27,30 @@ describe('getAppLink()', () => {
     expect(navigate).toHaveBeenCalledWith(`/dev/engine_url=${info.engineUrl}/app/${targetApp}`);
   });
 
+  test('should call navigate to correct engine url from localhost without prefix', () => {
+    info = {
+      engineUrl: 'ws://localhost:1234',
+      enigma: { secure: false, host: 'localhost', port: 1234, prefix: undefined },
+    };
+    location.search = `engine_url=${info.engineUrl}`;
+    getAppLink({ navigate, location, info, targetApp });
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith(`/dev/engine_url=${info.engineUrl}/app/${targetApp}`);
+  });
+
+  test('should call navigate to correct engine url with prefix', () => {
+    info = {
+      engineUrl: 'ws://localhost:1234/prefix',
+      enigma: { secure: false, host: 'localhost', port: 1234, prefix: 'prefix' },
+    };
+    location.search = `engine_url=${info.engineUrl}`;
+    getAppLink({ navigate, location, info, targetApp });
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith(`/dev/engine_url=${info.engineUrl}/app/${targetApp}`);
+  });
+
   test('should call navigate to correct engine url from remote SDE', () => {
     info = {
       engineUrl: 'wss://some-remote.sde.in.eu.qlikdev.com',

--- a/commands/serve/web/utils/appLinkManager.js
+++ b/commands/serve/web/utils/appLinkManager.js
@@ -1,7 +1,9 @@
 export const getAppLink = ({ navigate, location, targetApp, info }) => {
   const { search } = location;
   const protocol = info.enigma.secure ? 'wss' : 'ws';
-  const host = info.enigma.host === 'localhost' ? `${info.enigma.host}:${info.enigma.port}` : info.enigma.host;
+  const port = info.enigma.port ? `:${info.enigma.port}` : '';
+  const prefix = info.enigma.prefix ? `/${info.enigma.prefix}` : '';
+  const host = (info.enigma.host === 'localhost' ? `${info.enigma.host}${port}` : info.enigma.host) + prefix;
   const newEngineUrl = `${protocol}://${host}/app/${encodeURIComponent(targetApp)}`;
   const modifiedEngineUrl = search.replace(info.engineUrl, newEngineUrl);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Makes sure the constructed URL from the app list contains the prefix

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
