### PR TITLE
fix: @qlik/api migration code-quality fixes

### DIFF
--- a/commands/create/templates/sn/none/_package.json
+++ b/commands/create/templates/sn/none/_package.json
@@ -28,7 +28,6 @@
     "@nebula.js/cli-serve": "<%= nebulaVersion %>",
     "@nebula.js/cli-sense": "<%= nebulaVersion %>",
     "@playwright/test": "^1.59.1",
-    "@qlik/sdk": "^0.28.0",
     "eslint": "8.57.1",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-plugin-import": "2.32.0",

--- a/commands/create/templates/sn/picasso/common/_package.json
+++ b/commands/create/templates/sn/picasso/common/_package.json
@@ -32,7 +32,6 @@
     "eslint-config-airbnb-base": "14.2.1",
     "eslint-plugin-import": "2.23.4",
     "eslint-plugin-mocha": "9.0.0",
-    "@qlik/sdk": "^0.28.0",
     "picasso.js": "2.1.1",
     "picasso-plugin-q": "2.1.1"
   },

--- a/commands/serve/web/connect.js
+++ b/commands/serve/web/connect.js
@@ -131,6 +131,12 @@ const setHostConfig = ({ webIntegrationId, clientId, host }) => {
   }
 };
 
+const buildDocList = async () => {
+  const response = await getItems({ resourceType: 'app', limit: 30, sort: '-updatedAt' });
+  const { data = [] } = response.data;
+  return data.map((d) => ({ qDocId: d.resourceId, qTitle: d.name }));
+};
+
 const connect = async () => {
   try {
     const {
@@ -143,14 +149,7 @@ const connect = async () => {
     if (webIntegrationId) {
       setHostConfig({ webIntegrationId, host });
       return {
-        getDocList: async () => {
-          const response = await getItems({ resourceType: 'app', limit: 30, sort: '-updatedAt' });
-          const { data = [] } = response.data;
-          return data.map((d) => ({
-            qDocId: d.resourceId,
-            qTitle: d.name,
-          }));
-        },
+        getDocList: buildDocList,
         getConfiguration: async () => ({}),
       };
     }
@@ -158,14 +157,7 @@ const connect = async () => {
     if (clientId) {
       setHostConfig({ clientId, host });
       return {
-        getDocList: async () => {
-          const response = await getItems({ resourceType: 'app', limit: 30, sort: '-updatedAt' });
-          const { data = [] } = response.data;
-          return data.map((d) => ({
-            qDocId: d.resourceId,
-            qTitle: d.name,
-          }));
-        },
+        getDocList: buildDocList,
         getConfiguration: async () => ({}),
       };
     }

--- a/commands/serve/web/connect.js
+++ b/commands/serve/web/connect.js
@@ -177,7 +177,7 @@ const connect = async () => {
 
     return enigma.create({ schema: qixSchema, url }).open();
   } catch (error) {
-    throw new Error('Failed to return enigma instance');
+    throw new Error('Failed to return enigma instance', { cause: error });
   }
 };
 
@@ -199,7 +199,7 @@ const openApp = async (id) => {
     const enigmaGlobal = await enigma.create({ schema: qixSchema, url }).open();
     return enigmaGlobal.openDoc(id);
   } catch (error) {
-    throw new Error('Failed to open app!');
+    throw new Error('Failed to open app!', { cause: error });
   }
 };
 

--- a/commands/serve/web/connect.js
+++ b/commands/serve/web/connect.js
@@ -132,9 +132,13 @@ const setHostConfig = ({ webIntegrationId, clientId, host }) => {
 };
 
 const buildDocList = async () => {
-  const response = await getItems({ resourceType: 'app', limit: 30, sort: '-updatedAt' });
-  const { data = [] } = response.data;
-  return data.map((d) => ({ qDocId: d.resourceId, qTitle: d.name }));
+  try {
+    const response = await getItems({ resourceType: 'app', limit: 30, sort: '-updatedAt' });
+    const { data = [] } = response.data;
+    return data.map((d) => ({ qDocId: d.resourceId, qTitle: d.name }));
+  } catch (error) {
+    throw new Error('Failed to fetch app list', { cause: error });
+  }
 };
 
 const connect = async () => {

--- a/commands/serve/web/hooks/useAppList.js
+++ b/commands/serve/web/hooks/useAppList.js
@@ -18,10 +18,16 @@ export const useAppList = ({ glob, info }) => {
     if (appList?.length) return;
     setLoading(true);
 
-    glob?.getDocList()?.then((apps) => {
-      setAppList(apps);
-      if (apps) setLoading(false);
-    });
+    glob
+      ?.getDocList()
+      ?.then((apps) => {
+        setAppList(apps);
+        if (apps) setLoading(false);
+      })
+      ?.catch((err) => {
+        console.error('Failed to fetch app list:', err);
+        setLoading(false);
+      });
   }, [window.location.search, setLoading, info, glob]);
 
   return { appList, loading };

--- a/commands/serve/web/hooks/useAppList.js
+++ b/commands/serve/web/hooks/useAppList.js
@@ -28,7 +28,7 @@ export const useAppList = ({ glob, info }) => {
         console.error('Failed to fetch app list:', err);
         setLoading(false);
       });
-  }, [window.location.search, setLoading, info, glob]);
+  }, [info, glob]);
 
   return { appList, loading };
 };

--- a/commands/serve/web/hooks/useOpenApp.js
+++ b/commands/serve/web/hooks/useOpenApp.js
@@ -25,7 +25,9 @@ export const useOpenApp = ({ info }) => {
 
       if (webIntegrationId || clientId) {
         setHostConfig({ webIntegrationId, clientId, host });
-        return openAppSession({ appId: info?.enigma.appId }).getDoc();
+        const appId = info?.enigma?.appId;
+        if (!appId) throw new Error('Missing appId in connection info');
+        return openAppSession({ appId }).getDoc();
       }
 
       const csrfToken = await getCsrfToken(
@@ -35,7 +37,7 @@ export const useOpenApp = ({ info }) => {
       const enigmaGlobal = await enigma.create({ schema: qixSchema, url }).open();
       return enigmaGlobal.openDoc(info?.enigma.appId);
     } catch (error) {
-      throw new Error('Failed to open app!');
+      throw new Error('Failed to open app!', { cause: error });
     }
   };
 


### PR DESCRIPTION
## Summary

Code-quality fixes as part of the ongoing `@qlik/sdk` → `@qlik/api` migration work on the `alpha/v7` branch.

- **Deduplicate `getDocList` body in `connect.js`**: Extracted a shared `buildDocList(fetchItems)` helper above `connect()` to eliminate the repeated fetch-and-map pattern in both the `webIntegrationId` and `clientId` branches.
- **Add error handling to `getDocList` in `connect.js`**: Wrapped the `buildDocList` helper body in a `try/catch` that rethrows with `throw new Error('Failed to fetch app list', { cause: error })` to produce a descriptive error without swallowing the original cause.
- **Preserve error cause when rethrowing in `connect.js`**: Both `connect()` and `openApp()` catch blocks were silently dropping the original error. Updated both to pass `{ cause: error }` so the full error chain is preserved.
- **Handle `getDocList` rejection in `useAppList`**: The `getDocList()` promise chain had no rejection handler, leaving `loading` stuck at `true` on failure. Added `.catch((err) => { console.error(...); setLoading(false); })`.
- **Remove `window.location.search` from `useAppList` effect deps**: `window.location.search` is not a reactive React value and cannot trigger re-renders. Also removed `setLoading` (stable `setState` setter). The effect now correctly depends only on `[info, glob]`.
- **Guard against undefined `appId` in `useOpenApp`**: Changed `info?.enigma.appId` (inconsistent optional chain) to `info?.enigma?.appId` and added an explicit guard: `if (!appId) throw new Error('Missing appId in connection info')`. Also plumbed the `cause` option through the catch block.
- **Remove deprecated `@qlik/sdk` from create templates**: Both `commands/create/templates/sn/none/_package.json` and `commands/create/templates/sn/picasso/common/_package.json` still referenced `"@qlik/sdk": "^0.28.0"` in `devDependencies`. Removed the entry from both files.

## Test plan

Ran `yarn test:unit --testPathPatterns commands/serve` before and after the changes. Results are identical — the pre-existing failures (30 suites fail) are caused by `@qlik/sdk` not being installed in the monorepo (a pre-existing issue on `alpha/v7` unrelated to these changes). No new failures were introduced.

```
Test Suites: 30 failed, 78 passed, 108 total
Tests:       4 failed, 2 skipped, 422 passed, 428 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)