### PR TITLE
test: fill coverage gaps from @qlik/api migration

### DIFF
--- a/commands/serve/web/__tests__/connect.test.js
+++ b/commands/serve/web/__tests__/connect.test.js
@@ -110,7 +110,7 @@ describe('connect.js', () => {
       test('getDocList should propagate errors from getItems', async () => {
         getItems.mockRejectedValue(new Error('network error'));
         const result = await connect();
-        await expect(result.getDocList()).rejects.toThrow();
+        await expect(result.getDocList()).rejects.toThrow('network error');
       });
     });
 

--- a/commands/serve/web/__tests__/connect.test.js
+++ b/commands/serve/web/__tests__/connect.test.js
@@ -106,6 +106,12 @@ describe('connect.js', () => {
         expect(getItems).toHaveBeenCalledWith(expect.objectContaining({ resourceType: 'app', limit: 30 }));
         expect(docList).toEqual([{ qDocId: 'app-1', qTitle: 'My App' }]);
       });
+
+      test('getDocList should propagate errors from getItems', async () => {
+        getItems.mockRejectedValue(new Error('network error'));
+        const result = await connect();
+        await expect(result.getDocList()).rejects.toThrow();
+      });
     });
 
     describe('connecting with `clientId` (OAuth2) flow', () => {

--- a/commands/serve/web/__tests__/connect.test.js
+++ b/commands/serve/web/__tests__/connect.test.js
@@ -261,6 +261,44 @@ describe('connect.js', () => {
         });
       });
 
+      describe('open app with clientId (OAuth2) flow', () => {
+        let getDocMock;
+        let appSessionMock;
+
+        beforeEach(() => {
+          jsonResponseMock.mockImplementation(() =>
+            Promise.resolve({
+              clientId: 'someClientId',
+              enigma: {
+                secure: true,
+                host: 'some.eu.tenant.pte.qlikdev.com',
+              },
+            })
+          );
+          getDocMock = jest.fn().mockResolvedValue({ id: appId });
+          appSessionMock = { getDoc: getDocMock };
+          openAppSession.mockReturnValue(appSessionMock);
+        });
+
+        test('should call `auth.setDefaultHostConfig` with oauth2 authType', async () => {
+          await openApp(appId);
+          expect(auth.setDefaultHostConfig).toHaveBeenCalledWith(
+            expect.objectContaining({ authType: 'oauth2', clientId: 'someClientId' })
+          );
+        });
+
+        test('should call `openAppSession` with the app id', async () => {
+          await openApp(appId);
+          expect(openAppSession).toHaveBeenCalledWith({ appId });
+        });
+
+        test('should call `getDoc` and return the document', async () => {
+          const result = await openApp(appId);
+          expect(getDocMock).toHaveBeenCalledTimes(1);
+          expect(result).toEqual({ id: appId });
+        });
+      });
+
       describe('with Local engine flow', () => {
         beforeEach(() => {
           connectionResponse = {

--- a/commands/serve/web/hooks/__tests__/useDeauthorizePrevOAuthInstance.test.js
+++ b/commands/serve/web/hooks/__tests__/useDeauthorizePrevOAuthInstance.test.js
@@ -9,17 +9,16 @@ jest.mock('@qlik/api/auth', () => ({
 }));
 
 describe('useDeauthorizePrevOAuthInstance', () => {
-  let cachedConnections;
+  let useRootContextSpy;
 
   beforeEach(() => {
-    cachedConnections = [];
-    jest.spyOn(RootContextModule, 'useRootContext').mockReturnValue({
-      cachedConnectionsData: { cachedConnections },
+    useRootContextSpy = jest.spyOn(RootContextModule, 'useRootContext').mockReturnValue({
+      cachedConnectionsData: { cachedConnections: [] },
     });
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   test('should call auth.setDefaultHostConfig(undefined) on mount', () => {
@@ -30,14 +29,15 @@ describe('useDeauthorizePrevOAuthInstance', () => {
 
   test('should call auth.setDefaultHostConfig(undefined) again when cachedConnections length changes', () => {
     let connections = [];
-    jest.spyOn(RootContextModule, 'useRootContext').mockReturnValue({
+    useRootContextSpy.mockReturnValue({
       cachedConnectionsData: { cachedConnections: connections },
     });
+
     const { rerender } = renderHook(() => useDeauthorizePrevOAuthInstance());
     expect(auth.setDefaultHostConfig).toHaveBeenCalledTimes(1);
 
     connections = ['ws://localhost:9000/new-connection'];
-    jest.spyOn(RootContextModule, 'useRootContext').mockReturnValue({
+    useRootContextSpy.mockReturnValue({
       cachedConnectionsData: { cachedConnections: connections },
     });
     rerender();

--- a/commands/serve/web/hooks/__tests__/useDeauthorizePrevOAuthInstance.test.js
+++ b/commands/serve/web/hooks/__tests__/useDeauthorizePrevOAuthInstance.test.js
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react';
+import auth from '@qlik/api/auth';
+import { useDeauthorizePrevOAuthInstance } from '../useDeauthorizePrevOAuthInstance';
+import * as RootContextModule from '../../contexts/RootContext';
+
+jest.mock('@qlik/api/auth', () => ({
+  __esModule: true,
+  default: { setDefaultHostConfig: jest.fn() },
+}));
+
+describe('useDeauthorizePrevOAuthInstance', () => {
+  let cachedConnections;
+
+  beforeEach(() => {
+    cachedConnections = [];
+    jest.spyOn(RootContextModule, 'useRootContext').mockReturnValue({
+      cachedConnectionsData: { cachedConnections },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should call auth.setDefaultHostConfig(undefined) on mount', () => {
+    renderHook(() => useDeauthorizePrevOAuthInstance());
+    expect(auth.setDefaultHostConfig).toHaveBeenCalledTimes(1);
+    expect(auth.setDefaultHostConfig).toHaveBeenCalledWith(undefined);
+  });
+
+  test('should call auth.setDefaultHostConfig(undefined) again when cachedConnections length changes', () => {
+    let connections = [];
+    jest.spyOn(RootContextModule, 'useRootContext').mockReturnValue({
+      cachedConnectionsData: { cachedConnections: connections },
+    });
+    const { rerender } = renderHook(() => useDeauthorizePrevOAuthInstance());
+    expect(auth.setDefaultHostConfig).toHaveBeenCalledTimes(1);
+
+    connections = ['ws://localhost:9000/new-connection'];
+    jest.spyOn(RootContextModule, 'useRootContext').mockReturnValue({
+      cachedConnectionsData: { cachedConnections: connections },
+    });
+    rerender();
+
+    expect(auth.setDefaultHostConfig).toHaveBeenCalledTimes(2);
+    expect(auth.setDefaultHostConfig).toHaveBeenCalledWith(undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses test coverage gaps identified during the `@qlik/sdk` → `@qlik/api` migration review.

- **clientId openApp tests**: New `describe` block covering the OAuth2 `openApp` flow (mirrors the existing `webIntegrationId` block)
- **getDocList error path**: Verifies that a rejected `getItems` call propagates as a rejection from `getDocList`
- **Remove stale skipped tests**: Two `test.skip` blocks in `useAppList.test.js` covered the deleted `shouldFetchAppList` URL flow — removed entirely
- **useDeauthorizePrevOAuthInstance tests**: New test file verifying `auth.setDefaultHostConfig(undefined)` is called on mount and when `cachedConnections` length changes

## Test plan
- [ ] All 4 new/modified test files pass
- [ ] `yarn test:unit --testPathPatterns commands/serve` green