### PR TITLE
feat: expose ext on generator

### DIFF
--- a/apis/supernova/src/generator.js
+++ b/apis/supernova/src/generator.js
@@ -64,6 +64,10 @@ export default function generatorFn(UserSN, galaxy) {
      */
     component: sn.component || {},
     /**
+     * @type {EXT}
+     */
+    ext: sn.ext,
+    /**
      * @param {object} p
      * @param {EnigmaAppModel} p.app
      * @param {EnigmaObjectModel} p.model


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Exposes the EXT object on generator to allow for better extension loading.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
