### PR TITLE
feat: allow mocking of getListObject

### DIFF
--- a/apis/enigma-mocker/src/__tests__/from-generic-objects.test.js
+++ b/apis/enigma-mocker/src/__tests__/from-generic-objects.test.js
@@ -341,4 +341,28 @@ describe('enigma-mocker', () => {
       });
     });
   });
+
+  describe('getListObject', () => {
+    test('should return a model that maps to corresponding genericObject', async () => {
+      const app = await createEnigmaMocker([
+        {
+          getLayout: {
+            qInfo: { qId: 'TestList' },
+            qAppObjectList: {
+              qItems: [],
+            },
+          },
+        },
+      ]);
+
+      const listObjectModel = await app.getListObject({ qInfo: { qId: 'TestList' } });
+      expect(listObjectModel.id).toEqual('TestList');
+    });
+
+    test('should return undefined if no mock exist', async () => {
+      const app = await createEnigmaMocker(genericObjects);
+      const listObjectModel = await app.getListObject({ qInfo: { qId: 'TestList' } });
+      expect(listObjectModel).toBe(undefined);
+    });
+  });
 });

--- a/apis/enigma-mocker/src/from-generic-objects.js
+++ b/apis/enigma-mocker/src/from-generic-objects.js
@@ -16,7 +16,7 @@ export default function fromGenericObjects(genericObjects, options = {}) {
     destroySessionObject: async () => {},
     getObject,
     getAppLayout,
-    getListObject: async () => {},
+    getListObject: async (props) => getObject(props.qInfo?.qId),
   };
 
   return Promise.resolve(app);


### PR DESCRIPTION
Makes it possible to provide a mocked response for `getListObject` when using enigma-mocker through nebula serve.

Instead of always resolving an empty promise it now looks in the list of provided genericObject mocks and returns the corresponding one if provided.