### PR TITLE
fix: add return type for viz.destroy

### DIFF
--- a/apis/nucleus/src/viz.js
+++ b/apis/nucleus/src/viz.js
@@ -145,7 +145,7 @@ export default function viz({
     model,
     /**
      * Destroys the visualization and removes it from the the DOM.
-     * @returns {Promise<undefined>}
+     * @returns {Promise<void>}
      * @example
      * const viz = await embed(app).render({
      *   element,

--- a/apis/nucleus/src/viz.js
+++ b/apis/nucleus/src/viz.js
@@ -145,6 +145,7 @@ export default function viz({
     model,
     /**
      * Destroys the visualization and removes it from the the DOM.
+     * @returns {Promise<undefined>}
      * @example
      * const viz = await embed(app).render({
      *   element,

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1352,6 +1352,14 @@
           "description": "Destroys the visualization and removes it from the the DOM.",
           "kind": "function",
           "params": [],
+          "returns": {
+            "type": "Promise",
+            "generics": [
+              {
+                "type": "undefined"
+              }
+            ]
+          },
           "examples": [
             "const viz = await embed(app).render({\n  element,\n  id: 'abc'\n});\nviz.destroy();"
           ]
@@ -1730,6 +1738,33 @@
         }
       }
     },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
+    },
     "Field": {
       "kind": "alias",
       "items": {
@@ -1880,33 +1915,6 @@
           ]
         }
       }
-    },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
-      "kind": "interface",
-      "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
-              "type": "string"
-            }
-          }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
-        }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
     },
     "LoadType": {
       "kind": "interface",

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1356,7 +1356,7 @@
             "type": "Promise",
             "generics": [
               {
-                "type": "undefined"
+                "type": "void"
               }
             ]
           },

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -430,7 +430,7 @@ declare namespace stardust {
         /**
          * Destroys the visualization and removes it from the the DOM.
          */
-        destroy(): void;
+        destroy(): Promise<undefined>;
 
         /**
          * Converts the visualization to a different registered type.
@@ -559,6 +559,16 @@ declare namespace stardust {
 
     }
 
+    /**
+     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
+     */
+    interface Plugin {
+        info: {
+            name: string;
+        };
+        fn: ()=>void;
+    }
+
     type Field = string | qix.NxDimension | qix.NxMeasure | stardust.LibraryField;
 
     /**
@@ -598,16 +608,6 @@ declare namespace stardust {
     interface LibraryField {
         qLibraryId: string;
         type: "dimension" | "measure";
-    }
-
-    /**
-     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
-     */
-    interface Plugin {
-        info: {
-            name: string;
-        };
-        fn: ()=>void;
     }
 
     interface LoadType {

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -430,7 +430,7 @@ declare namespace stardust {
         /**
          * Destroys the visualization and removes it from the the DOM.
          */
-        destroy(): Promise<undefined>;
+        destroy(): Promise<void>;
 
         /**
          * Converts the visualization to a different registered type.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Adds correct return type to viz.destroy

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
