### PR TITLE
chore: add emitter to sheet Cell

### DIFF
--- a/apis/nucleus/src/components/Sheet.jsx
+++ b/apis/nucleus/src/components/Sheet.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useContext, useMemo, forwardRef, useImperativeHandle, useRef } from 'react';
+import EventEmitter from 'node-event-emitter';
 import useLayout from '../hooks/useLayout';
 import getObject from '../object/get-object';
 import Cell from './Cell';
@@ -27,6 +28,8 @@ function getCellRenderer(cell, halo, initialSnOptions, initialSnPlugins, initial
     style.padding = '4px';
   }
 
+  const emitter = new EventEmitter();
+
   return (
     <div style={style} key={cell.model.id}>
       <Cell
@@ -38,6 +41,7 @@ function getCellRenderer(cell, halo, initialSnOptions, initialSnPlugins, initial
         initialSnPlugins={initialSnPlugins}
         initialError={initialError}
         onMount={onMount}
+        emitter={emitter}
         navigation={navigation}
         onError={onError}
       />


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Emitter needs to be defined even on sheets to exits for charts that use it, even if it isn't exposed through the Sheet api.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
