### PR TITLE
fix: make layout timing match old setup

### DIFF
--- a/apis/nucleus/src/hooks/useLayout.js
+++ b/apis/nucleus/src/hooks/useLayout.js
@@ -2,7 +2,7 @@ import useRpc from './useRpc';
 
 export default function useLayout(model) {
   const [layout, { validating, canCancel, canRetry }, longrunning] = useRpc(model, 'getLayout');
-  if (model?.pureLayout) {
+  if (model?.pureLayout && layout) {
     return [model.pureLayout, { validating, canCancel, canRetry }, longrunning];
   }
   return [layout, { validating, canCancel, canRetry }, longrunning];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Due to a change in how the useLayout timing works we get some issues with the ListboxPopover. By checking that we actually get a layout back first we can ensure that the timing is the same and that the data is up to date.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
