### PR TITLE
feat(serve): add rerender and simulatedMemLeakKB options

### DIFF
--- a/commands/serve/docs/fixture-render.md
+++ b/commands/serve/docs/fixture-render.md
@@ -56,3 +56,19 @@ Specify an array of available themes in the instance config. Provide the `id` of
 ### `language`
 
 Language to use when rendering visualization.
+
+### `rerenders`
+
+Number of destroy-and-re-render cycles to run after the initial render. After each cycle `data-render-count` on `#chart-container` is incremented, so when it reaches `N` all cycles are complete.
+
+Intended for memory leak testing. The recommended pattern is two separate navigations: first load the fixture without `rerenders` and take a baseline heap snapshot, then reload with `rerenders=N` and take the after-snapshot once `#chart-container[data-render-count='N']` is present.
+
+Example: `http://localhost:8000/render?fixture=scenario-1.fix.js&rerenders=20`
+
+### `simulatedMemLeakKB`
+
+Wraps the fixture's `getLayout` to accumulate approximately the given number of kilobytes of plain JS objects per render cycle, pinned to the DOM so the garbage collector cannot reclaim them. Use together with `rerenders` to verify that your memory measurement infrastructure can detect a real leak before trusting clean-chart results.
+
+This parameter has no effect unless `rerenders` is also set.
+
+Example leaking 500 KB per cycle: `http://localhost:8000/render?fixture=scenario-1.fix.js&rerenders=20&simulatedMemLeakKB=500`

--- a/commands/serve/web/__tests__/render-fixture.test.js
+++ b/commands/serve/web/__tests__/render-fixture.test.js
@@ -1,0 +1,167 @@
+import EnigmaMocker from '@nebula.js/enigma-mocker';
+import { embed } from '@nebula.js/stardust';
+import { getConnectionInfo } from '../connect';
+import { getModule } from '../hot';
+import renderFixture from '../render-fixture';
+
+jest.mock('@nebula.js/enigma-mocker', () => ({
+  __esModule: true,
+  default: {
+    fromGenericObjects: jest.fn(),
+  },
+}));
+
+jest.mock('@nebula.js/stardust', () => ({
+  embed: jest.fn(),
+}));
+
+jest.mock('../connect', () => ({
+  getConnectionInfo: jest.fn(),
+}));
+
+jest.mock('../hot', () => ({
+  getModule: jest.fn(),
+}));
+
+describe('render-fixture', () => {
+  let chartContainer;
+  let qId;
+  let baseLayout;
+  let getLayoutBase;
+  let mockObject;
+  let mockApp;
+  let nebbie;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="chart-container"></div><div id="events"></div>';
+    chartContainer = document.querySelector('#chart-container');
+
+    qId = 'obj-1';
+    baseLayout = {
+      qInfo: { qId },
+      visualization: 'my-viz',
+    };
+
+    getLayoutBase = jest.fn(async () => baseLayout);
+    mockObject = {
+      getLayout: getLayoutBase,
+    };
+
+    mockApp = {
+      getObject: jest.fn(async () => mockObject),
+    };
+
+    window.serveFixtures = new Map([
+      [
+        'my.fix.js',
+        () => ({
+          type: 'my-viz',
+          load: async () => ({}),
+          genericObjects: [{ getLayout: baseLayout }],
+          snConfig: {},
+        }),
+      ],
+    ]);
+
+    getConnectionInfo.mockResolvedValue({ types: [] });
+    getModule.mockResolvedValue(() => ({}));
+    EnigmaMocker.fromGenericObjects.mockResolvedValue(mockApp);
+
+    nebbie = {
+      render: jest.fn(async () => {
+        const vizEl = document.createElement('div');
+        vizEl.className = 'njs-viz';
+        vizEl.setAttribute('data-render-count', '1');
+        chartContainer.appendChild(vizEl);
+
+        const obj = await mockApp.getObject(qId);
+        let onChanged = null;
+        if (obj.on) {
+          onChanged = async () => {
+            await obj.getLayout();
+            const current = parseInt(vizEl.getAttribute('data-render-count'), 10);
+            vizEl.setAttribute('data-render-count', String(current + 1));
+          };
+          obj.on('changed', onChanged);
+        }
+
+        return {
+          addListener: jest.fn(),
+          destroy: jest.fn(async () => {
+            if (obj.removeListener && onChanged) {
+              obj.removeListener('changed', onChanged);
+            }
+            vizEl.remove();
+          }),
+        };
+      }),
+    };
+
+    embed.mockReturnValue(nebbie);
+
+    jest.spyOn(global, 'requestAnimationFrame').mockImplementation((cb) => setTimeout(cb, 0));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+  });
+
+  test('throws a useful error when fixture cannot be found', async () => {
+    await expect(renderFixture({ fixture: 'missing.fix.js' })).rejects.toThrow('Unable to load fixture missing.fix.js');
+  });
+
+  test('falls back to default generic object when fixture has none', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(12345);
+    window.serveFixtures.set('no-generic.fix.js', () => ({
+      type: 'my-viz',
+      load: async () => ({}),
+      snConfig: {},
+    }));
+
+    await renderFixture({ fixture: 'no-generic.fix.js' });
+
+    expect(EnigmaMocker.fromGenericObjects).toHaveBeenCalledWith(
+      [
+        {
+          getLayout: {
+            qInfo: { qId: 12345 },
+            visualization: 'my-viz',
+          },
+        },
+      ],
+      undefined
+    );
+    nowSpy.mockRestore();
+  });
+
+  test('maps URL params to embed context', async () => {
+    await renderFixture({ fixture: 'my.fix.js', theme: 'dark', language: 'sv-SE', keyboardNavigation: 'true' });
+
+    expect(embed).toHaveBeenCalledWith(
+      mockApp,
+      expect.objectContaining({
+        context: expect.objectContaining({
+          theme: 'dark',
+          language: 'sv-SE',
+          keyboardNavigation: 'true',
+        }),
+      })
+    );
+  });
+
+  test('rerenders requested number of times and updates container render count', async () => {
+    await renderFixture({ fixture: 'my.fix.js', rerenders: '3' });
+
+    expect(nebbie.render).toHaveBeenCalledTimes(4); // initial render + 3 rerenders
+    expect(chartContainer.getAttribute('data-render-count')).toBe('3');
+  });
+
+  test('simulatedMemLeakKB keeps leak store reachable and triggers getLayout on changed events', async () => {
+    await renderFixture({ fixture: 'my.fix.js', rerenders: '2', simulatedMemLeakKB: '8' });
+
+    expect(Array.isArray(chartContainer.leakStore)).toBe(true);
+    expect(chartContainer.leakStore.length).toBeGreaterThan(0);
+    expect(getLayoutBase).toHaveBeenCalled();
+  });
+});

--- a/commands/serve/web/render-fixture.js
+++ b/commands/serve/web/render-fixture.js
@@ -101,8 +101,28 @@ function getQId(genericObjects = []) {
   return layout.qInfo.qId;
 }
 
+const waitForVizGone = (element) =>
+  new Promise((resolve) => {
+    const check = () => {
+      if (!element.querySelector('.njs-viz')) resolve();
+      else requestAnimationFrame(check);
+    };
+    requestAnimationFrame(check);
+  });
+
+const waitForRenderCountAbove = (element, count) =>
+  new Promise((resolve) => {
+    const check = () => {
+      const vizEl = element.querySelector('.njs-viz[data-render-count]');
+      if (vizEl && parseInt(vizEl.getAttribute('data-render-count'), 10) > count) resolve();
+      else requestAnimationFrame(check);
+    };
+    requestAnimationFrame(check);
+  });
+
 const renderFixture = async (params) => {
   const element = document.querySelector('#chart-container');
+  const rerenders = params.rerenders ? parseInt(params.rerenders, 10) : 0;
   const serverInfo = await getConnectionInfo();
   const fixture = await getFixture(params.fixture);
   const { type, load, genericObjects, instanceConfig, snConfig, enigmaMockerOptions } = await getOptions({
@@ -110,8 +130,46 @@ const renderFixture = async (params) => {
     params,
     serverInfo,
   });
+
   const mockedApp = await EnigmaMocker.fromGenericObjects(genericObjects, enigmaMockerOptions);
   const qId = getQId(genericObjects);
+
+  // When ?simulatedMemLeakKB=<n>: patch the mock object to support real event emission so nebula
+  // re-calls getLayout on every 'changed' event. Each getLayout call accumulates plain JS objects
+  // totalling ~n KB, pinned via element.leakStore so GC cannot collect them. Use together with
+  // ?rerenders to verify that your memory measurement infrastructure detects a real leak before
+  // trusting clean-chart results.
+  // 48 bytes is the measured V8 heap cost of one { j, v } object.
+  let leakMock = null;
+  if (params.simulatedMemLeakKB) {
+    const leakKB = parseFloat(params.simulatedMemLeakKB);
+    const itemCount = Math.round((leakKB * 1024) / 48);
+    leakMock = await mockedApp.getObject(qId);
+    const evListeners = {};
+    leakMock.on = (event, fn) => {
+      (evListeners[event] = evListeners[event] || []).push(fn);
+    };
+    leakMock.once = (event, fn) => {
+      const wrapper = () => {
+        fn();
+        leakMock.removeListener(event, wrapper);
+      };
+      leakMock.on(event, wrapper);
+    };
+    leakMock.removeListener = (event, fn) => {
+      if (evListeners[event]) evListeners[event] = evListeners[event].filter((h) => h !== fn);
+    };
+    leakMock.emit = (event) => {
+      (evListeners[event] || []).forEach((h) => h());
+    };
+    // Pin to the DOM element so the store stays reachable after renderFixture returns.
+    element.leakStore = [];
+    const origGetLayout = leakMock.getLayout.bind(leakMock);
+    leakMock.getLayout = async () => {
+      element.leakStore.push(new Array(itemCount).fill(null).map((_, j) => ({ j, v: Math.random() })));
+      return origGetLayout();
+    };
+  }
   const servedTypes = (serverInfo && serverInfo.types) || [];
   const nebbie = embed(mockedApp, {
     types: [
@@ -138,6 +196,36 @@ const renderFixture = async (params) => {
       document.querySelector('#events').innerHTML = message;
     });
   });
+
+  let currentViz = viz;
+
+  const runRerenders = async (count) => {
+    for (let i = 0; i < count; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await currentViz.destroy();
+      // eslint-disable-next-line no-await-in-loop
+      await waitForVizGone(element);
+      // eslint-disable-next-line no-await-in-loop
+      currentViz = await nebbie.render({ type, element, id: qId, ...snConfig });
+      // eslint-disable-next-line no-await-in-loop
+      await waitForRenderCountAbove(element, 0);
+      if (leakMock) {
+        const currentCount = parseInt(
+          element.querySelector('.njs-viz[data-render-count]').getAttribute('data-render-count'),
+          10
+        );
+        leakMock.emit('changed');
+        // eslint-disable-next-line no-await-in-loop
+        await waitForRenderCountAbove(element, currentCount);
+      }
+      element.setAttribute('data-render-count', String(i + 1));
+    }
+  };
+
+  if (rerenders > 0) {
+    await waitForRenderCountAbove(element, 0);
+    await runRerenders(rerenders);
+  }
 };
 
 export default renderFixture;


### PR DESCRIPTION
## Motivation

This PR adds two new URL parameters in fixture rendering:

* `rerenders`: runs repeated destroy/re-render cycles.
* `simulatedMemLeakKB`: injects controlled retained memory per cycle.

They can, for example, be used for testing chart memory consumption and validating that memory measurements detect known leaks.

Also included:

documentation for both parameters,
focused unit tests covering rerender behavior, simulated leak behavior, and a few core render-fixture cases.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [x] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [x] Add code reviewers, for example @qlik-oss/nebula-core
