### PR TITLE
fix: cropped text issue in listbox disclaimer

### DIFF
--- a/apis/nucleus/src/components/listbox/components/ListBoxDisclaimer.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxDisclaimer.jsx
@@ -8,6 +8,7 @@ const StyledText = styled(Typography, { shouldForwardProp: (p) => !['width', 'de
     minWidth: `${width}px`,
     textAlign: 'center',
     fontSize: `${dense ? '12px' : '14px'}`,
+    whiteSpace: 'normal',
     ...(dense && {
       textOverflow: 'ellipsis',
       overflow: 'hidden',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

This PR fixes this internally reported bug. In short, the bug description is that the listbox disclaimer text gets cropped in selections tool. The videos shows before and after the fix. 

Before: 

https://github.com/user-attachments/assets/370ffe48-1b0b-4d14-b7ef-d2e4b9eb8761

After: 


https://github.com/user-attachments/assets/1789de9f-2b0a-4537-8edd-ad7236f20c4b


## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
