### PR TITLE
chore: add :automergeMinor and :automergeDigest to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["local>qlik-oss/renovate-config"],
+  "extends": ["local>qlik-oss/renovate-config", ":automergeMinor", ":automergeDigest"],
   "circleci": {
     "ignoreDeps": []
   },


### PR DESCRIPTION
Add `:automergeMinor` and `:automergeDigest` explicitly. The shared preset (qlik-oss/renovate-config) no longer provides these — adding them here preserves existing automerge behaviour and adds digest update automerge.