### PR TITLE
fix(theme): don't crash generating a pyramid from a single-color class scale

### DIFF
--- a/apis/theme/src/__tests__/theme-scale-generator.test.js
+++ b/apis/theme/src/__tests__/theme-scale-generator.test.js
@@ -24,6 +24,18 @@ describe('Theme scale generator', () => {
     expect(colors).toEqual(base8);
   });
 
+  test('Should not throw and generate a constant pyramid for a single-color scale', () => {
+    const scales = [{ type: 'class', scale: ['#3200e6'] }];
+    expect(() => scaleGenerator(scales)).not.toThrow();
+    const { scale, type } = scales[0];
+
+    expect(type).toBe('class-pyramid');
+    expect(scale).toHaveLength(8);
+    scale.slice(1).forEach((level) => {
+      level.forEach((c) => expect(c).toBe('#3200e6'));
+    });
+  });
+
   test('Should work correctly on a scale from the sense theme', () => {
     const senseDivergentScale = [
       '#ae1c3e',

--- a/apis/theme/src/theme-scale-generator.js
+++ b/apis/theme/src/theme-scale-generator.js
@@ -32,9 +32,10 @@ function setupColorScale(colors, nanColor, gradient) {
     newColors.push(colors[i]);
   }
 
-  newColors.push(colors[i]);
+  const lastColor = colors[colors.length - 1];
+  newColors.push(lastColor);
   if (!gradient) {
-    newColors.push(colors[i]);
+    newColors.push(lastColor);
   }
 
   for (let j = 0; j < newColors.length; j += 2) {


### PR DESCRIPTION
## Summary
- Themes with a single-color "class" scale (a valid, common authoring pattern — e.g. a single-color measure palette) crash theme parsing with `TypeError: Cannot read properties of null (reading 'formatHex')`.
- Root cause: `setupColorScale` in `theme-scale-generator.js` reads `colors[i]` after a duplication loop, where `i` is left at `1` when the input array has exactly one color — out of bounds, yielding `undefined`, which then fails `color(undefined).formatHex()`.
- Fix: use `colors[colors.length - 1]` instead, which is equivalent for scales with 2+ colors and resolves correctly to the sole color for length-1 scales.
- On the classic sense-client renderer this crash is masked by an outer `.catch()` that warns and disables the whole theme; on the new-sheet path (qmfe-embed/analytic-sheet) the equivalent rejection is silently swallowed, so the sheet renders `Loading...` forever with no console output. Companion PR: qlik-trial/qmfe-embed#TBD (adds logging so future failures aren't silent).

## Test plan
- [x] Added a regression test: single-color class scale no longer throws and produces a constant pyramid.
- [x] Existing `theme-scale-generator.test.js` suite passes unchanged.
- [x] Reproduced the crash against the actual customer theme JSON from SUPPORT-11278 before the fix, confirmed it no longer throws after.