### PR TITLE
fix: serve infrastructure documentation and clarity

### DIFF
--- a/commands/serve/BREAKING.md
+++ b/commands/serve/BREAKING.md
@@ -1,0 +1,6 @@
+# Breaking Changes
+
+## Node.js >=24 required
+
+As of this release, `@nebula.js/cli-serve` and `@nebula.js/cli` require Node.js 24 or later.
+Node 18 and Node 20 are no longer supported by the serve devtool.

--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -250,6 +250,7 @@ export default async ({
 
             const leadingWhitespace = trimmedLine.match(/^\s*/)[0];
             const art = trimmedLine.slice(leadingWhitespace.length);
+            // Brand color for the nebula serve startup banner
             return `${leadingWhitespace}${chalk.bgHex('#305be7').white(art)}`;
           })
           .join('\n');

--- a/commands/serve/lib/webpack.serve.js
+++ b/commands/serve/lib/webpack.serve.js
@@ -98,6 +98,9 @@ export default async ({
     port,
     allowedHosts: disableHostCheck ? 'all' : 'auto',
     open,
+    // NOTE: historyApiFallback intentionally handles the @qlik/api OAuth2 callback at
+    // /auth/login/callback — the SPA is served for all paths and @qlik/api detects
+    // the authorization code in the URL to complete the token exchange client-side.
     historyApiFallback: true,
     // Disable nebula serve dev env when in MFE mode
     static: !serveConfig.mfe && {

--- a/commands/serve/package.json
+++ b/commands/serve/package.json
@@ -21,6 +21,7 @@
   },
   "files": [
     "assets",
+    "BREAKING.md",
     "command.js",
     "data",
     "dist",


### PR DESCRIPTION
## Summary

- **historyApiFallback OAuth2 dependency** (`commands/serve/lib/webpack.serve.js`): Added a comment above `historyApiFallback: true` explaining that this setting is intentionally required by the `@qlik/api` OAuth2 callback flow — the dev-server serves the SPA for all paths so the client can detect the authorization code at `/auth/login/callback` and complete the token exchange.

- **Serve banner brand color** (`commands/serve/lib/webpack.serve.js`): Added a one-line comment above the `chalk.bgHex('#305be7')` call marking it as the nebula serve startup banner brand color, making it easy to locate and update without wading through git history (several recent commits indicate color churn: `chore: new color`, `chore: update serve hex color`).

- **Node >=24 breaking change** (`commands/serve/BREAKING.md`): Created a `BREAKING.md` in `commands/serve` documenting that `@nebula.js/cli-serve` and `@nebula.js/cli` both require Node.js 24 or later as of this release. Both `commands/serve/package.json` and `commands/cli/package.json` already carry `"node": ">=24.0.0"`, but the change was not documented anywhere visible to consumers.

## Test plan

- [ ] Verify `commands/serve/lib/webpack.serve.js` lint passes (`eslint` via lint-staged ran cleanly on all commits)
- [ ] Confirm the three commits land on `alpha/v7` and no functional code was changed
- [ ] Review `commands/serve/BREAKING.md` content is accurate against both package.json engine fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)