### PR TITLE
fix: change default navigation value to undefined

### DIFF
--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -158,7 +158,7 @@ const DEFAULT_CONTEXT = /** @lends Context */ {
    * */
   dataViewType: 'sn-table',
   /** @type {Navigation=} */
-  navigation: {},
+  navigation: undefined,
 };
 
 DEFAULT_CONFIG.context = DEFAULT_CONTEXT;


### PR DESCRIPTION
Set navigation default value to `undefined` instead of `{}`.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
