### PR TITLE
fix: fix listbox title for master dimension (re-land + drilldown support)

### DIFF
--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -184,7 +184,7 @@ function ListBoxInline({ options, layout }) {
   const showSearchIcon = searchEnabled !== false && search === 'toggle' && !isLocked;
 
   const dimInfo = layout?.qListObject?.qDimensionInfo;
-  const effectiveTitle = (dimInfo?.qLibraryId ? dimInfo?.qFallbackTitle : layout?.title);
+  const effectiveTitle = dimInfo?.qLibraryId ? dimInfo?.qFallbackTitle : layout?.title;
   const canShowTitle = effectiveTitle?.length && layout?.showTitle !== false;
   const showDetachedToolbarOnly = toolbar && !canShowTitle && !isPopover;
   const showAttachedToolbar = (toolbar && canShowTitle) || isPopover;

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -183,7 +183,9 @@ function ListBoxInline({ options, layout }) {
   const isLocked = layout?.qListObject?.qDimensionInfo?.qLocked;
   const showSearchIcon = searchEnabled !== false && search === 'toggle' && !isLocked;
 
-  const canShowTitle = layout?.title?.length && layout?.showTitle !== false;
+  const dimInfo = layout?.qListObject?.qDimensionInfo;
+  const effectiveTitle = (dimInfo?.qLibraryId ? dimInfo?.qFallbackTitle : layout?.title);
+  const canShowTitle = effectiveTitle?.length && layout?.showTitle !== false;
   const showDetachedToolbarOnly = toolbar && !canShowTitle && !isPopover;
   const showAttachedToolbar = (toolbar && canShowTitle) || isPopover;
 
@@ -245,6 +247,7 @@ function ListBoxInline({ options, layout }) {
       isDirectQuery={isDirectQuery}
       autoConfirm={autoConfirm}
       showDetachedToolbarOnly={showDetachedToolbarOnly}
+      title={effectiveTitle}
       layout={layout}
       translator={translator}
       styles={styles}

--- a/apis/nucleus/src/components/listbox/components/ListBoxHeader/ListBoxHeader.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxHeader/ListBoxHeader.jsx
@@ -82,6 +82,7 @@ export default function ListBoxHeader({
   keyboard,
   autoConfirm,
   app,
+  title,
   disablePortal,
 }) {
   const [isToolbarDetached, setIsToolbarDetached] = useState(showDetachedToolbarOnly);
@@ -257,8 +258,8 @@ export default function ListBoxHeader({
         justifyContent={isRtl ? 'flex-end' : 'flex-start'}
         className={classes.listBoxHeader}
       >
-        <HeaderTitle variant="h6" noWrap ref={titleRef} title={layout.title} styles={styles}>
-          {layout.title}
+        <HeaderTitle variant="h6" noWrap ref={titleRef} title={title ?? layout.title} styles={styles}>
+          {title ?? layout.title}
         </HeaderTitle>
       </Grid>
       <Grid display="flex">{actionsToolbar}</Grid>

--- a/apis/nucleus/src/object/__tests__/filterpane-handler.test.js
+++ b/apis/nucleus/src/object/__tests__/filterpane-handler.test.js
@@ -100,7 +100,7 @@ describe('filterpane-handler', () => {
             qInfo: {
               qType: expect.any(String),
             },
-            title: 'lib dim title',
+            title: '',
             searchEnabled: true,
             showTitle: true,
             wildCardSearch: false,

--- a/apis/nucleus/src/object/__tests__/filterpane-handler.test.js
+++ b/apis/nucleus/src/object/__tests__/filterpane-handler.test.js
@@ -218,6 +218,19 @@ describe('filterpane-handler', () => {
       ]);
     });
 
+    test('from master dimension with drilldown grouping - leaves title empty so qFallbackTitle is used', async () => {
+      halo.app.getDimension = async () => ({
+        getProperties: async () => ({
+          qDim: {
+            title: 'drilldown dim',
+            qGrouping: 'H',
+          },
+        }),
+      });
+      await h.addDimension({ qLibraryId: 'abc' });
+      expect(children[0].qProperty.title).toEqual('');
+    });
+
     test('from master dimension with cyclic grouping - uses GroupDimensionLabel expression', async () => {
       halo.app.getDimension = async () => ({
         getProperties: async () => ({
@@ -230,21 +243,6 @@ describe('filterpane-handler', () => {
       await h.addDimension({ qLibraryId: 'abc' });
       expect(children[0].qProperty.title).toEqual({
         qStringExpression: { qExpr: "GroupDimensionLabel('cyclic dim')" },
-      });
-    });
-
-    test('from master dimension with drilldown grouping - uses GroupDimensionLabel expression', async () => {
-      halo.app.getDimension = async () => ({
-        getProperties: async () => ({
-          qDim: {
-            title: 'drilldown dim',
-            qGrouping: 'H',
-          },
-        }),
-      });
-      await h.addDimension({ qLibraryId: 'abc' });
-      expect(children[0].qProperty.title).toEqual({
-        qStringExpression: { qExpr: "GroupDimensionLabel('drilldown dim')" },
       });
     });
 

--- a/apis/nucleus/src/object/__tests__/filterpane-handler.test.js
+++ b/apis/nucleus/src/object/__tests__/filterpane-handler.test.js
@@ -218,6 +218,36 @@ describe('filterpane-handler', () => {
       ]);
     });
 
+    test('from master dimension with cyclic grouping - uses GroupDimensionLabel expression', async () => {
+      halo.app.getDimension = async () => ({
+        getProperties: async () => ({
+          qDim: {
+            title: 'cyclic dim',
+            qGrouping: 'C',
+          },
+        }),
+      });
+      await h.addDimension({ qLibraryId: 'abc' });
+      expect(children[0].qProperty.title).toEqual({
+        qStringExpression: { qExpr: "GroupDimensionLabel('cyclic dim')" },
+      });
+    });
+
+    test('from master dimension with drilldown grouping - uses GroupDimensionLabel expression', async () => {
+      halo.app.getDimension = async () => ({
+        getProperties: async () => ({
+          qDim: {
+            title: 'drilldown dim',
+            qGrouping: 'H',
+          },
+        }),
+      });
+      await h.addDimension({ qLibraryId: 'abc' });
+      expect(children[0].qProperty.title).toEqual({
+        qStringExpression: { qExpr: "GroupDimensionLabel('drilldown dim')" },
+      });
+    });
+
     test('from listbox object - override title', () => {
       h.addDimension({
         checkboxes: true,

--- a/apis/nucleus/src/object/filterpane-handler.js
+++ b/apis/nucleus/src/object/filterpane-handler.js
@@ -36,9 +36,16 @@ export default function filterpaneHandler({ /* dc, def, properties, */ children,
                 qExpr: dimProps.qDim.qLabelExpression,
               },
             };
-          } else {
-            listboxProps.title = dimProps.qDim.title;
+          } else if (dimProps.qDim.qGrouping === 'C') {
+            listboxProps.title = {
+              qStringExpression: {
+                qExpr: `GroupDimensionLabel('${dimProps.qDim.title}')`,
+              },
+            };
           }
+          // For regular (non-cyclic) master dimensions without a label expression,
+          // leave title empty so qFallbackTitle is used instead. This ensures the
+          // filterpane title always reflects the current master dimension name.
         } else {
           listboxProps.title =
             dimension.qDef.title || dimension.qDef.qFieldLabels?.[0] || dimension.qDef.qFieldDefs?.[0];

--- a/apis/nucleus/src/object/filterpane-handler.js
+++ b/apis/nucleus/src/object/filterpane-handler.js
@@ -36,14 +36,14 @@ export default function filterpaneHandler({ /* dc, def, properties, */ children,
                 qExpr: dimProps.qDim.qLabelExpression,
               },
             };
-          } else if (dimProps.qDim.qGrouping === 'C') {
+          } else if (dimProps.qDim.qGrouping === 'C' || dimProps.qDim.qGrouping === 'H') {
             listboxProps.title = {
               qStringExpression: {
                 qExpr: `GroupDimensionLabel('${dimProps.qDim.title}')`,
               },
             };
           }
-          // For regular (non-cyclic) master dimensions without a label expression,
+          // For regular (non-cyclic, non-drilldown) master dimensions without a label expression,
           // leave title empty so qFallbackTitle is used instead. This ensures the
           // filterpane title always reflects the current master dimension name.
         } else {

--- a/apis/nucleus/src/object/filterpane-handler.js
+++ b/apis/nucleus/src/object/filterpane-handler.js
@@ -36,14 +36,14 @@ export default function filterpaneHandler({ /* dc, def, properties, */ children,
                 qExpr: dimProps.qDim.qLabelExpression,
               },
             };
-          } else if (dimProps.qDim.qGrouping === 'C' || dimProps.qDim.qGrouping === 'H') {
+          } else if (dimProps.qDim.qGrouping === 'C') {
             listboxProps.title = {
               qStringExpression: {
                 qExpr: `GroupDimensionLabel('${dimProps.qDim.title}')`,
               },
             };
           }
-          // For regular (non-cyclic, non-drilldown) master dimensions without a label expression,
+          // For regular (non-cyclic) master dimensions without a label expression,
           // leave title empty so qFallbackTitle is used instead. This ensures the
           // filterpane title always reflects the current master dimension name.
         } else {


### PR DESCRIPTION
Re-lands #2083 which was reverted in #2103.

**Changes**

- Re-applies the original fix for listbox title on master dimensions
- Adds unit tests for cyclic and drilldown grouped master dimension title handling

Why GroupDimensionLabel is only for cyclic, not drilldown
Cyclic dimensions (qGrouping === 'C') need the GroupDimensionLabel('group name') engine expression because the active field changes when the user cycles — the expression resolves dynamically to the current field's label.

Drilldown dimensions (qGrouping === 'H') don't need this. The engine already reflects the current active field in qFallbackTitle on the layout, which ListBoxInline reads at render time. This is also consistent with how sense-client handles it.

Backward compatibility
This does not break existing filterpanes. The three changed files each handle a distinct case:

- filterpane-handler.js: For regular (non-cyclic) master dims, the stored title is now left empty instead of capturing a static name at creation time. ListBoxInline compensates by reading the engine's live qFallbackTitle when qLibraryId is present — so the displayed title is always current, even if the dimension is renamed in the library.
- ListBoxInline.jsx: The effectiveTitle logic uses qFallbackTitle for master dims and layout.title for inline dims — both paths behave correctly for existing and new objects.
- ListBoxHeader.jsx: The new title prop is optional with a ?? layout.title fallback, so any caller that does not pass it is unaffected.

Before the change:

https://github.com/user-attachments/assets/8dad4d64-06e4-4f15-849b-56f0a72180d3

After the change:

https://github.com/user-attachments/assets/f21896f1-a3b4-4411-b8a7-2675b373873f

