### PR TITLE
fix: incorrect height setting

### DIFF
--- a/apis/nucleus/src/components/Sheet.jsx
+++ b/apis/nucleus/src/components/Sheet.jsx
@@ -194,7 +194,8 @@ const Sheet = forwardRef(
     - sheet exposed classnames for theming
   */
 
-    const height = !layout || Number.isNaN(layout.height) ? '100%' : `${Number(layout.height)}%`;
+    const height =
+      !layout || layout.height === undefined || Number.isNaN(layout.height) ? '100%' : `${Number(layout.height)}%`;
     const promises = cells.map((c) => c.mountedPromise);
     const ps = promises.filter((p) => !!p);
     if (ps.length) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Sheet breaks due to https://github.com/qlik-oss/nebula.js/pull/1733 coupled with the height check for the sheet.
It always got an undefined height first, which set the css to 100%, but then the Number.isNaN(layout.height) which is false for undefined broke it to NaN%. Browser still applied the old height.

With the new useLayout fallback to pure, we get a layout at first pass as it likely already exists, therefore the check resolves to Nan% to begin with.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
