### PR TITLE
fix: detach selection toolbar from title

### DIFF
--- a/apis/nucleus/src/components/Header.jsx
+++ b/apis/nucleus/src/components/Header.jsx
@@ -4,7 +4,6 @@ import { styled } from '@mui/material/styles';
 
 import { Grid, Tooltip, Typography } from '@mui/material';
 import ActionsToolbar from './ActionsToolbar';
-import useRect from '../hooks/useRect';
 
 const PREFIX = 'Header';
 
@@ -22,12 +21,6 @@ const StyledGrid = styled(Grid)(({ theme }) => ({
     paddingBottom: theme.spacing(1),
   },
 }));
-
-const ITEM_WIDTH = 32;
-const ITEM_SPACING = 4;
-const DIVIDER = 1;
-const NUMBER_OF_ITEMS = 6;
-const MIN_WIDTH = (ITEM_WIDTH + ITEM_SPACING) * NUMBER_OF_ITEMS + DIVIDER + ITEM_SPACING;
 
 /**
  * @interface
@@ -55,9 +48,6 @@ function Header({ layout, sn, anchorEl, hovering, focusHandler, titleStyles = {}
   const showInSelectionActions = layout.qSelectionInfo && layout.qSelectionInfo.qInSelections;
   const [actions, setActions] = useState([]);
 
-  const [containerRef, containerRect] = useRect();
-  const [shouldShowPopoverToolbar, setShouldShowPopoverToolbar] = useState(false);
-
   useEffect(() => {
     if (!sn || !sn.component || !sn.component.isHooked) {
       return;
@@ -67,20 +57,10 @@ function Header({ layout, sn, anchorEl, hovering, focusHandler, titleStyles = {}
     });
   }, [sn]);
 
-  useEffect(() => {
-    if (!containerRect) return;
-    const { width } = containerRect;
-    setShouldShowPopoverToolbar(width < MIN_WIDTH);
-  }, [containerRect]);
-
-  const showTitles = showTitle || showSubtitle;
-  const cls = [classes.containerStyle, ...(showTitles ? [classes.containerTitleStyle] : [])];
-  const showPopoverToolbar = (hovering || showInSelectionActions) && (shouldShowPopoverToolbar || !showTitles);
-  const showToolbar = showTitles && !showPopoverToolbar && !shouldShowPopoverToolbar;
+  const showPopoverToolbar = hovering || showInSelectionActions;
 
   const Toolbar = (
     <ActionsToolbar
-      show={showToolbar}
       selections={{
         show: showInSelectionActions,
         api: sn.component.selections,
@@ -94,7 +74,7 @@ function Header({ layout, sn, anchorEl, hovering, focusHandler, titleStyles = {}
   );
 
   return (
-    <StyledGrid ref={containerRef} item container wrap="nowrap" className={cls.join(' ')}>
+    <StyledGrid item container wrap="nowrap" className={classes.containerStyle}>
       <Grid item zeroMinWidth xs>
         <Grid container wrap="nowrap" direction="column">
           {showTitle && (

--- a/apis/nucleus/src/components/Header.jsx
+++ b/apis/nucleus/src/components/Header.jsx
@@ -63,6 +63,7 @@ function Header({ layout, sn, anchorEl, hovering, focusHandler, titleStyles = {}
 
   const Toolbar = (
     <ActionsToolbar
+      show={false}
       selections={{
         show: showInSelectionActions,
         api: sn.component.selections,

--- a/apis/nucleus/src/components/Header.jsx
+++ b/apis/nucleus/src/components/Header.jsx
@@ -57,6 +57,8 @@ function Header({ layout, sn, anchorEl, hovering, focusHandler, titleStyles = {}
     });
   }, [sn]);
 
+  const showTitles = showTitle || showSubtitle;
+  const cls = [classes.containerStyle, ...(showTitles ? [classes.containerTitleStyle] : [])];
   const showPopoverToolbar = hovering || showInSelectionActions;
 
   const Toolbar = (
@@ -74,7 +76,7 @@ function Header({ layout, sn, anchorEl, hovering, focusHandler, titleStyles = {}
   );
 
   return (
-    <StyledGrid item container wrap="nowrap" className={classes.containerStyle}>
+    <StyledGrid item container wrap="nowrap" className={cls.join(' ')}>
       <Grid item zeroMinWidth xs>
         <Grid container wrap="nowrap" direction="column">
           {showTitle && (


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Previously selection toolbar is inline with title when

- Has chart title or chart subtitle
- and chart width is more than 221 px

Which causing chart area jumping when enter and exit selection mode. Original implementation PR https://github.com/qlik-oss/nebula.js/pull/401.

The fix is detaching selection toolbar from title, always show as a popover. Also make it as same behaviour with classic chart in sense client. (The selection popover top position is slightly different than classic chart selection popover, I think is acceptable).
Tested header of listbox works as before, didn't affected by this change.

<img width="874" alt="Screenshot 2025-03-31 at 10 05 44" src="https://github.com/user-attachments/assets/5dd9b441-8d66-4cdf-9e7e-0f1bae85c8cf" />


**Before fix nebula chart:**

https://github.com/user-attachments/assets/cb0226f2-6f3d-456a-aed4-c721acc92b71

**After fix nebula chart:**

https://github.com/user-attachments/assets/1c309643-8345-4d23-8fd3-677524899b59

**Classic chart**

https://github.com/user-attachments/assets/ff6253d5-a1a6-43c6-8202-cd2501b5a1f9


## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
