### PR TITLE
fix: make listbox cover entire parent element

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -273,7 +273,7 @@ function ListBoxInline({ options, layout }) {
         gap={0}
         containerPadding={containerPadding}
         styles={styles}
-        style={{ height: '100%', flexFlow: 'column nowrap' }}
+        style={{ height: '100%', width: "100%",  flexFlow: 'column nowrap' }}
         onKeyDown={handleKeyDown}
         onMouseEnter={handleOnMouseEnter}
         onMouseLeave={handleOnMouseLeave}

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -273,7 +273,7 @@ function ListBoxInline({ options, layout }) {
         gap={0}
         containerPadding={containerPadding}
         styles={styles}
-        style={{ height: '100%', width: "100%",  flexFlow: 'column nowrap' }}
+        style={{ height: '100%', width: '100%',  flexFlow: 'column nowrap' }}
         onKeyDown={handleKeyDown}
         onMouseEnter={handleOnMouseEnter}
         onMouseLeave={handleOnMouseLeave}

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -273,7 +273,7 @@ function ListBoxInline({ options, layout }) {
         gap={0}
         containerPadding={containerPadding}
         styles={styles}
-        style={{ height: '100%', width: '100%',  flexFlow: 'column nowrap' }}
+        style={{ height: '100%', width: '100%', flexFlow: 'column nowrap' }}
         onKeyDown={handleKeyDown}
         onMouseEnter={handleOnMouseEnter}
         onMouseLeave={handleOnMouseLeave}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

When mounting a listbox in an element it has 100% height but not width, so will not fit into for example a popover properly.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
