### PR TITLE
rollup: resolve .mjs and silence Mantine sourcemap warnings

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -112,6 +112,9 @@ const config = ({ format = 'umd', debug = false, file, targetPkg }) => {
       if (warning.code === 'MODULE_LEVEL_DIRECTIVE' && warning.message.includes(`"use client"`)) {
         return;
       }
+      if (warning.code === 'SOURCEMAP_ERROR' && warning.message.includes('@mantine')) {
+        return;
+      }
       if (warning.code === 'INVALID_ANNOTATION' && warning.frame.includes(`// eslint-disable-next-line react`)) {
         return;
       }
@@ -159,7 +162,7 @@ const config = ({ format = 'umd', debug = false, file, targetPkg }) => {
         preventAssignment: true,
       }),
       nodeResolve({
-        extensions: [debug ? '.dev.js' : false, '.js', '.jsx'].filter(Boolean),
+        extensions: [debug ? '.dev.js' : false, '.mjs', '.js', '.jsx'].filter(Boolean),
         browser: true,
       }),
       json(),


### PR DESCRIPTION
Add .mjs to nodeResolve extensions so Rollup can load Mantine's ESM-only build, and suppress SOURCEMAP_ERROR warnings originating from @mantine packages.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
