### PR TITLE
fix: allow for external focus management

### DIFF
--- a/apis/supernova/src/creator.js
+++ b/apis/supernova/src/creator.js
@@ -82,6 +82,7 @@ function createWithHooks(generator, opts, galaxy) {
       layout: {},
       appLayout: {},
       keyboardNavigation: opts.keyboardNavigation,
+      externalFocusManagement: opts.externalFocusManagement || false,
       focusHandler: opts.focusHandler,
       constraints: forcedConstraints,
       interactions: forcedInteractions,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

When rendering multiple Nebula instances then handling keyboard navigation between Cells needs to be done external to Nebula. The same applies if we need to move Cells around and control the navigation order.
We do need keyboardNavigation to be true, but we also need to disable Nebulas tabIndecies and keyboard handlers.

Additionally for viewData when setting an external blurHandler, we need to make sure it runs instead of the internal one that gets created as the chart model changes.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
