### PR TITLE
revert: react-virtualized-auto-sizer and ignore version updates

### DIFF
--- a/apis/nucleus/package.json
+++ b/apis/nucleus/package.json
@@ -21,7 +21,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-test-renderer": "18.3.1",
-    "react-virtualized-auto-sizer": "1.0.26",
+    "react-virtualized-auto-sizer": "1.0.25",
     "react-window": "1.8.11",
     "react-window-infinite-loader": "1.0.10",
     "semver": "7.7.1"

--- a/apis/stardust/package.json
+++ b/apis/stardust/package.json
@@ -61,7 +61,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-test-renderer": "18.3.1",
-    "react-virtualized-auto-sizer": "1.0.26",
+    "react-virtualized-auto-sizer": "1.0.25",
     "react-window": "1.8.11",
     "react-window-infinite-loader": "1.0.10",
     "regenerator-runtime": "0.14.1",

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "circleci": {
     "ignoreDeps": []
   },
+  "ignoreDeps": ["react-virtualized-auto-sizer"],
   "semanticCommits": true,
   "rangeStrategy": "bump",
   "packageRules": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -14826,10 +14826,10 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-virtualized-auto-sizer@1.0.26:
-  version "1.0.26"
-  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz#e9470ef6a778dc4f1d5fd76305fa2d8b610c357a"
-  integrity sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==
+react-virtualized-auto-sizer@1.0.25:
+  version "1.0.25"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.25.tgz#b13cbc528ac200be2bd1ffa40c8bb19bcc60ac3f"
+  integrity sha512-YHsksEGDfsHbHuaBVDYwJmcktblcHGafz4ZVuYPQYuSHMUGjpwmUCrAOcvMSGMwwk1eFWj1M/1GwYpNPuyhaBg==
 
 react-window-infinite-loader@1.0.10:
   version "1.0.10"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

The new auto-sizer version causes issues with the popover listbox, haven't been able to sort out how to resolve it so reverting and locking that version for now.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
