### PR TITLE
fix: stop rendering if destroyed

### DIFF
--- a/apis/nucleus/src/components/glue.jsx
+++ b/apis/nucleus/src/components/glue.jsx
@@ -42,9 +42,18 @@ export default function glue({
   };
   model.on('closed', unmount);
 
-  root.add(portal, unmount);
   // Cannot use model.id as it is not unique in a given mashup
   root.addCell(currentId, cellRef);
+
+  (async () => {
+    try {
+      await root.add(portal, unmount);
+    } catch (e) {
+      unmount();
+      onMount();
+      onError(e);
+    }
+  })();
 
   return [unmount, cellRef];
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

Makes sure a new render gets an error if the Nebula instance was destroyed before it could finish

## Requirements checklist

<!-- Make sure you got these covered -->

- [x] Api specification
  - [x] Ran `yarn spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
