### PR TITLE
feat: add theme to galaxy and getPropertyPanelDefinition to viz

### DIFF
--- a/apis/nucleus/src/__tests__/nucleus.test.js
+++ b/apis/nucleus/src/__tests__/nucleus.test.js
@@ -26,7 +26,7 @@ describe('nucleus', () => {
     createObjectMock = jest.fn().mockReturnValue('created object');
     getObjectMock = jest.fn().mockReturnValue('got object');
     setThemeMock = jest.fn();
-    appThemeFnMock = jest.fn().mockReturnValue({ externalAPI: 'internal', setTheme: setThemeMock });
+    appThemeFnMock = jest.fn().mockReturnValue({ externalAPI: 'external', setTheme: setThemeMock });
     deviceTypeFnMock = jest.fn().mockReturnValue('desktop');
     rootAppMock = jest.fn().mockReturnValue([{}]);
     translatorAddMock = jest.fn();
@@ -127,6 +127,7 @@ describe('nucleus', () => {
         some: 'thing',
       },
       flags: 'flags',
+      theme: 'external',
       deviceType: 'desktop',
       hostConfig: 'HOST',
       translator,

--- a/apis/nucleus/src/__tests__/viz.test.js
+++ b/apis/nucleus/src/__tests__/viz.test.js
@@ -34,7 +34,7 @@ describe('viz', () => {
     setSnOptions = jest.fn();
     setSnContext = jest.fn();
     setSnPlugins = jest.fn();
-    getExtensionDefinition = jest.fn();
+    getExtensionDefinition = jest.fn().mockReturnValue({ definition: 'props' });
     setModel = jest.fn();
     takeSnapshot = jest.fn();
     exportImage = jest.fn();
@@ -79,7 +79,7 @@ describe('viz', () => {
       model,
       halo: {
         public: {},
-        config: { context: { dataViewType: 'sn-table' } },
+        context: { dataViewType: 'sn-table', enablePrivateExperimental: true },
         app: { createSessionObject: createSessionObjectMock, destroySessionObject: destroySessionObjectMock },
         types: { getSupportedVersion: () => true },
       },
@@ -280,6 +280,18 @@ describe('viz', () => {
       args.onInitialRender();
       const handle = await api.getImperativeHandle();
       expect(handle.api).toEqual('api');
+    });
+  });
+
+  describe('getPropertyPanelDefinition', () => {
+    test('should fetch the definition.ext.definition', async () => {
+      const opts = { myops: 'myopts', onInitialRender: jest.fn() };
+      api.__DO_NOT_USE__.options(opts);
+      await mounted;
+      const args = cellRef.current.setSnOptions.mock.lastCall[0];
+      args.onInitialRender();
+      const panelDef = api.getPropertyPanelDefinition();
+      expect(panelDef).toEqual('props');
     });
   });
 });

--- a/apis/nucleus/src/__tests__/viz.test.js
+++ b/apis/nucleus/src/__tests__/viz.test.js
@@ -29,12 +29,14 @@ describe('viz', () => {
 
   let mockElement;
 
+  let definitionName = 'props';
+
   beforeAll(() => {
     unmountMock = jest.fn();
     setSnOptions = jest.fn();
     setSnContext = jest.fn();
     setSnPlugins = jest.fn();
-    getExtensionDefinition = jest.fn().mockReturnValue({ definition: 'props' });
+    getExtensionDefinition = jest.fn().mockImplementation(() => ({ definition: { name: definitionName } }));
     setModel = jest.fn();
     takeSnapshot = jest.fn();
     exportImage = jest.fn();
@@ -291,7 +293,22 @@ describe('viz', () => {
       const args = cellRef.current.setSnOptions.mock.lastCall[0];
       args.onInitialRender();
       const panelDef = api.getPropertyPanelDefinition();
-      expect(panelDef).toEqual('props');
+      expect(panelDef.name).toEqual('props');
+    });
+
+    test('should return original after data view toggle the definition.ext.definition', async () => {
+      const opts = { myops: 'myopts', onInitialRender: jest.fn() };
+      api.__DO_NOT_USE__.options(opts);
+      await mounted;
+      const args = cellRef.current.setSnOptions.mock.lastCall[0];
+      args.onInitialRender();
+      let panelDef = api.getPropertyPanelDefinition();
+      expect(panelDef.name).toEqual('props');
+      definitionName = 'old';
+      await api.toggleDataView(); // locks in the "old" definition
+      definitionName = 'new';
+      panelDef = api.getPropertyPanelDefinition();
+      expect(panelDef.name).toEqual('old');
     });
   });
 });

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -237,6 +237,8 @@ function nuked(configuration = {}) {
       galaxy: /** @lends Galaxy */ {
         /** @type {Translator} */
         translator: locale.translator,
+        /** @type {Theme} */
+        theme: appTheme.externalAPI,
         // TODO - validate flags input
         /** @type {Flags} */
         flags: flagsFn(configuration.flags),

--- a/apis/nucleus/src/utils/escape-field.js
+++ b/apis/nucleus/src/utils/escape-field.js
@@ -1,13 +1,3 @@
-/**
- * Escape a script field name. Will add surrounding brackets if the field name contains special characters.
- * Examples:
- * Field1 -> Field1
- * My field -> [My field]
- * My] field -> [My]] field]
- *
- * @param field
- * @returns {*}
- */
 const escapeField = (field) => {
   if (!field || field === ']') {
     return field;

--- a/apis/nucleus/src/viz.js
+++ b/apis/nucleus/src/viz.js
@@ -104,6 +104,12 @@ export default function viz({
         }
         return false;
       },
+      getPropertyPanelDefinition() {
+        if (mountedReference && successfulRender) {
+          return originalExtensionDef ? originalExtensionDef.ext : cellRef.current.getExtensionDefinition().definition;
+        }
+        return false;
+      },
       toggleFocus(focus) {
         cellRef.current.toggleFocus(focus);
       },

--- a/apis/nucleus/src/viz.js
+++ b/apis/nucleus/src/viz.js
@@ -106,7 +106,9 @@ export default function viz({
       },
       getPropertyPanelDefinition() {
         if (mountedReference && successfulRender) {
-          return originalExtensionDef ? originalExtensionDef.ext : cellRef.current.getExtensionDefinition().definition;
+          return originalExtensionDef
+            ? originalExtensionDef.definition
+            : cellRef.current.getExtensionDefinition().definition;
         }
         return false;
       },
@@ -210,7 +212,7 @@ export default function viz({
     async toggleDataView(showDataView) {
       let newModel;
       if (!viewDataObjectId && showDataView !== false) {
-        let newType = halo.config.context.dataViewType;
+        let newType = halo.context.dataViewType;
         const oldProperties = await model.getEffectiveProperties();
         // Check if dataViewType is registered. Otherwise potentially fallback to table
         if (!halo.types.getSupportedVersion(newType)) {

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -801,6 +801,9 @@
         "translator": {
           "type": "#/definitions/Translator"
         },
+        "theme": {
+          "type": "#/definitions/Theme"
+        },
         "flags": {
           "type": "#/definitions/Flags"
         },
@@ -1727,6 +1730,33 @@
         }
       }
     },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
+    },
     "Field": {
       "kind": "alias",
       "items": {
@@ -1877,33 +1907,6 @@
           ]
         }
       }
-    },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
-      "kind": "interface",
-      "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
-              "type": "string"
-            }
-          }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
-        }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
     },
     "LoadType": {
       "kind": "interface",

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -274,6 +274,7 @@ declare namespace stardust {
 
     interface Galaxy {
         translator: stardust.Translator;
+        theme: stardust.Theme;
         flags: stardust.Flags;
         deviceType: string;
         hostConfig: object;
@@ -558,6 +559,16 @@ declare namespace stardust {
 
     }
 
+    /**
+     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
+     */
+    interface Plugin {
+        info: {
+            name: string;
+        };
+        fn: ()=>void;
+    }
+
     type Field = string | qix.NxDimension | qix.NxMeasure | stardust.LibraryField;
 
     /**
@@ -597,16 +608,6 @@ declare namespace stardust {
     interface LibraryField {
         qLibraryId: string;
         type: "dimension" | "measure";
-    }
-
-    /**
-     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
-     */
-    interface Plugin {
-        info: {
-            name: string;
-        };
-        fn: ()=>void;
     }
 
     interface LoadType {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Adds theme to the galaxy env which means we can get the same setup for property panel def in and out of client.
Adds getPropertyPanelDefinition to new viz APis.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
