### PR TITLE
chore: add hypercube generic functions - part04

### DIFF
--- a/apis/conversion/src/array-util.js
+++ b/apis/conversion/src/array-util.js
@@ -66,8 +66,26 @@ function indexRemoved(array, index) {
   return removeIndex;
 }
 
+/**
+ * Move an element from position old_index to position new_index in
+ * the array.
+ * @param array
+ * @param oldIndex
+ * @param newIndex
+ */
+function move(array, oldIndex, newIndex) {
+  if (newIndex >= array.length) {
+    let k = newIndex - array.length;
+    while (k-- + 1) {
+      array.push(undefined);
+    }
+  }
+  array.splice(newIndex, 0, array.splice(oldIndex, 1)[0]);
+}
+
 export default {
   isOrderedSubset,
   indexAdded,
   indexRemoved,
+  move,
 };

--- a/apis/conversion/src/array-util.js
+++ b/apis/conversion/src/array-util.js
@@ -74,13 +74,19 @@ function indexRemoved(array, index) {
  * @param newIndex
  */
 function move(array, oldIndex, newIndex) {
+  if (newIndex < 0) throw Error('newIndex cannot be a negative value!');
+
   if (newIndex >= array.length) {
-    let k = newIndex - array.length;
-    while (k-- + 1) {
+    let k = newIndex - array.length + 1;
+    while (k) {
       array.push(undefined);
+      k--;
     }
   }
-  array.splice(newIndex, 0, array.splice(oldIndex, 1)[0]);
+
+  const movingValue = array.at(oldIndex);
+  array.splice(oldIndex, 1);
+  array.splice(newIndex, 0, movingValue);
 }
 
 export default {

--- a/apis/supernova/src/handler/__tests__/data-property-handler.test.js
+++ b/apis/supernova/src/handler/__tests__/data-property-handler.test.js
@@ -85,23 +85,21 @@ describe('DataPropertyHandler', () => {
       expect(result.customDefault).toBe('value');
     });
 
-    describe('createLibraryDimension', () => {
-      test('should create a library dimension with default properties', () => {
-        const result = handler.createLibraryDimension('libraryId', { customDefault: 'value' });
+    test('should create a library dimension with default properties', () => {
+      const result = handler.createLibraryDimension('libraryId', { customDefault: 'value' });
 
-        expect(result.qLibraryId).toBe('libraryId');
-        expect(result.qDef.qSortCriterias).toEqual(sortingProperties);
-        expect(result.qDef.autoSort).toBe(true);
-        expect(result.someProperty).toBe('defaultValue');
-        expect(result.customDefault).toBe('value');
-      });
+      expect(result.qLibraryId).toBe('libraryId');
+      expect(result.qDef.qSortCriterias).toEqual(sortingProperties);
+      expect(result.qDef.autoSort).toBe(true);
+      expect(result.someProperty).toBe('defaultValue');
+      expect(result.customDefault).toBe('value');
+    });
 
-      test('should delete qFieldDefs and qFieldLabels from the dimension', () => {
-        const result = handler.createLibraryDimension('libraryId', {});
+    test('should delete qFieldDefs and qFieldLabels from the dimension', () => {
+      const result = handler.createLibraryDimension('libraryId', {});
 
-        expect(result.qDef.qFieldDefs).toBeUndefined();
-        expect(result.qDef.qFieldLabels).toBeUndefined();
-      });
+      expect(result.qDef.qFieldDefs).toBeUndefined();
+      expect(result.qDef.qFieldLabels).toBeUndefined();
     });
 
     test('should create a dimension with provided field and label', () => {

--- a/apis/supernova/src/handler/__tests__/data-property-handler.test.js
+++ b/apis/supernova/src/handler/__tests__/data-property-handler.test.js
@@ -95,6 +95,21 @@ describe('DataPropertyHandler', () => {
       expect(result.customDefault).toBe('value');
     });
 
+    test('should create a dimension with provided field and label', () => {
+      const result = handler.createFieldDimension('fieldName', 'fieldLabel', { customDefault: 'value' });
+
+      expect(result.qDef.qFieldDefs).toEqual(['fieldName']);
+      expect(result.qDef.qFieldLabels).toEqual(['fieldLabel']);
+    });
+  });
+
+  describe('createLibraryDimension', () => {
+    beforeEach(() => {
+      handler = new DataPropertyHandler({
+        dimensionProperties: { someProperty: 'defaultValue' },
+      });
+    });
+
     test('should delete qFieldDefs and qFieldLabels from the dimension', () => {
       const result = handler.createLibraryDimension('libraryId', {});
 
@@ -102,11 +117,14 @@ describe('DataPropertyHandler', () => {
       expect(result.qDef.qFieldLabels).toBeUndefined();
     });
 
-    test('should create a dimension with provided field and label', () => {
-      const result = handler.createFieldDimension('fieldName', 'fieldLabel', { customDefault: 'value' });
+    test('should create a library dimension with default properties', () => {
+      const result = handler.createLibraryDimension('libraryId', { customDefault: 'value' });
 
-      expect(result.qDef.qFieldDefs).toEqual(['fieldName']);
-      expect(result.qDef.qFieldLabels).toEqual(['fieldLabel']);
+      expect(result.qLibraryId).toBe('libraryId');
+      expect(result.qDef.qSortCriterias).toEqual(sortingProperties);
+      expect(result.qDef.autoSort).toBe(true);
+      expect(result.someProperty).toBe('defaultValue');
+      expect(result.customDefault).toBe('value');
     });
   });
 

--- a/apis/supernova/src/handler/hypercube-handler.js
+++ b/apis/supernova/src/handler/hypercube-handler.js
@@ -202,9 +202,10 @@ class HyperCubeHandler extends DataPropertyHandler {
   }
 
   addMeasure(measure, alternative, idx) {
+    const measures = this.getAlternativeMeasure();
     const meas = initializeId(measure);
 
-    if (hcUtils.isMeasureAlternative(this, alternative)) {
+    if (hcUtils.isMeasureAlternative(this, measures, alternative)) {
       return hcUtils.addAlternativeMeasure(this, meas, idx);
     }
 
@@ -221,7 +222,7 @@ class HyperCubeHandler extends DataPropertyHandler {
     return Promise.resolve(meas);
   }
 
-  addMeasures(measures, alternative) {
+  addMeasures(measures, alternative = false) {
     const existingMeasures = this.getMeasures();
     const addedMeasures = [];
     let addedActive = 0;
@@ -233,7 +234,7 @@ class HyperCubeHandler extends DataPropertyHandler {
 
       const meas = initializeId(measure);
 
-      if (hcUtils.isMeasureAlternative(this, alternative)) {
+      if (hcUtils.isMeasureAlternative(this, existingMeasures, alternative)) {
         hcUtils.addAlternativeMeasure(this, meas);
         addedMeasures.push(meas);
       } else if (existingMeasures.length < this.maxMeasures()) {
@@ -282,9 +283,10 @@ class HyperCubeHandler extends DataPropertyHandler {
   }
 
   reinsertMeasure(measure, alternative, idx) {
+    const measures = this.getAlternativeMeasures();
     const meas = initializeId(measure);
 
-    if (hcUtils.isMeasureAlternative(this, alternative)) {
+    if (hcUtils.isMeasureAlternative(this, measures, alternative)) {
       return hcUtils.addAlternativeMeasure(this, meas, idx);
     }
 

--- a/apis/supernova/src/handler/utils/hypercube-helper/__tests__/hypercube-utils.test.js
+++ b/apis/supernova/src/handler/utils/hypercube-helper/__tests__/hypercube-utils.test.js
@@ -1,0 +1,342 @@
+// eslint-disable-next-line import/no-relative-packages
+import uid from '../../../../../../nucleus/src/object/uid';
+import * as hcUtils from '../hypercube-utils';
+
+jest.mock('../../../../../../nucleus/src/object/uid', () => jest.fn());
+
+describe('replaceDimensionToColumnOrder', () => {
+  let self;
+  let dimension;
+  let replacedDimension;
+  let index;
+
+  beforeEach(() => {
+    index = 1;
+    uid.mockReturnValue('dim3Id');
+
+    self = {
+      getDimensions: jest.fn().mockReturnValue([{ qDef: { cId: 'dimId1' } }, { qDef: { cId: 'dimId2' } }]),
+      dimensionDefinition: {
+        replace: jest.fn(),
+      },
+      properties: {},
+    };
+
+    dimension = { qDef: { cId: 'dim3Id' } };
+    replacedDimension = { qDef: { cId: 'dimId2' } };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should replace the dimension at the specified index', () => {
+    const result = hcUtils.replaceDimensionOrder(self, index, dimension);
+
+    expect(result).toEqual({
+      qDef: { cId: 'dim3Id' },
+    });
+    expect(self.getDimensions()).toEqual([{ qDef: { cId: 'dimId1' } }, { qDef: { cId: 'dim3Id' } }]);
+  });
+
+  test('should call dimensionDefinition.replace with the correct arguments', () => {
+    hcUtils.replaceDimensionOrder(self, index, dimension);
+
+    expect(self.dimensionDefinition.replace).toHaveBeenCalledWith(
+      { qDef: { cId: 'dim3Id' } },
+      replacedDimension,
+      index,
+      self.properties,
+      self
+    );
+  });
+
+  test('should not replace dimension when the dimensionDefinition.replace is undefined', () => {
+    self.dimensionDefinition.replace = undefined;
+    hcUtils.replaceDimensionOrder(self, index, dimension);
+
+    expect(self.getDimensions()).toEqual([{ qDef: { cId: 'dimId1' } }, { qDef: { cId: 'dim3Id' } }]);
+  });
+
+  test('should not replace any order when the given dimension is undefined', () => {
+    dimension = undefined;
+    const result = hcUtils.replaceDimensionOrder(self, index, dimension);
+
+    expect(result).toBeUndefined();
+    expect(self.getDimensions()).toEqual([{ qDef: { cId: 'dimId1' } }, { qDef: { cId: 'dimId2' } }]);
+  });
+});
+
+describe('MoveMeasure', () => {
+  let measures;
+  let altMeasures;
+
+  beforeEach(() => {
+    measures = [{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'meas2' } }];
+    altMeasures = [{ qDef: { cId: 'altMeas1' } }, { qDef: { cId: 'altMeas2' } }, { qDef: { cId: 'altMeas3' } }];
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe('moveMeasureFromEnabledToDisabled', () => {
+    test('moves a measure from main to alternative at correct index', async () => {
+      const result = await hcUtils.moveMeasureFromMainToAlternative(1, 3, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'meas2' } });
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'altMeas1' } }]);
+      expect(altMeasures).toEqual([
+        { qDef: { cId: 'altMeas2' } },
+        { qDef: { cId: 'meas2' } },
+        { qDef: { cId: 'altMeas3' } },
+      ]);
+    });
+
+    test('should handle empty main measures array', async () => {
+      measures = [];
+
+      const result = await hcUtils.moveMeasureFromMainToAlternative(0, 0, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'altMeas1' } });
+      expect(measures).toEqual([]);
+      expect(altMeasures).toEqual([
+        { qDef: { cId: 'altMeas1' } },
+        { qDef: { cId: 'altMeas2' } },
+        { qDef: { cId: 'altMeas3' } },
+      ]);
+    });
+
+    test('should handle empty alternative measures array', async () => {
+      altMeasures = [];
+
+      const result = await hcUtils.moveMeasureFromMainToAlternative(1, 2, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'meas2' } });
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, undefined]);
+      expect(altMeasures).toEqual([{ qDef: { cId: 'meas2' } }]);
+    });
+
+    test('should add undefined if fromIndex is out of bounds', async () => {
+      const result = await hcUtils.moveMeasureFromMainToAlternative(10, 1, measures, altMeasures);
+
+      expect(result).toBeUndefined();
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'meas2' } }, { qDef: { cId: 'altMeas1' } }]);
+      expect(altMeasures).toEqual([{ qDef: { cId: 'altMeas2' } }, undefined, { qDef: { cId: 'altMeas3' } }]);
+    });
+
+    test('should handle it if toIndex is out of bounds', async () => {
+      const result = await hcUtils.moveMeasureFromMainToAlternative(1, 10, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'meas2' } });
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'altMeas1' } }]);
+      expect(altMeasures).toEqual([
+        { qDef: { cId: 'altMeas2' } },
+        { qDef: { cId: 'altMeas3' } },
+        { qDef: { cId: 'meas2' } },
+      ]);
+    });
+  });
+
+  describe('moveMeasureFromAlternativeToMain', () => {
+    beforeEach(() => {
+      measures = [{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'meas2' } }];
+      altMeasures = [{ qDef: { cId: 'altMeas1' } }, { qDef: { cId: 'altMeas2' } }, { qDef: { cId: 'altMeas3' } }];
+    });
+
+    test('moves a measure from alternative to main at correct index', async () => {
+      const result = await hcUtils.moveMeasureFromAlternativeToMain(2, 1, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'altMeas1' } });
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'altMeas1' } }]);
+      expect(altMeasures).toEqual([
+        { qDef: { cId: 'meas2' } },
+        { qDef: { cId: 'altMeas2' } },
+        { qDef: { cId: 'altMeas3' } },
+      ]);
+    });
+
+    test('should handle empty main measures array', async () => {
+      measures = [];
+
+      const result = await hcUtils.moveMeasureFromAlternativeToMain(0, 0, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'altMeas1' } });
+      expect(measures).toEqual([{ qDef: { cId: 'altMeas1' } }]);
+      expect(altMeasures).toEqual([undefined, { qDef: { cId: 'altMeas2' } }, { qDef: { cId: 'altMeas3' } }]);
+    });
+
+    test('should handle empty alternative measures array', async () => {
+      altMeasures = [];
+
+      const result = await hcUtils.moveMeasureFromAlternativeToMain(1, 2, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'meas2' } });
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'meas2' } }]);
+      expect(altMeasures).toEqual([]);
+    });
+
+    test('should add undefined if fromIndex is out of bounds', async () => {
+      const result = await hcUtils.moveMeasureFromAlternativeToMain(10, 1, measures, altMeasures);
+
+      expect(result).toBeUndefined();
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, undefined]);
+      expect(altMeasures).toEqual([
+        { qDef: { cId: 'meas2' } },
+        { qDef: { cId: 'altMeas1' } },
+        { qDef: { cId: 'altMeas2' } },
+        { qDef: { cId: 'altMeas3' } },
+      ]);
+    });
+
+    test('should handle it if toIndex is out of bounds', async () => {
+      const result = await hcUtils.moveMeasureFromAlternativeToMain(1, 10, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'meas2' } });
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'meas2' } }]);
+      expect(altMeasures).toEqual([
+        { qDef: { cId: 'altMeas1' } },
+        { qDef: { cId: 'altMeas2' } },
+        { qDef: { cId: 'altMeas3' } },
+      ]);
+    });
+  });
+});
+
+describe('MoveDimension', () => {
+  let measures;
+  let altMeasures;
+
+  beforeEach(() => {
+    measures = [{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'meas2' } }];
+    altMeasures = [{ qDef: { cId: 'altMeas1' } }, { qDef: { cId: 'altMeas2' } }, { qDef: { cId: 'altMeas3' } }];
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe('moveMeasureFromEnabledToDisabled', () => {
+    test('moves a measure from main to alternative at correct index', async () => {
+      const result = await hcUtils.moveMeasureFromMainToAlternative(1, 3, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'meas2' } });
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'altMeas1' } }]);
+      expect(altMeasures).toEqual([
+        { qDef: { cId: 'altMeas2' } },
+        { qDef: { cId: 'meas2' } },
+        { qDef: { cId: 'altMeas3' } },
+      ]);
+    });
+
+    test('should handle empty main measures array', async () => {
+      measures = [];
+
+      const result = await hcUtils.moveMeasureFromMainToAlternative(0, 0, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'altMeas1' } });
+      expect(measures).toEqual([]);
+      expect(altMeasures).toEqual([
+        { qDef: { cId: 'altMeas1' } },
+        { qDef: { cId: 'altMeas2' } },
+        { qDef: { cId: 'altMeas3' } },
+      ]);
+    });
+
+    test('should handle empty alternative measures array', async () => {
+      altMeasures = [];
+
+      const result = await hcUtils.moveMeasureFromMainToAlternative(1, 2, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'meas2' } });
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, undefined]);
+      expect(altMeasures).toEqual([{ qDef: { cId: 'meas2' } }]);
+    });
+
+    test('should add undefined if fromIndex is out of bounds', async () => {
+      const result = await hcUtils.moveMeasureFromMainToAlternative(10, 1, measures, altMeasures);
+
+      expect(result).toBeUndefined();
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'meas2' } }, { qDef: { cId: 'altMeas1' } }]);
+      expect(altMeasures).toEqual([{ qDef: { cId: 'altMeas2' } }, undefined, { qDef: { cId: 'altMeas3' } }]);
+    });
+
+    test('should handle it if toIndex is out of bounds', async () => {
+      const result = await hcUtils.moveMeasureFromMainToAlternative(1, 10, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'meas2' } });
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'altMeas1' } }]);
+      expect(altMeasures).toEqual([
+        { qDef: { cId: 'altMeas2' } },
+        { qDef: { cId: 'altMeas3' } },
+        { qDef: { cId: 'meas2' } },
+      ]);
+    });
+  });
+
+  describe('moveMeasureFromAlternativeToMain', () => {
+    beforeEach(() => {
+      measures = [{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'meas2' } }];
+      altMeasures = [{ qDef: { cId: 'altMeas1' } }, { qDef: { cId: 'altMeas2' } }, { qDef: { cId: 'altMeas3' } }];
+    });
+
+    test('moves a measure from alternative to main at correct index', async () => {
+      const result = await hcUtils.moveMeasureFromAlternativeToMain(2, 1, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'altMeas1' } });
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'altMeas1' } }]);
+      expect(altMeasures).toEqual([
+        { qDef: { cId: 'meas2' } },
+        { qDef: { cId: 'altMeas2' } },
+        { qDef: { cId: 'altMeas3' } },
+      ]);
+    });
+
+    test('should handle empty main measures array', async () => {
+      measures = [];
+
+      const result = await hcUtils.moveMeasureFromAlternativeToMain(0, 0, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'altMeas1' } });
+      expect(measures).toEqual([{ qDef: { cId: 'altMeas1' } }]);
+      expect(altMeasures).toEqual([undefined, { qDef: { cId: 'altMeas2' } }, { qDef: { cId: 'altMeas3' } }]);
+    });
+
+    test('should handle empty alternative measures array', async () => {
+      altMeasures = [];
+
+      const result = await hcUtils.moveMeasureFromAlternativeToMain(1, 2, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'meas2' } });
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'meas2' } }]);
+      expect(altMeasures).toEqual([]);
+    });
+
+    test('should add undefined if fromIndex is out of bounds', async () => {
+      const result = await hcUtils.moveMeasureFromAlternativeToMain(10, 1, measures, altMeasures);
+
+      expect(result).toBeUndefined();
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, undefined]);
+      expect(altMeasures).toEqual([
+        { qDef: { cId: 'meas2' } },
+        { qDef: { cId: 'altMeas1' } },
+        { qDef: { cId: 'altMeas2' } },
+        { qDef: { cId: 'altMeas3' } },
+      ]);
+    });
+
+    test('should handle it if toIndex is out of bounds', async () => {
+      const result = await hcUtils.moveMeasureFromAlternativeToMain(1, 10, measures, altMeasures);
+
+      expect(result).toEqual({ qDef: { cId: 'meas2' } });
+      expect(measures).toEqual([{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'meas2' } }]);
+      expect(altMeasures).toEqual([
+        { qDef: { cId: 'altMeas1' } },
+        { qDef: { cId: 'altMeas2' } },
+        { qDef: { cId: 'altMeas3' } },
+      ]);
+    });
+  });
+});

--- a/apis/supernova/src/handler/utils/hypercube-helper/__tests__/reinsert-main-dimension.test.js
+++ b/apis/supernova/src/handler/utils/hypercube-helper/__tests__/reinsert-main-dimension.test.js
@@ -1,0 +1,62 @@
+import reinsertMainDimension from '../reinsert-main-dimension';
+import * as hcUtils from '../hypercube-utils';
+
+describe('reinsertMainDimension', () => {
+  let self;
+  let index;
+  let insertedDimension;
+
+  beforeEach(() => {
+    index = 1;
+    insertedDimension = { qDef: { cId: 'dim3' } };
+    self = {
+      hcProperties: {
+        qInterColumnSortOrder: [0, 1],
+      },
+      getDimensions: jest.fn().mockReturnValue([{ qDef: { cId: 'dim1' } }, { qDef: { cId: 'dim2' } }]),
+      maxDimensions: jest.fn().mockReturnValue(3),
+    };
+    jest.spyOn(hcUtils, 'addDimensionToColumnSortOrder').mockReturnValue();
+    jest.spyOn(hcUtils, 'moveDimensionToColumnOrder').mockReturnValue();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  test('should call updateDimensionOrders if dimensions are below the maximum limit', async () => {
+    await reinsertMainDimension(self, insertedDimension, index);
+
+    expect(hcUtils.addDimensionToColumnSortOrder).toHaveBeenCalled();
+    expect(hcUtils.moveDimensionToColumnOrder).toHaveBeenCalled();
+  });
+
+  test('should return a resolved promise if dimensions are at the maximum limit', async () => {
+    self.maxDimensions.mockReturnValue(2);
+
+    const result = await reinsertMainDimension(self, insertedDimension, index);
+
+    expect(result).toEqual(insertedDimension);
+    expect(hcUtils.addDimensionToColumnSortOrder).not.toHaveBeenCalled();
+    expect(hcUtils.moveDimensionToColumnOrder).not.toHaveBeenCalled();
+  });
+
+  test('should handle empty dimensions array', async () => {
+    self.getDimensions.mockReturnValue([]);
+
+    await reinsertMainDimension(self, insertedDimension, index);
+
+    expect(hcUtils.addDimensionToColumnSortOrder).toHaveBeenCalled();
+    expect(hcUtils.moveDimensionToColumnOrder).toHaveBeenCalled();
+  });
+
+  test('should handle dimension when index is undefined', async () => {
+    index = undefined;
+
+    await reinsertMainDimension(self, insertedDimension, index);
+
+    expect(hcUtils.addDimensionToColumnSortOrder).toHaveBeenCalled();
+    expect(hcUtils.moveDimensionToColumnOrder).toHaveBeenCalled();
+  });
+});

--- a/apis/supernova/src/handler/utils/hypercube-helper/__tests__/reinsert-main-measure.test.js
+++ b/apis/supernova/src/handler/utils/hypercube-helper/__tests__/reinsert-main-measure.test.js
@@ -1,0 +1,62 @@
+import * as hcUtils from '../hypercube-utils';
+import reinsertMainMeasure from '../reinsert-main-measure';
+
+describe('reinsertMainMeasure', () => {
+  let self;
+  let index;
+  let insertedMeasure;
+
+  beforeEach(() => {
+    index = 1;
+    insertedMeasure = { qDef: { cId: 'meas3' } };
+    self = {
+      hcProperties: {
+        qInterColumnSortOrder: [0, 1],
+      },
+      getMeasures: jest.fn().mockReturnValue([{ qDef: { cId: 'meas1' } }, { qDef: { cId: 'meas2' } }]),
+      maxMeasures: jest.fn().mockReturnValue(3),
+    };
+    jest.spyOn(hcUtils, 'addMeasureToColumnSortOrder').mockReturnValue();
+    jest.spyOn(hcUtils, 'moveMeasureColumnOrder').mockReturnValue();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  test('should call updateDimensionOrders if measures are below the maximum limit', async () => {
+    await reinsertMainMeasure(self, insertedMeasure, index);
+
+    expect(hcUtils.addMeasureToColumnSortOrder).toHaveBeenCalled();
+    expect(hcUtils.moveMeasureColumnOrder).toHaveBeenCalled();
+  });
+
+  test('should return a resolved promise if measures are at the maximum limit', async () => {
+    self.maxMeasures.mockReturnValue(2);
+
+    const result = await reinsertMainMeasure(self, insertedMeasure, index);
+
+    expect(result).toEqual(insertedMeasure);
+    expect(hcUtils.addMeasureToColumnSortOrder).not.toHaveBeenCalled();
+    expect(hcUtils.moveMeasureColumnOrder).not.toHaveBeenCalled();
+  });
+
+  test('should handle empty measures array', async () => {
+    self.getMeasures.mockReturnValue([]);
+
+    await reinsertMainMeasure(self, insertedMeasure, index);
+
+    expect(hcUtils.addMeasureToColumnSortOrder).toHaveBeenCalled();
+    expect(hcUtils.moveMeasureColumnOrder).toHaveBeenCalled();
+  });
+
+  test('should handle measure when index is undefined', async () => {
+    index = undefined;
+
+    await reinsertMainMeasure(self, insertedMeasure, index);
+
+    expect(hcUtils.addMeasureToColumnSortOrder).toHaveBeenCalled();
+    expect(hcUtils.moveMeasureColumnOrder).toHaveBeenCalled();
+  });
+});

--- a/apis/supernova/src/handler/utils/hypercube-helper/hypercube-utils.js
+++ b/apis/supernova/src/handler/utils/hypercube-helper/hypercube-utils.js
@@ -3,6 +3,8 @@ import getValue from '../../../../../conversion/src/utils';
 // eslint-disable-next-line import/no-relative-packages
 import arrayUtil from '../../../../../conversion/src/array-util';
 import { TOTAL_MAX } from '../constants';
+// eslint-disable-next-line import/no-relative-packages
+import uid from '../../../../../nucleus/src/object/uid';
 
 export const notSupportedError = new Error('Not supported in this object, need to implement in subclass.');
 
@@ -36,8 +38,8 @@ export const getHyperCube = (layout, path) => {
 
 export function setDefaultProperties(self) {
   const current = self;
-  current.hcProperties.qDimensions = current.hcProperties.qDimensions ?? [];
-  current.hcProperties.qMeasures = current.hcProperties.qMeasures ?? [];
+  current.hcProperties.qDimensions = current.getDimensions() ?? [];
+  current.hcProperties.qMeasures = current.getMeasures() ?? [];
   current.hcProperties.qInterColumnSortOrder = current.hcProperties.qInterColumnSortOrder ?? [];
   current.hcProperties.qLayoutExclude = current.hcProperties.qLayoutExclude ?? {
     qHyperCubeDef: { qDimensions: [], qMeasures: [] },
@@ -46,10 +48,8 @@ export function setDefaultProperties(self) {
     qDimensions: [],
     qMeasures: [],
   };
-  current.hcProperties.qLayoutExclude.qHyperCubeDef.qDimensions =
-    current.hcProperties.qLayoutExclude.qHyperCubeDef.qDimensions ?? [];
-  current.hcProperties.qLayoutExclude.qHyperCubeDef.qMeasures =
-    current.hcProperties.qLayoutExclude.qHyperCubeDef.qMeasures ?? [];
+  current.hcProperties.qLayoutExclude.qHyperCubeDef.qDimensions = current.getAlternativeDimensions() ?? [];
+  current.hcProperties.qLayoutExclude.qHyperCubeDef.qMeasures = current.getAlternativeMeasures() ?? [];
 }
 
 export function setPropForLineChartWithForecast(self) {
@@ -77,7 +77,7 @@ export function getRemainedFields(fields, indexes) {
 // ----------------------------------
 
 export function addAlternativeDimension(self, dimension, index = undefined) {
-  const dimensions = self.hcProperties.qLayoutExclude.qHyperCubeDef.qDimensions;
+  const dimensions = self.getAlternativeDimensions();
   const idx = index ?? dimensions.length;
   dimensions.splice(idx, 0, dimension);
   return Promise.resolve(dimension);
@@ -88,12 +88,45 @@ export function addDimensionToColumnSortOrder(self, dimensions, index) {
 }
 
 export function addDimensionToColumnOrder(self, dimension) {
-  if (typeof self.dimensionDefinition.add === 'function') {
+  if (dimension && typeof self.dimensionDefinition.add === 'function') {
     return Promise.resolve(self.dimensionDefinition.add.call(null, dimension, self.properties, self)).then(
       () => dimension
     );
   }
-  return undefined;
+  return Promise.resolve(dimension);
+}
+
+export function moveDimensionToColumnOrder(self, dimension) {
+  if (typeof self.dimensionDefinition.move === 'function') {
+    return Promise.resolve(self.dimensionDefinition.move.call(self, dimension, self.properties, self)).then(
+      () => dimension
+    );
+  }
+  return Promise.resolve(dimension);
+}
+
+export function replaceDimensionOrder(self, index, dimension) {
+  if (!dimension) {
+    return undefined;
+  }
+
+  const dimensions = self.getDimensions();
+  const replacedDimension = dimensions[index];
+
+  const newDimension = {
+    ...dimension,
+    qDef: {
+      ...dimension.qDef,
+      cId: uid(),
+    },
+  };
+
+  dimensions[index] = newDimension;
+  if (newDimension && typeof self.dimensionDefinition.replace === 'function') {
+    self.dimensionDefinition.replace.call(null, newDimension, replacedDimension, index, self.properties, self);
+  }
+
+  return newDimension;
 }
 
 export function removeDimensionFromColumnSortOrder(self, index) {
@@ -101,12 +134,12 @@ export function removeDimensionFromColumnSortOrder(self, index) {
 }
 
 export function removeDimensionFromColumnOrder(self, index) {
-  const [dimension] = self.hcProperties.qDimensions.splice(index, 1);
+  const [dimension] = self.getDimensions().splice(index, 1);
   if (dimension && typeof self.dimensionDefinition.remove === 'function') {
     return Promise.resolve(self.dimensionDefinition.remove.call(null, dimension, self.properties, self, index));
   }
 
-  return undefined;
+  return Promise.resolve();
 }
 
 export function isTotalDimensionsExceeded(self, dimensions) {
@@ -115,7 +148,7 @@ export function isTotalDimensionsExceeded(self, dimensions) {
 }
 
 export function isDimensionAlternative(self, alternative) {
-  const dimensions = self.hcProperties.qLayoutExclude.qHyperCubeDef.qDimensions;
+  const dimensions = self.getAlternativeDimensions();
   return alternative || (self.maxDimensions() <= dimensions.length && dimensions.length < TOTAL_MAX.DIMENSIONS);
 }
 
@@ -140,12 +173,42 @@ export async function addActiveDimension(
   }
 }
 
+export function moveDimensionFromMainToAlternative(fromIndex, toIndex, dimensions, altDimensions) {
+  const alternativeToIndex = toIndex - dimensions.length;
+
+  let [movingDimension] = altDimensions.splice(0, 1);
+  dimensions.push(movingDimension);
+
+  [movingDimension] = dimensions.splice(fromIndex, 1);
+  altDimensions.splice(alternativeToIndex, 0, movingDimension);
+
+  return Promise.resolve(movingDimension);
+}
+
+export function moveDimensionFromAlternativeToMain(fromIndex, toIndex, dimensions, altDimensions) {
+  const alternativeToIndex = fromIndex - dimensions.length;
+
+  let [movingDimension] = dimensions.splice(dimensions.length - 1, 1);
+  altDimensions.splice(0, 0, movingDimension);
+
+  [movingDimension] = altDimensions.splice(alternativeToIndex + 1, 1);
+  dimensions.splice(toIndex, 0, movingDimension);
+
+  return Promise.resolve(movingDimension);
+}
+
+export function moveDimensionWithinAlternative(fromIndex, toIndex, dimensions, altDimensions) {
+  const alternativeFromIdx = fromIndex - dimensions.length;
+  const alternativeToIndex = toIndex - dimensions.length;
+  arrayUtil.move(altDimensions, alternativeFromIdx, alternativeToIndex);
+}
+
 // ----------------------------------
 // ------------ MEASURES ------------
 // ----------------------------------
 
 export function addAlternativeMeasure(self, measure, index = undefined) {
-  const measures = self.hcProperties.qLayoutExclude.qHyperCubeDef.qMeasures;
+  const measures = self.getAlternativeMeasures();
   const idx = index ?? measures.length;
   measures.splice(idx, 0, measure);
   return Promise.resolve(measure);
@@ -156,10 +219,20 @@ export function addMeasureToColumnSortOrder(self, measures) {
 }
 
 export function addMeasureToColumnOrder(self, measure) {
-  if (typeof self.measureDefinition.add === 'function') {
+  if (measure && typeof self.measureDefinition.add === 'function') {
     return Promise.resolve(self.measureDefinition.add.call(null, measure, self.properties, self));
   }
-  return undefined;
+  return Promise.resolve();
+}
+
+export function moveMeasureColumnOrder(self, measure) {
+  if (typeof self.measureDefinition.move === 'function') {
+    return Promise.resolve(self.measureDefinition.move.call(null, measure, self.properties, self, true)).then(
+      () => measure
+    );
+  }
+
+  return Promise.resolve(measure);
 }
 
 export function isTotalMeasureExceeded(self, measures) {
@@ -168,7 +241,8 @@ export function isTotalMeasureExceeded(self, measures) {
   return altMeasures.length + measures.length >= TOTAL_MAX.MEASURES;
 }
 
-export function isMeasureAlternative(self, measures, alternative) {
+export function isMeasureAlternative(self, alternative) {
+  const measures = self.getAlternativeMeasures();
   return alternative || (self.maxMeasures() <= measures.length && measures.length < TOTAL_MAX.MEASURES);
 }
 
@@ -199,13 +273,64 @@ export function removeMeasureFromColumnSortOrder(self, index) {
 }
 
 export function removeMeasureFromColumnOrder(self, index) {
-  const [measure] = self.hcProperties.qMeasures.splice(index, 1);
+  const [measure] = self.getMeasures().splice(index, 1);
   if (measure && typeof self.measureDefinition.remove === 'function') {
     return Promise.resolve(self.measureDefinition.remove.call(null, measure, self.properties, self, index));
   }
-  return undefined;
+  return Promise.resolve();
 }
 
 export function removeAltMeasureByIndex(self, index) {
-  return self.hcProperties.qLayoutExclude.qHyperCubeDef.qMeasures.splice(index, 1);
+  return self.getAlternativeMeasures().splice(index, 1);
+}
+
+export function replaceMeasureToColumnOrder(self, index, measure) {
+  const measures = self.getMeasures();
+  const replacedMeasure = measures[index];
+
+  const newMeasure = {
+    ...measure,
+    qDef: {
+      ...measure.qDef,
+      cId: uid(),
+    },
+  };
+
+  measures[index] = newMeasure;
+
+  if (newMeasure && typeof self.measureDefinition.replace === 'function') {
+    self.dimensionDefinition.replace.call(null, newMeasure, replacedMeasure, index, self.properties, self);
+  }
+
+  return newMeasure;
+}
+
+export function moveMeasureFromMainToAlternative(fromIndex, toIndex, measures, altMeasures) {
+  const alternativeToIndex = toIndex - measures.length;
+
+  let [movingMeasure] = altMeasures.splice(0, 1);
+  measures.push(movingMeasure);
+
+  [movingMeasure] = measures.splice(fromIndex, 1);
+  altMeasures.splice(alternativeToIndex, 0, movingMeasure);
+
+  return Promise.resolve(movingMeasure);
+}
+
+export function moveMeasureFromAlternativeToMain(fromIndex, toIndex, measures, altMeasures) {
+  const alternativeFromIndex = fromIndex - measures.length;
+
+  let [movingMeasure] = measures.splice(measures.length - 1, 1);
+  altMeasures.splice(0, 0, movingMeasure);
+
+  [movingMeasure] = altMeasures.splice(alternativeFromIndex + 1, 1);
+  measures.splice(toIndex, 0, movingMeasure);
+
+  return Promise.resolve(movingMeasure);
+}
+
+export function moveMeasureWithinAlternative(fromIndex, toIndex, measures, altMeasures) {
+  const alternativeFromIndex = fromIndex - measures.length;
+  const alternativeToIndex = toIndex - measures.length;
+  arrayUtil.move(altMeasures, alternativeFromIndex, alternativeToIndex);
 }

--- a/apis/supernova/src/handler/utils/hypercube-helper/hypercube-utils.js
+++ b/apis/supernova/src/handler/utils/hypercube-helper/hypercube-utils.js
@@ -241,8 +241,7 @@ export function isTotalMeasureExceeded(self, measures) {
   return altMeasures.length + measures.length >= TOTAL_MAX.MEASURES;
 }
 
-export function isMeasureAlternative(self, alternative) {
-  const measures = self.getAlternativeMeasures();
+export function isMeasureAlternative(self, measures, alternative) {
   return alternative || (self.maxMeasures() <= measures.length && measures.length < TOTAL_MAX.MEASURES);
 }
 

--- a/apis/supernova/src/handler/utils/hypercube-helper/reinsert-main-dimension.js
+++ b/apis/supernova/src/handler/utils/hypercube-helper/reinsert-main-dimension.js
@@ -1,0 +1,17 @@
+import { addDimensionToColumnSortOrder, moveDimensionToColumnOrder } from './hypercube-utils';
+
+function reinsertMainDimension(self, dimension, index) {
+  const dimensions = self.getDimensions();
+  const idx = index ?? dimensions.length;
+
+  if (dimensions.length < self.maxDimensions()) {
+    dimensions.splice(idx, 0, dimension);
+
+    addDimensionToColumnSortOrder(self, dimensions);
+    return moveDimensionToColumnOrder(self, dimension);
+  }
+
+  return Promise.resolve(dimension);
+}
+
+export default reinsertMainDimension;

--- a/apis/supernova/src/handler/utils/hypercube-helper/reinsert-main-measure.js
+++ b/apis/supernova/src/handler/utils/hypercube-helper/reinsert-main-measure.js
@@ -1,0 +1,17 @@
+import { addMeasureToColumnSortOrder, moveMeasureColumnOrder } from './hypercube-utils';
+
+function reinsertMainMeasure(self, measure, index) {
+  const measures = self.getMeasures();
+  const idx = index ?? measures.length;
+
+  if (measures.length < self.maxMeasures()) {
+    measures.splice(idx, 0, measure);
+
+    addMeasureToColumnSortOrder(self, measures);
+    return moveMeasureColumnOrder(self, measure);
+  }
+
+  return Promise.resolve(measure);
+}
+
+export default reinsertMainMeasure;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Moving generic hypercube functions from sense-client to nebula.js - PART04
In this PR the functions that are required to move, replace and reinsert fields and alternative fields, are considered.

The source files for these functions are in sense-client (data-property-handler.ts & hypercube-handler.js)

P.S: Other parts of this task can be found here: 
[Part01](https://github.com/qlik-oss/nebula.js/pull/1716) ✅ 
[Part02](https://github.com/qlik-oss/nebula.js/pull/1715) ✅ 
[Part03](https://github.com/qlik-oss/nebula.js/pull/1729) ✅

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
