### PR TITLE
feat: cell spacing based on theme

### DIFF
--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -18,6 +18,7 @@ import useObjectSelections from '../hooks/useObjectSelections';
 import eventmixin from '../selections/event-mixin';
 import useStyling from '../hooks/useStyling';
 import RenderError from '../utils/render-error';
+import getPadding from '../utils/cell-padding';
 
 /**
  * @interface
@@ -538,6 +539,15 @@ const Cell = forwardRef(
       );
     }
 
+    const { cellPadding, bodyPadding } = getPadding({
+      disableCellPadding,
+      halo,
+      layout,
+      isError: state.error,
+      theme,
+      titleStyles,
+    });
+
     return (
       <Paper
         style={{
@@ -571,7 +581,7 @@ const Cell = forwardRef(
             position: 'relative',
             width: '100%',
             height: '100%',
-            ...(!disableCellPadding ? { padding: theme.spacing(1) } : {}),
+            ...(cellPadding ? { padding: cellPadding } : {}),
             ...(state.longRunningQuery ? { opacity: '0.3' } : {}),
           }}
         >
@@ -594,6 +604,7 @@ const Cell = forwardRef(
             xs
             style={{
               height: '100%',
+              ...(bodyPadding ? { padding: bodyPadding } : {}),
             }}
             ref={contentRef}
           >

--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -29,6 +29,15 @@ const CellElement = {
   className: 'njs-cell',
 };
 
+/**
+ * @interface
+ * @extends HTMLElement
+ */
+const CellBody = {
+  /** @type {'njs-cell-body'} */
+  className: 'njs-cell-body',
+};
+
 const initialState = (err) => ({
   loading: false,
   loaded: false,
@@ -613,6 +622,7 @@ const Cell = forwardRef(
             onKeyDown={keyboardNavigation ? handleKeyDown : null}
             item
             xs
+            className={CellBody.className}
             style={{
               height: '100%',
               ...(bodyPadding ? { padding: bodyPadding } : {}),

--- a/apis/nucleus/src/components/Cell.jsx
+++ b/apis/nucleus/src/components/Cell.jsx
@@ -539,14 +539,25 @@ const Cell = forwardRef(
       );
     }
 
-    const { cellPadding, bodyPadding } = getPadding({
-      disableCellPadding,
-      halo,
-      layout,
-      isError: state.error,
-      theme,
-      titleStyles,
-    });
+    const flags = halo.public.galaxy?.flags;
+    let useOldCellPadding;
+    let bodyPadding;
+    if (disableCellPadding) {
+      useOldCellPadding = false;
+      bodyPadding = undefined;
+    } else if (!flags?.isEnabled('VNA-13_CELLPADDING_FROM_THEME')) {
+      useOldCellPadding = true;
+      bodyPadding = undefined;
+    } else {
+      const senseTheme = halo.public.theme;
+      useOldCellPadding = false;
+      bodyPadding = getPadding({
+        layout,
+        isError: state.error,
+        senseTheme,
+        titleStyles,
+      });
+    }
 
     return (
       <Paper
@@ -581,7 +592,7 @@ const Cell = forwardRef(
             position: 'relative',
             width: '100%',
             height: '100%',
-            ...(cellPadding ? { padding: cellPadding } : {}),
+            ...(useOldCellPadding ? { padding: theme.spacing(1) } : {}),
             ...(state.longRunningQuery ? { opacity: '0.3' } : {}),
           }}
         >

--- a/apis/nucleus/src/components/Sheet.jsx
+++ b/apis/nucleus/src/components/Sheet.jsx
@@ -19,11 +19,16 @@ const SheetElement = {
 
 function getCellRenderer(cell, halo, initialSnOptions, initialSnPlugins, initialError, onMount, navigation, onError) {
   const { x, y, width, height } = cell.bounds;
+
+  const style = { left: `${x}%`, top: `${y}%`, width: `${width}%`, height: `${height}%`, position: 'absolute' };
+  const flags = halo.public.galaxy?.flags;
+  if (flags?.isEnabled('VNA-13_CELLPADDING_FROM_THEME')) {
+    style.boxSizing = 'border-box';
+    style.padding = '4px';
+  }
+
   return (
-    <div
-      style={{ left: `${x}%`, top: `${y}%`, width: `${width}%`, height: `${height}%`, position: 'absolute' }}
-      key={cell.model.id}
-    >
+    <div style={style} key={cell.model.id}>
       <Cell
         ref={cell.cellRef}
         halo={halo}

--- a/apis/nucleus/src/utils/__tests__/cell-padding.test.js
+++ b/apis/nucleus/src/utils/__tests__/cell-padding.test.js
@@ -1,0 +1,179 @@
+import getPadding from '../cell-padding';
+
+describe('cell padding', () => {
+  let testFn;
+  let titleStyles;
+
+  beforeEach(() => {
+    titleStyles = {
+      main: {},
+      subTitle: {},
+      footer: {},
+    };
+    testFn = ({
+      flagOn,
+      disableCellPadding = false,
+      cardTheme = false,
+      isError = false,
+      showTitles = false,
+      title = false,
+      subtitle = false,
+      footer = false,
+      visualization = 'barchart',
+    }) => {
+      const halo = {
+        public: {
+          galaxy: {
+            flags: {
+              isEnabled: () => flagOn,
+            },
+          },
+          theme: {
+            getStyle: () => (cardTheme ? true : undefined),
+          },
+        },
+      };
+      const layout = {
+        showTitles,
+        title: title ? 'yes' : '',
+        subtitle: subtitle ? 'yes' : '',
+        footnote: footer ? 'yes' : '',
+        visualization,
+      };
+      const theme = {
+        spacing: (n) => `theme.spacing(${n})`,
+      };
+      return getPadding({ disableCellPadding, halo, layout, isError, theme, titleStyles });
+    };
+  });
+
+  test('should default to theme.spacing() without flag', () => {
+    const { cellPadding, bodyPadding } = testFn({ flagOn: false });
+    expect(cellPadding).toBe('theme.spacing(1)');
+    expect(bodyPadding).toBeUndefined();
+  });
+
+  test('disableCellPadding true return undefined', () => {
+    const { cellPadding, bodyPadding } = testFn({ disableCellPadding: true });
+    expect(cellPadding).toBeUndefined();
+    expect(bodyPadding).toBeUndefined();
+  });
+
+  test('not card theme return undefined', () => {
+    const { cellPadding, bodyPadding } = testFn({ flagOn: true, cardTheme: false });
+    expect(cellPadding).toBeUndefined();
+    expect(bodyPadding).toBeUndefined();
+  });
+
+  test('card theme return bodyPadding', () => {
+    const { cellPadding, bodyPadding } = testFn({ flagOn: true, cardTheme: true });
+    expect(cellPadding).toBeUndefined();
+    expect(bodyPadding).toBe('10px 10px 5px');
+  });
+
+  test('card theme with title, subtitel & footer should update titleStyles', () => {
+    const { cellPadding, bodyPadding } = testFn({
+      flagOn: true,
+      cardTheme: true,
+      showTitles: true,
+      title: true,
+      subtitle: true,
+      footer: true,
+    });
+    expect(cellPadding).toBeUndefined();
+    expect(bodyPadding).toBe('0 10px 0');
+    expect(titleStyles.main.padding).toBe('10px 10px 0');
+    expect(titleStyles.subTitle.padding).toBe('0 10px');
+    expect(titleStyles.footer.padding).toBe('6px 10px');
+    expect(titleStyles.footer.borderTop).toBe('1px solid #d9d9d9');
+  });
+
+  test('card theme with only subtitel', () => {
+    const { cellPadding, bodyPadding } = testFn({
+      flagOn: true,
+      cardTheme: true,
+      showTitles: true,
+      subtitle: true,
+    });
+    expect(cellPadding).toBeUndefined();
+    expect(bodyPadding).toBe('0 10px 5px');
+    expect(titleStyles.main.padding).toBeUndefined();
+    expect(titleStyles.subTitle.padding).toBe('10px 10px 0');
+    expect(titleStyles.footer.padding).toBeUndefined();
+    expect(titleStyles.footer.borderTop).toBeUndefined();
+  });
+
+  test('card theme with only footer', () => {
+    const { cellPadding, bodyPadding } = testFn({
+      flagOn: true,
+      cardTheme: true,
+      showTitles: true,
+      footer: true,
+    });
+    expect(cellPadding).toBeUndefined();
+    expect(bodyPadding).toBe('10px 10px 0');
+    expect(titleStyles.main.padding).toBeUndefined();
+    expect(titleStyles.subTitle.padding).toBeUndefined();
+    expect(titleStyles.footer.padding).toBe('6px 10px');
+    expect(titleStyles.footer.borderTop).toBe('1px solid #d9d9d9');
+  });
+
+  test('card theme with sn-filter-pane visualization type the do not include padding', () => {
+    const { cellPadding, bodyPadding } = testFn({
+      flagOn: true,
+      cardTheme: true,
+      visualization: 'sn-filter-pane',
+    });
+    expect(cellPadding).toBeUndefined();
+    expect(bodyPadding).toBeUndefined();
+  });
+
+  test('card theme with action-button visualization do not include padding', () => {
+    const { cellPadding, bodyPadding } = testFn({
+      flagOn: true,
+      cardTheme: true,
+      visualization: 'action-button',
+    });
+    expect(cellPadding).toBeUndefined();
+    expect(bodyPadding).toBeUndefined();
+  });
+
+  test('card theme with action-button visualization do include padding if showTitels is true', () => {
+    const { cellPadding, bodyPadding } = testFn({
+      flagOn: true,
+      cardTheme: true,
+      visualization: 'action-button',
+      showTitles: true,
+    });
+    expect(cellPadding).toBeUndefined();
+    expect(bodyPadding).toBe('10px 10px 5px');
+  });
+
+  test('card theme with sn-filter-pane visualization type the do include footer styling', () => {
+    const { cellPadding, bodyPadding } = testFn({
+      flagOn: true,
+      cardTheme: true,
+      visualization: 'sn-filter-pane',
+      showTitles: true,
+      footer: true,
+    });
+    expect(cellPadding).toBeUndefined();
+    expect(bodyPadding).toBeUndefined();
+    expect(titleStyles.footer.padding).toBe('6px 10px');
+    expect(titleStyles.footer.borderTop).toBe('1px solid #d9d9d9');
+  });
+
+  test('not card theme with sn-filter-pane visualization', () => {
+    const { cellPadding, bodyPadding } = testFn({
+      flagOn: true,
+      cardTheme: false,
+      visualization: 'sn-filter-pane',
+      showTitles: true,
+      footer: true,
+    });
+    expect(cellPadding).toBeUndefined();
+    expect(bodyPadding).toBeUndefined();
+    expect(titleStyles.footer.padding).toBeUndefined();
+    expect(titleStyles.footer.borderTop).toBeUndefined();
+  });
+});

--- a/apis/nucleus/src/utils/__tests__/cell-padding.test.js
+++ b/apis/nucleus/src/utils/__tests__/cell-padding.test.js
@@ -11,8 +11,6 @@ describe('cell padding', () => {
       footer: {},
     };
     testFn = ({
-      flagOn,
-      disableCellPadding = false,
       cardTheme = false,
       isError = false,
       showTitles = false,
@@ -21,17 +19,8 @@ describe('cell padding', () => {
       footer = false,
       visualization = 'barchart',
     }) => {
-      const halo = {
-        public: {
-          galaxy: {
-            flags: {
-              isEnabled: () => flagOn,
-            },
-          },
-          theme: {
-            getStyle: () => (cardTheme ? true : undefined),
-          },
-        },
+      const senseTheme = {
+        getStyle: () => (cardTheme ? true : undefined),
       };
       const layout = {
         showTitles,
@@ -40,47 +29,28 @@ describe('cell padding', () => {
         footnote: footer ? 'yes' : '',
         visualization,
       };
-      const theme = {
-        spacing: (n) => `theme.spacing(${n})`,
-      };
-      return getPadding({ disableCellPadding, halo, layout, isError, theme, titleStyles });
+      return getPadding({ layout, isError, senseTheme, titleStyles });
     };
   });
 
-  test('should default to theme.spacing() without flag', () => {
-    const { cellPadding, bodyPadding } = testFn({ flagOn: false });
-    expect(cellPadding).toBe('theme.spacing(1)');
-    expect(bodyPadding).toBeUndefined();
-  });
-
-  test('disableCellPadding true return undefined', () => {
-    const { cellPadding, bodyPadding } = testFn({ disableCellPadding: true });
-    expect(cellPadding).toBeUndefined();
-    expect(bodyPadding).toBeUndefined();
-  });
-
   test('not card theme return undefined', () => {
-    const { cellPadding, bodyPadding } = testFn({ flagOn: true, cardTheme: false });
-    expect(cellPadding).toBeUndefined();
+    const bodyPadding = testFn({ cardTheme: false });
     expect(bodyPadding).toBeUndefined();
   });
 
   test('card theme return bodyPadding', () => {
-    const { cellPadding, bodyPadding } = testFn({ flagOn: true, cardTheme: true });
-    expect(cellPadding).toBeUndefined();
+    const bodyPadding = testFn({ cardTheme: true });
     expect(bodyPadding).toBe('10px 10px 5px');
   });
 
   test('card theme with title, subtitel & footer should update titleStyles', () => {
-    const { cellPadding, bodyPadding } = testFn({
-      flagOn: true,
+    const bodyPadding = testFn({
       cardTheme: true,
       showTitles: true,
       title: true,
       subtitle: true,
       footer: true,
     });
-    expect(cellPadding).toBeUndefined();
     expect(bodyPadding).toBe('0 10px 0');
     expect(titleStyles.main.padding).toBe('10px 10px 0');
     expect(titleStyles.subTitle.padding).toBe('0 10px');
@@ -89,13 +59,11 @@ describe('cell padding', () => {
   });
 
   test('card theme with only subtitel', () => {
-    const { cellPadding, bodyPadding } = testFn({
-      flagOn: true,
+    const bodyPadding = testFn({
       cardTheme: true,
       showTitles: true,
       subtitle: true,
     });
-    expect(cellPadding).toBeUndefined();
     expect(bodyPadding).toBe('0 10px 5px');
     expect(titleStyles.main.padding).toBeUndefined();
     expect(titleStyles.subTitle.padding).toBe('10px 10px 0');
@@ -104,13 +72,11 @@ describe('cell padding', () => {
   });
 
   test('card theme with only footer', () => {
-    const { cellPadding, bodyPadding } = testFn({
-      flagOn: true,
+    const bodyPadding = testFn({
       cardTheme: true,
       showTitles: true,
       footer: true,
     });
-    expect(cellPadding).toBeUndefined();
     expect(bodyPadding).toBe('10px 10px 0');
     expect(titleStyles.main.padding).toBeUndefined();
     expect(titleStyles.subTitle.padding).toBeUndefined();
@@ -119,59 +85,49 @@ describe('cell padding', () => {
   });
 
   test('card theme with sn-filter-pane visualization type the do not include padding', () => {
-    const { cellPadding, bodyPadding } = testFn({
-      flagOn: true,
+    const bodyPadding = testFn({
       cardTheme: true,
       visualization: 'sn-filter-pane',
     });
-    expect(cellPadding).toBeUndefined();
     expect(bodyPadding).toBeUndefined();
   });
 
   test('card theme with action-button visualization do not include padding', () => {
-    const { cellPadding, bodyPadding } = testFn({
-      flagOn: true,
+    const bodyPadding = testFn({
       cardTheme: true,
       visualization: 'action-button',
     });
-    expect(cellPadding).toBeUndefined();
     expect(bodyPadding).toBeUndefined();
   });
 
   test('card theme with action-button visualization do include padding if showTitels is true', () => {
-    const { cellPadding, bodyPadding } = testFn({
-      flagOn: true,
+    const bodyPadding = testFn({
       cardTheme: true,
       visualization: 'action-button',
       showTitles: true,
     });
-    expect(cellPadding).toBeUndefined();
     expect(bodyPadding).toBe('10px 10px 5px');
   });
 
   test('card theme with sn-filter-pane visualization type the do include footer styling', () => {
-    const { cellPadding, bodyPadding } = testFn({
-      flagOn: true,
+    const bodyPadding = testFn({
       cardTheme: true,
       visualization: 'sn-filter-pane',
       showTitles: true,
       footer: true,
     });
-    expect(cellPadding).toBeUndefined();
     expect(bodyPadding).toBeUndefined();
     expect(titleStyles.footer.padding).toBe('6px 10px');
     expect(titleStyles.footer.borderTop).toBe('1px solid #d9d9d9');
   });
 
   test('not card theme with sn-filter-pane visualization', () => {
-    const { cellPadding, bodyPadding } = testFn({
-      flagOn: true,
+    const bodyPadding = testFn({
       cardTheme: false,
       visualization: 'sn-filter-pane',
       showTitles: true,
       footer: true,
     });
-    expect(cellPadding).toBeUndefined();
     expect(bodyPadding).toBeUndefined();
     expect(titleStyles.footer.padding).toBeUndefined();
     expect(titleStyles.footer.borderTop).toBeUndefined();

--- a/apis/nucleus/src/utils/cell-padding.js
+++ b/apis/nucleus/src/utils/cell-padding.js
@@ -1,0 +1,82 @@
+const NP_PADDINH_IN_CARDS_WITHOUT_TITLE = ['action-button', 'sn-nav-menu'];
+const NO_PADDING_IN_CARDS = [
+  'pivot-table',
+  'table',
+  'sn-table',
+  'sn-pivot-table',
+  'kpi',
+  'map',
+  'filterpane',
+  'sn-calendar',
+  'sn-filter-pane',
+  'sn-layout-container',
+  'sn-listbox',
+  'sn-shape',
+  'sn-tabbed-container',
+];
+
+const shouldUseCardPadding = ({ isCardTheme, layout, isError }) => {
+  const visualization = layout?.visualization;
+
+  if (!isCardTheme) {
+    return false;
+  }
+  if (isError) {
+    return true;
+  }
+
+  if (NO_PADDING_IN_CARDS.indexOf(visualization) !== -1) {
+    return false;
+  }
+  const showTitle = layout?.showTitles;
+  if (!showTitle && NP_PADDINH_IN_CARDS_WITHOUT_TITLE.indexOf(visualization) !== -1) {
+    return false;
+  }
+  return true;
+};
+
+const getPadding = ({ disableCellPadding, halo, layout, isError, theme, titleStyles }) => {
+  const flags = halo.public.galaxy?.flags;
+  const senseTheme = halo.public.theme;
+
+  if (disableCellPadding) {
+    return { cellPadding: undefined, bodyPadding: undefined };
+  }
+
+  if (!flags?.isEnabled('VNA-13_CELLPADDING_FROM_THEME')) {
+    return { cellPadding: theme.spacing(1), bodyPadding: undefined };
+  }
+
+  const isCardTheme = senseTheme?.getStyle('', '', '_cards');
+  const cardPadding = shouldUseCardPadding({ isCardTheme, layout, isError });
+  if (isCardTheme) {
+    const showTitle = layout?.showTitles && !!layout?.title;
+    const showSubtitle = layout?.showTitles && !!layout?.subtitle;
+    const showFootnote = layout?.showTitles && !!layout?.footnote;
+
+    if (showTitle && cardPadding) {
+      // eslint-disable-next-line no-param-reassign
+      titleStyles.main.padding = '10px 10px 0';
+    }
+    if (showSubtitle && cardPadding) {
+      // eslint-disable-next-line no-param-reassign
+      titleStyles.subTitle.padding = showTitle ? '0 10px' : '10px 10px 0';
+    }
+    if (showFootnote) {
+      // eslint-disable-next-line no-param-reassign
+      titleStyles.footer.borderTop = '1px solid #d9d9d9';
+      // eslint-disable-next-line no-param-reassign
+      titleStyles.footer.padding = '6px 10px';
+    }
+
+    let bodyPadding;
+    if (cardPadding) {
+      bodyPadding = `${showTitle || showSubtitle ? '0' : '10px'} 10px ${showFootnote ? '0' : '5px'}`;
+    }
+
+    return { cellPadding: undefined, bodyPadding };
+  }
+  return { cellPadding: undefined, bodyPadding: undefined };
+};
+
+export default getPadding;

--- a/apis/nucleus/src/utils/cell-padding.js
+++ b/apis/nucleus/src/utils/cell-padding.js
@@ -35,18 +35,7 @@ const shouldUseCardPadding = ({ isCardTheme, layout, isError }) => {
   return true;
 };
 
-const getPadding = ({ disableCellPadding, halo, layout, isError, theme, titleStyles }) => {
-  const flags = halo.public.galaxy?.flags;
-  const senseTheme = halo.public.theme;
-
-  if (disableCellPadding) {
-    return { cellPadding: undefined, bodyPadding: undefined };
-  }
-
-  if (!flags?.isEnabled('VNA-13_CELLPADDING_FROM_THEME')) {
-    return { cellPadding: theme.spacing(1), bodyPadding: undefined };
-  }
-
+const getPadding = ({ layout, isError, senseTheme, titleStyles }) => {
   const isCardTheme = senseTheme?.getStyle('', '', '_cards');
   const cardPadding = shouldUseCardPadding({ isCardTheme, layout, isError });
   if (isCardTheme) {
@@ -74,9 +63,9 @@ const getPadding = ({ disableCellPadding, halo, layout, isError, theme, titleSty
       bodyPadding = `${showTitle || showSubtitle ? '0' : '10px'} 10px ${showFootnote ? '0' : '5px'}`;
     }
 
-    return { cellPadding: undefined, bodyPadding };
+    return bodyPadding;
   }
-  return { cellPadding: undefined, bodyPadding: undefined };
+  return undefined;
 };
 
 export default getPadding;

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -2079,6 +2079,20 @@
         }
       }
     },
+    "CellBody": {
+      "extends": [
+        {
+          "type": "HTMLElement"
+        }
+      ],
+      "kind": "interface",
+      "entries": {
+        "className": {
+          "value": "'njs-cell-body'",
+          "kind": "literal"
+        }
+      }
+    },
     "CellFooter": {
       "availability": {
         "since": "2.0.0"

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -657,6 +657,10 @@ declare namespace stardust {
         className: "njs-cell";
     }
 
+    interface CellBody extends HTMLElement{
+        className: "njs-cell-body";
+    }
+
     interface CellFooter extends HTMLElement{
         className: "njs-cell-footer";
     }


### PR DESCRIPTION
when feature flag (VNA-13_CELLPADDING_FROM_THEME) is on set cell padding depending on if the sense theme is card or not. and add footer divider for card themes

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
