### PR TITLE
feat: make requirements more responsive + toolbarmode

### DIFF
--- a/apis/nucleus/src/components/Error.jsx
+++ b/apis/nucleus/src/components/Error.jsx
@@ -92,8 +92,7 @@ export default function Error({ title = 'Error', message = '', data = [] }) {
     baseContentRect.width + descriptionsMeasureRect.width <= containerRect.width;
 
   const hasMeasurements = !!containerRect && !!baseContentRect && !!descriptionsMeasureRect;
-  const showDescriptions =
-    hasDescriptions && hasMeasurements && (!needsSecondColumn || secondColumnFits);
+  const showDescriptions = hasDescriptions && hasMeasurements && (!needsSecondColumn || secondColumnFits);
 
   return (
     <Grid

--- a/apis/nucleus/src/components/Error.jsx
+++ b/apis/nucleus/src/components/Error.jsx
@@ -4,6 +4,7 @@ import { Grid, Typography, Icon } from '@mui/material';
 import WarningTriangle from '@nebula.js/ui/icons/warning-triangle-2';
 import Tick from '@nebula.js/ui/icons/tick';
 import { useTheme } from '@nebula.js/ui/theme';
+import useRect from '../hooks/useRect';
 
 function DescriptionRow({ d }) {
   const theme = useTheme();
@@ -73,28 +74,62 @@ function Descriptions({ data }) {
 }
 
 export default function Error({ title = 'Error', message = '', data = [] }) {
+  const [containerRef, containerRect] = useRect();
+  const [baseContentRef, baseContentRect] = useRect();
+  const [descriptionsMeasureRef, descriptionsMeasureRect] = useRect();
+  const hasDescriptions = data.some((entry) => entry.descriptions && entry.descriptions.length > 0);
+
+  const needsSecondColumn =
+    !!containerRect &&
+    !!baseContentRect &&
+    !!descriptionsMeasureRect &&
+    baseContentRect.height + descriptionsMeasureRect.height > containerRect.height;
+
+  const secondColumnFits =
+    !!containerRect &&
+    !!baseContentRect &&
+    !!descriptionsMeasureRect &&
+    baseContentRect.width + descriptionsMeasureRect.width <= containerRect.width;
+
+  const hasMeasurements = !!containerRect && !!baseContentRect && !!descriptionsMeasureRect;
+  const showDescriptions =
+    hasDescriptions && hasMeasurements && (!needsSecondColumn || secondColumnFits);
+
   return (
     <Grid
+      ref={containerRef}
       container
       direction="column"
+      wrap="wrap"
       alignItems="center"
       justifyContent="center"
       style={{ position: 'relative', height: '100%', width: '100%' }}
     >
-      <Grid>
-        <WarningTriangle style={{ fontSize: '38px' }} />
+      <Grid ref={baseContentRef} container direction="column" alignItems="center" wrap="nowrap">
+        <Grid>
+          <WarningTriangle style={{ fontSize: '38px' }} />
+        </Grid>
+        <Grid>
+          <Typography variant="h6" align="center" data-tid="error-title">
+            {title}
+          </Typography>
+        </Grid>
+        <Grid>
+          <Typography variant="subtitle1" align="center" data-tid="error-message">
+            {message}
+          </Typography>
+        </Grid>
       </Grid>
-      <Grid>
-        <Typography variant="h6" align="center" data-tid="error-title">
-          {title}
-        </Typography>
-      </Grid>
-      <Grid>
-        <Typography variant="subtitle1" align="center" data-tid="error-message">
-          {message}
-        </Typography>
-      </Grid>
-      <Descriptions data={data} />
+      {showDescriptions ? <Descriptions data={data} /> : null}
+      {hasDescriptions ? (
+        <Grid
+          ref={descriptionsMeasureRef}
+          aria-hidden
+          style={{ position: 'absolute', visibility: 'hidden', pointerEvents: 'none', left: 0, top: 0 }}
+        >
+          <Descriptions data={data} />
+        </Grid>
+      ) : null}
     </Grid>
   );
 }

--- a/apis/nucleus/src/components/__tests__/error.test.jsx
+++ b/apis/nucleus/src/components/__tests__/error.test.jsx
@@ -3,6 +3,7 @@ import { create, act } from 'react-test-renderer';
 import WarningTriangle from '@nebula.js/ui/icons/warning-triangle-2';
 import Tick from '@nebula.js/ui/icons/tick';
 import * as nebulaUIThemeModule from '@nebula.js/ui/theme';
+import * as useRectModule from '../../hooks/useRect';
 
 import Error, { Descriptions, DescriptionRow } from '../Error';
 
@@ -11,6 +12,7 @@ jest.mock('@nebula.js/ui/theme', () => ({ ...jest.requireActual('@nebula.js/ui/t
 describe('<Error />', () => {
   let renderer;
   let render;
+  let mockRects;
   beforeEach(() => {
     // for getter functions of a module, we need to mock and jest.requireActual them as well to pass the getter step
     jest.spyOn(nebulaUIThemeModule, 'useTheme').mockImplementation(() => ({
@@ -27,6 +29,13 @@ describe('<Error />', () => {
         },
       },
     }));
+    mockRects = (containerRect, baseContentRect, descriptionsMeasureRect) => {
+      jest
+        .spyOn(useRectModule, 'default')
+        .mockImplementationOnce(() => [() => {}, containerRect])
+        .mockImplementationOnce(() => [() => {}, baseContentRect])
+        .mockImplementationOnce(() => [() => {}, descriptionsMeasureRect]);
+    };
     render = async (title, message, data) => {
       await act(async () => {
         renderer = create(<Error title={title} message={message} data={data} />);
@@ -47,6 +56,7 @@ describe('<Error />', () => {
   });
 
   test('should render error', async () => {
+    mockRects({ width: 400, height: 400 }, { width: 100, height: 100 }, { width: 200, height: 100 });
     await render('foo', 'bar', [{ title: 'foo', descriptions: [] }]);
     const title = renderer.root.find((el) => el.props['data-tid'] === 'error-title');
     expect(title.props.children).toBe('foo');
@@ -54,7 +64,7 @@ describe('<Error />', () => {
     expect(msg.props.children).toBe('bar');
   });
 
-  test('should render error with descriptions', async () => {
+  test('should render visible and measured descriptions when they fit', async () => {
     const d = [1, 2, 3, 4, 5, 6].map((n) => ({
       description: `d-${n}`,
       label: `l-${n}`,
@@ -70,13 +80,32 @@ describe('<Error />', () => {
       descriptions: d.slice(3),
     };
     const data = [dims, meas];
+    mockRects({ width: 400, height: 400 }, { width: 100, height: 100 }, { width: 200, height: 100 });
     await render('foo', 'bar', data);
-    const list = renderer.root.findByType(Descriptions);
-    const rows = list.findAllByType(DescriptionRow);
-    expect(rows).toHaveLength(6);
-    const w = list.findAllByType(WarningTriangle);
-    const t = list.findAllByType(Tick);
-    expect(w).toHaveLength(3);
-    expect(t).toHaveLength(3);
+    const lists = renderer.root.findAllByType(Descriptions);
+    const rows = renderer.root.findAllByType(DescriptionRow);
+    expect(lists).toHaveLength(2);
+    expect(rows).toHaveLength(12);
+    const w = renderer.root.findAllByType(WarningTriangle);
+    const t = renderer.root.findAllByType(Tick);
+    expect(w).toHaveLength(7);
+    expect(t).toHaveLength(6);
+  });
+
+  test('should only render measured descriptions when a second column would overflow', async () => {
+    const data = [
+      {
+        title: 'Dimensions',
+        descriptions: [{ description: 'd-1', label: 'l-1' }],
+      },
+    ];
+
+    mockRects({ width: 250, height: 150 }, { width: 100, height: 100 }, { width: 200, height: 100 });
+    await render('foo', 'bar', data);
+
+    const lists = renderer.root.findAllByType(Descriptions);
+    const rows = renderer.root.findAllByType(DescriptionRow);
+    expect(lists).toHaveLength(1);
+    expect(rows).toHaveLength(1);
   });
 });

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -51,6 +51,8 @@ const StyledGrid = styled(Grid, {
 
 const isModal = ({ app, appSelections }) => app.isInModalSelection?.() ?? appSelections.isInModal();
 
+const isToolbarMode = (value) => ['attach', 'detach', 'auto'].includes(value);
+
 function ListBoxInline({ options, layout }) {
   const {
     app,
@@ -70,6 +72,7 @@ function ListBoxInline({ options, layout }) {
     scrollState = undefined,
     renderedCallback,
     toolbar = true,
+    toolbarMode = 'auto',
     isPopover = false,
     showLock = false,
     components,
@@ -184,8 +187,16 @@ function ListBoxInline({ options, layout }) {
   const showSearchIcon = searchEnabled !== false && search === 'toggle' && !isLocked;
 
   const canShowTitle = layout?.title?.length && layout?.showTitle !== false;
-  const showDetachedToolbarOnly = toolbar && !canShowTitle && !isPopover;
-  const showAttachedToolbar = (toolbar && canShowTitle) || isPopover;
+  const normalizedToolbarMode = isToolbarMode(toolbarMode) ? toolbarMode : 'auto';
+  const shouldShowToolbar = toolbar || isPopover;
+  const resolvedToolbarMode =
+    normalizedToolbarMode === 'auto'
+      ? !canShowTitle && !isPopover
+        ? 'detach'
+        : 'attach'
+      : normalizedToolbarMode;
+  const renderDetachedToolbar = shouldShowToolbar && resolvedToolbarMode === 'detach';
+  const renderAttachedToolbar = shouldShowToolbar && resolvedToolbarMode !== 'detach';
 
   const isRtl = direction === 'rtl';
 
@@ -233,7 +244,7 @@ function ListBoxInline({ options, layout }) {
     renderedCallback?.();
   }
 
-  const listBoxMinHeight = showAttachedToolbar ? DENSE_ROW_HEIGHT + SCROLL_BAR_WIDTH : 0;
+  const listBoxMinHeight = renderAttachedToolbar ? DENSE_ROW_HEIGHT + SCROLL_BAR_WIDTH : 0;
 
   const listBoxHeader = (
     <ListBoxHeader
@@ -244,7 +255,7 @@ function ListBoxInline({ options, layout }) {
       showToolbar={showToolbar}
       isDirectQuery={isDirectQuery}
       autoConfirm={autoConfirm}
-      showDetachedToolbarOnly={showDetachedToolbarOnly}
+      toolbarMode={renderDetachedToolbar ? 'detach' : normalizedToolbarMode}
       layout={layout}
       translator={translator}
       styles={styles}
@@ -264,7 +275,7 @@ function ListBoxInline({ options, layout }) {
 
   return (
     <>
-      {showDetachedToolbarOnly && listBoxHeader}
+      {renderDetachedToolbar && listBoxHeader}
       <StyledGrid
         className="listbox-container"
         container
@@ -292,7 +303,7 @@ function ListBoxInline({ options, layout }) {
           childNode={listboxChildNode}
           containerNode={containerNode}
         />
-        {showAttachedToolbar && listBoxHeader}
+        {renderAttachedToolbar && listBoxHeader}
         <Grid
           container
           direction="column"

--- a/apis/nucleus/src/components/listbox/ListBoxInline.jsx
+++ b/apis/nucleus/src/components/listbox/ListBoxInline.jsx
@@ -53,6 +53,18 @@ const isModal = ({ app, appSelections }) => app.isInModalSelection?.() ?? appSel
 
 const isToolbarMode = (value) => ['attach', 'detach', 'auto'].includes(value);
 
+function getResolvedToolbarMode({ toolbarMode, canShowTitle, isPopover }) {
+  if (toolbarMode !== 'auto') {
+    return toolbarMode;
+  }
+
+  if (!canShowTitle && !isPopover) {
+    return 'detach';
+  }
+
+  return 'attach';
+}
+
 function ListBoxInline({ options, layout }) {
   const {
     app,
@@ -86,7 +98,15 @@ function ListBoxInline({ options, layout }) {
     useContext(InstanceContext);
 
   const { checkboxes = checkboxesOption } = layout || {};
-  const styles = useListboxStyling({ app, themeApi, theme, queryParams, components, checkboxes, hostConfig });
+  const styles = useListboxStyling({
+    app,
+    themeApi,
+    theme,
+    queryParams,
+    components,
+    checkboxes,
+    hostConfig,
+  });
 
   const isDirectQuery = isDirectQueryEnabled({ appLayout: app?.layout });
 
@@ -189,14 +209,12 @@ function ListBoxInline({ options, layout }) {
   const canShowTitle = layout?.title?.length && layout?.showTitle !== false;
   const normalizedToolbarMode = isToolbarMode(toolbarMode) ? toolbarMode : 'auto';
   const shouldShowToolbar = toolbar || isPopover;
-  const resolvedToolbarMode =
-    normalizedToolbarMode === 'auto'
-      ? !canShowTitle && !isPopover
-        ? 'detach'
-        : 'attach'
-      : normalizedToolbarMode;
+  const resolvedToolbarMode = getResolvedToolbarMode({
+    toolbarMode: normalizedToolbarMode,
+    canShowTitle,
+    isPopover,
+  });
   const renderDetachedToolbar = shouldShowToolbar && resolvedToolbarMode === 'detach';
-  const renderAttachedToolbar = shouldShowToolbar && resolvedToolbarMode !== 'detach';
 
   const isRtl = direction === 'rtl';
 
@@ -244,7 +262,7 @@ function ListBoxInline({ options, layout }) {
     renderedCallback?.();
   }
 
-  const listBoxMinHeight = renderAttachedToolbar ? DENSE_ROW_HEIGHT + SCROLL_BAR_WIDTH : 0;
+  const listBoxMinHeight = shouldShowToolbar && !renderDetachedToolbar ? DENSE_ROW_HEIGHT + SCROLL_BAR_WIDTH : 0;
 
   const listBoxHeader = (
     <ListBoxHeader
@@ -303,7 +321,7 @@ function ListBoxInline({ options, layout }) {
           childNode={listboxChildNode}
           containerNode={containerNode}
         />
-        {renderAttachedToolbar && listBoxHeader}
+        {shouldShowToolbar && !renderDetachedToolbar && listBoxHeader}
         <Grid
           container
           direction="column"

--- a/apis/nucleus/src/components/listbox/__tests__/list-box-inline.test.jsx
+++ b/apis/nucleus/src/components/listbox/__tests__/list-box-inline.test.jsx
@@ -89,9 +89,12 @@ describe('<ListboxInline />', () => {
     jest.spyOn(lockModule, 'default').mockImplementation(() => 'lock');
     jest.spyOn(useLayoutModule, 'default').mockImplementation(() => [layout]);
     jest.spyOn(listboxKeyboardNavigationModule, 'default').mockImplementation(getListboxInlineKeyboardNavigation);
-    jest
-      .spyOn(styling, 'default')
-      .mockImplementation(() => ({ backgroundColor: '#FFFFFF', header: {}, content: {}, selections: {} }));
+    jest.spyOn(styling, 'default').mockImplementation(() => ({
+      backgroundColor: '#FFFFFF',
+      header: {},
+      content: {},
+      selections: {},
+    }));
     jest.spyOn(isDirectQueryEnabled, 'default').mockImplementation(() => false);
     jest.spyOn(useAppSelection, 'default').mockImplementation(() => [{ isInModal: jest.fn().mockReturnValue(false) }]);
 
@@ -222,6 +225,17 @@ describe('<ListboxInline />', () => {
 
       const listBoxSearches = await renderer.findAllByText('ListBoxSearch');
       expect(listBoxSearches).toHaveLength(1);
+    });
+
+    test('should not render toolbar when toolbar is false even if toolbarMode is detach', async () => {
+      const options = { toolbar: false, toolbarMode: 'detach' };
+      await render(options);
+
+      const actionToolbars = await renderer.queryAllByText('ActionsToolbar');
+      expect(actionToolbars).toHaveLength(0);
+
+      const typographs = await renderer.queryAllByText('title');
+      expect(typographs).toHaveLength(0);
     });
 
     test('should render without toolbar', async () => {

--- a/apis/nucleus/src/components/listbox/components/ListBoxHeader/ListBoxHeader.jsx
+++ b/apis/nucleus/src/components/listbox/components/ListBoxHeader/ListBoxHeader.jsx
@@ -73,7 +73,7 @@ export default function ListBoxHeader({
   containerRect,
   isPopover,
   showToolbar,
-  showDetachedToolbarOnly,
+  toolbarMode = 'auto',
   containerRef,
   model,
   selectionState,
@@ -84,7 +84,10 @@ export default function ListBoxHeader({
   app,
   disablePortal,
 }) {
-  const [isToolbarDetached, setIsToolbarDetached] = useState(showDetachedToolbarOnly);
+  const forceDetached = toolbarMode === 'detach';
+  const forceAttached = toolbarMode === 'attach';
+  const isAutoToolbarMode = !forceDetached && !forceAttached;
+  const [isToolbarDetached, setIsToolbarDetached] = useState(forceDetached);
   const [isLocked, setLocked] = useState(layout?.qListObject?.qDimensionInfo?.qLocked);
   const [settingLockedState, setSettingLockedState] = useState(false);
 
@@ -170,6 +173,10 @@ export default function ListBoxHeader({
   );
 
   useEffect(() => {
+    if (!isAutoToolbarMode) {
+      return;
+    }
+
     if (!titleRef.current || !containerRect) {
       return;
     }
@@ -181,17 +188,15 @@ export default function ListBoxHeader({
       paddingLeft,
       paddingRight,
     });
-    const isDetached = showDetachedToolbarOnly || mustShowDetached;
-    setIsToolbarDetached(isDetached);
+    setIsToolbarDetached(mustShowDetached);
   }, [
+    isAutoToolbarMode,
     iconsWidth,
     paddingLeft,
     paddingRight,
     titleRef.current,
-    showDetachedToolbarOnly,
-    Object.entries(containerRect || {})
-      .sort()
-      .join(','),
+    containerRect?.width,
+    containerRect?.height,
   ]);
 
   const toolbarProps = getListboxActionProps({
@@ -210,7 +215,7 @@ export default function ListBoxHeader({
 
   const actionsToolbar = <ActionsToolbar isRtl={isRtl} layout={layout} {...toolbarProps} />;
 
-  if (showDetachedToolbarOnly) {
+  if (forceDetached) {
     return actionsToolbar;
   }
 

--- a/apis/nucleus/src/components/listbox/components/__tests__/list-box-header.test.jsx
+++ b/apis/nucleus/src/components/listbox/components/__tests__/list-box-header.test.jsx
@@ -55,7 +55,7 @@ function getDefaultProps() {
     containerRect: { width: 200 },
     isPopover: false,
     showToolbar: true,
-    showDetachedToolbarOnly: false,
+    toolbarMode: 'auto',
     containerRef,
     model,
     selectionState: {
@@ -141,7 +141,7 @@ describe('<ListBoxHeader />', () => {
   });
 
   test('should render a detached toolbar when told to do so', async () => {
-    const testRenderer = await render({ showDetachedToolbarOnly: true });
+    const testRenderer = await render({ toolbarMode: 'detach' });
     const testInstance = testRenderer.root;
 
     const titles = testInstance.findAllByType(HeaderTitle);
@@ -159,7 +159,7 @@ describe('<ListBoxHeader />', () => {
 
   test.skip('should render a detached toolbar when space is limited', async () => {
     const containerRect = { width: 20 };
-    const testRenderer = await render({ showDetachedToolbarOnly: false, containerRect });
+    const testRenderer = await render({ toolbarMode: 'auto', containerRect });
     const testInstance = testRenderer.root;
 
     const titles = testInstance.findAllByType(HeaderTitle);

--- a/apis/nucleus/src/components/listbox/components/__tests__/list-box-header.test.jsx
+++ b/apis/nucleus/src/components/listbox/components/__tests__/list-box-header.test.jsx
@@ -93,6 +93,7 @@ const render = async (overrideProps = {}) => {
   await act(async () => {
     rendererInst = create(component);
   });
+  await act(async () => {});
   return rendererInst;
 };
 
@@ -100,9 +101,14 @@ let ActionsToolbar;
 let HeaderTitle;
 let hasSelections;
 
-function HeaderTitleMock() {
+const HeaderTitleMock = React.forwardRef((props, ref) => {
+  if (ref && typeof ref !== 'function') {
+    /* eslint-disable no-param-reassign */
+    ref.current = { clientWidth: 100, scrollWidth: 100, offsetWidth: 100 };
+    /* eslint-enable no-param-reassign */
+  }
   return <div />;
-}
+});
 
 describe('<ListBoxHeader />', () => {
   beforeEach(() => {
@@ -112,7 +118,6 @@ describe('<ListBoxHeader />', () => {
     InstanceContextModule.default = InstanceContext;
     const ActionsToolbarElement = <div id="test-actions-toolbar" />;
     ActionsToolbar = jest.spyOn(ActionsToolbarModule, 'default').mockImplementation(() => ActionsToolbarElement);
-    jest.spyOn(React, 'useRef').mockReturnValue({ current: { clientWidth: 100, scrollWidth: 100, offsetWidth: 100 } });
   });
 
   afterEach(() => {
@@ -146,6 +151,24 @@ describe('<ListBoxHeader />', () => {
     expect(titleProps.styles.header.color).toEqual('red');
   });
 
+  test('should keep toolbar attached in auto mode when space is sufficient', async () => {
+    const testRenderer = await render({ toolbarMode: 'auto', containerRect: { width: 500 } });
+    const testInstance = testRenderer.root;
+
+    const [actionsToolbar] = testInstance.findAllByType(ActionsToolbar);
+
+    expect(actionsToolbar.props.isDetached).toEqual(false);
+  });
+
+  test('should keep toolbar attached when toolbarMode is attach', async () => {
+    const testRenderer = await render({ toolbarMode: 'attach', containerRect: { width: 500 } });
+    const testInstance = testRenderer.root;
+
+    const [actionsToolbar] = testInstance.findAllByType(ActionsToolbar);
+
+    expect(actionsToolbar.props.isDetached).toEqual(false);
+  });
+
   test('should render a detached toolbar when told to do so', async () => {
     const testRenderer = await render({ toolbarMode: 'detach' });
     const testInstance = testRenderer.root;
@@ -163,7 +186,7 @@ describe('<ListBoxHeader />', () => {
     expect(actionsToolbars[0].props.isDetached).toEqual(true);
   });
 
-  test.skip('should render a detached toolbar when space is limited', async () => {
+  test('should render a detached toolbar in auto mode when auto detection says detach', async () => {
     const containerRect = { width: 20 };
     const testRenderer = await render({ toolbarMode: 'auto', containerRect });
     const testInstance = testRenderer.root;
@@ -179,6 +202,15 @@ describe('<ListBoxHeader />', () => {
 
     // Verify it is detached.
     expect(actionsToolbars[0].props.isDetached).toEqual(true);
+  });
+
+  test('should keep toolbar attached in attach mode even when space is limited', async () => {
+    const testRenderer = await render({ toolbarMode: 'attach', containerRect: { width: 20 } });
+    const testInstance = testRenderer.root;
+
+    const [actionsToolbar] = testInstance.findAllByType(ActionsToolbar);
+
+    expect(actionsToolbar.props.isDetached).toEqual(false);
   });
 
   test('trigger toggle search field when pressing search icon in toggle mode', async () => {

--- a/apis/nucleus/src/components/listbox/components/__tests__/list-box-header.test.jsx
+++ b/apis/nucleus/src/components/listbox/components/__tests__/list-box-header.test.jsx
@@ -21,7 +21,13 @@ const selections = {
   canCancel: () => true,
   isActive: () => false,
 };
-const styles = { content: {}, header: { color: 'red' }, selections: {}, search: {}, background: {} };
+const styles = {
+  content: {},
+  header: { color: 'red' },
+  selections: {},
+  search: {},
+  background: {},
+};
 let rendererInst;
 
 const translator = { get: jest.fn().mockImplementation((v) => v) };
@@ -212,7 +218,10 @@ describe('<ListBoxHeader />', () => {
   });
 
   test('There should be an unlock cover button on top of the actions toolbar', async () => {
-    const layout = { title: 'The title', qListObject: { qDimensionInfo: { qLocked: true, qGrouping: 'N' } } };
+    const layout = {
+      title: 'The title',
+      qListObject: { qDimensionInfo: { qLocked: true, qGrouping: 'N' } },
+    };
     hasSelections.mockReturnValue(false);
     const testRenderer = await render({
       layout,

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -527,6 +527,10 @@ function nuked(configuration = {}) {
          */
 
         /**
+         * @typedef { 'attach' | 'detach' | 'auto' } ToolbarMode
+         */
+
+        /**
          * @typedef { 'selectionActivated' | 'selectionDeactivated' } FieldEventTypes
          */
 
@@ -572,6 +576,7 @@ function nuked(configuration = {}) {
            * @param {SearchMode=} [options.search=true] Show the search bar permanently, using the toggle button or when in selection: false|true|toggle
            * @param {boolean=} [options.showLock=false] Show the button for toggling locked state.
            * @param {boolean=} [options.toolbar=true] Show the toolbar
+           * @param {ToolbarMode=} [options.toolbarMode=auto] Toolbar placement mode: attach, detach, or auto.
            * @param {boolean=} [options.checkboxes=false] Show values as checkboxes instead of as fields (not applicable for existing objects)
            * @param {boolean=} [options.dense=false] Reduces padding and text size (not applicable for existing objects)
            * @param {string=} [options.stateName="$"] Sets the state to make selections in (not applicable for existing objects)

--- a/apis/nucleus/src/index.js
+++ b/apis/nucleus/src/index.js
@@ -288,7 +288,9 @@ function nuked(configuration = {}) {
         await appTheme.setTheme(configuration.context.theme);
 
         if (configuration.hostConfig && auth && auth.getWebResourceAuthParams) {
-          const { queryParams } = await auth.getWebResourceAuthParams({ hostConfig: configuration.hostConfig });
+          const { queryParams } = await auth.getWebResourceAuthParams({
+            hostConfig: configuration.hostConfig,
+          });
           currentContext.queryParams = queryParams;
           root.context(currentContext);
         }

--- a/apis/stardust/api-spec/spec.json
+++ b/apis/stardust/api-spec/spec.json
@@ -1149,6 +1149,26 @@
         ]
       }
     },
+    "ToolbarMode": {
+      "kind": "alias",
+      "items": {
+        "kind": "union",
+        "items": [
+          {
+            "kind": "literal",
+            "value": "'attach'"
+          },
+          {
+            "kind": "literal",
+            "value": "'detach'"
+          },
+          {
+            "kind": "literal",
+            "value": "'auto'"
+          }
+        ]
+      }
+    },
     "FieldEventTypes": {
       "kind": "alias",
       "items": {
@@ -1275,6 +1295,12 @@
                   "optional": true,
                   "defaultValue": true,
                   "type": "boolean"
+                },
+                "toolbarMode": {
+                  "description": "Toolbar placement mode: attach, detach, or auto.",
+                  "optional": true,
+                  "defaultValue": "auto",
+                  "type": "#/definitions/ToolbarMode"
                 },
                 "checkboxes": {
                   "description": "Show values as checkboxes instead of as fields (not applicable for existing objects)",
@@ -1745,6 +1771,162 @@
         }
       }
     },
+    "Field": {
+      "kind": "alias",
+      "items": {
+        "kind": "union",
+        "items": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "qix.NxDimension"
+          },
+          {
+            "type": "qix.NxMeasure"
+          },
+          {
+            "type": "#/definitions/LibraryField"
+          }
+        ]
+      }
+    },
+    "CreateConfig": {
+      "description": "Rendering configuration for creating and rendering a new object",
+      "kind": "interface",
+      "entries": {
+        "type": {
+          "type": "string"
+        },
+        "version": {
+          "optional": true,
+          "type": "string"
+        },
+        "fields": {
+          "optional": true,
+          "kind": "union",
+          "items": [
+            {
+              "kind": "array",
+              "items": {
+                "type": "#/definitions/Field"
+              }
+            }
+          ]
+        },
+        "properties": {
+          "optional": true,
+          "type": "qix.GenericObjectProperties"
+        }
+      }
+    },
+    "RenderConfig": {
+      "description": "Configuration for rendering a visualisation, either creating or fetching an existing object.",
+      "kind": "interface",
+      "entries": {
+        "element": {
+          "description": "Target html element to render in to",
+          "type": "HTMLElement"
+        },
+        "options": {
+          "description": "Options passed into the visualisation",
+          "optional": true,
+          "type": "object"
+        },
+        "onRender": {
+          "description": "Callback function called after rendering successfully",
+          "optional": true,
+          "kind": "function",
+          "params": []
+        },
+        "onError": {
+          "description": "Callback function called if an error occurs. Also called with AbortError when signal aborts.",
+          "optional": true,
+          "kind": "function",
+          "params": [
+            {
+              "type": "#/definitions/RenderError"
+            }
+          ]
+        },
+        "plugins": {
+          "description": "plugins passed into the visualisation",
+          "optional": true,
+          "kind": "array",
+          "items": {
+            "type": "#/definitions/Plugin"
+          }
+        },
+        "signal": {
+          "description": "Optional AbortSignal to cancel the render operation. When aborted, destroy() is called for cleanup before onError() is called with the AbortError.",
+          "optional": true,
+          "type": "AbortSignal"
+        },
+        "id": {
+          "description": "For existing objects: Engine identifier of object to render",
+          "optional": true,
+          "type": "string"
+        },
+        "type": {
+          "description": "For creating objects: Type of visualisation to render",
+          "optional": true,
+          "type": "string"
+        },
+        "version": {
+          "description": "For creating objects: Version of visualization to render",
+          "optional": true,
+          "type": "string"
+        },
+        "fields": {
+          "description": "For creating objects: Data fields to use",
+          "optional": true,
+          "kind": "union",
+          "items": [
+            {
+              "kind": "array",
+              "items": {
+                "type": "#/definitions/Field"
+              }
+            }
+          ]
+        },
+        "extendProperties": {
+          "description": "For creating objects: Whether to deeply extend properties or not. If false then subtrees will be overwritten.",
+          "optional": true,
+          "defaultValue": false,
+          "type": "boolean"
+        },
+        "properties": {
+          "description": "For creating objects: Explicit properties to set",
+          "optional": true,
+          "type": "qix.GenericObjectProperties"
+        }
+      },
+      "examples": [
+        "// A config for Creating objects:\nconst createConfig = {\n  type: 'bar',\n  element: document.querySelector('.bar'),\n  extendProperties: true,\n  fields: ['[Country names]', '=Sum(Sales)'],\n  properties: {\n    legend: {\n      show: false,\n    },\n  }\n};\nnebbie.render(createConfig);\n// A config for rendering an existing object:\nconst renderConfig = {\n  id: 'jG5LP',\n  element: document.querySelector('.line'),\n};\nnebbie.render(renderConfig);\n// Using AbortSignal to cancel rendering:\nconst controller = new AbortController();\nconst abortConfig = {\n  type: 'bar',\n  element: document.querySelector('.bar'),\n  fields: ['Country', '=Sum(Sales)'],\n  signal: controller.signal,\n  onError: (err) => {\n    if (err.name === 'AbortError') {\n      console.log('Render was cancelled');\n    } else {\n      console.error('Render failed:', err);\n    }\n  }\n};\nconst vizPromise = nebbie.render(abortConfig);\n// Cancel the render operation\ncontroller.abort();"
+      ]
+    },
+    "LibraryField": {
+      "kind": "interface",
+      "entries": {
+        "qLibraryId": {
+          "type": "string"
+        },
+        "type": {
+          "kind": "union",
+          "items": [
+            {
+              "kind": "literal",
+              "value": "'dimension'"
+            },
+            {
+              "kind": "literal",
+              "value": "'measure'"
+            }
+          ]
+        }
+      }
+    },
     "AppSelections": {
       "kind": "class",
       "constructor": {
@@ -1982,189 +2164,6 @@
         }
       }
     },
-    "Field": {
-      "kind": "alias",
-      "items": {
-        "kind": "union",
-        "items": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "qix.NxDimension"
-          },
-          {
-            "type": "qix.NxMeasure"
-          },
-          {
-            "type": "#/definitions/LibraryField"
-          }
-        ]
-      }
-    },
-    "CreateConfig": {
-      "description": "Rendering configuration for creating and rendering a new object",
-      "kind": "interface",
-      "entries": {
-        "type": {
-          "type": "string"
-        },
-        "version": {
-          "optional": true,
-          "type": "string"
-        },
-        "fields": {
-          "optional": true,
-          "kind": "union",
-          "items": [
-            {
-              "kind": "array",
-              "items": {
-                "type": "#/definitions/Field"
-              }
-            }
-          ]
-        },
-        "properties": {
-          "optional": true,
-          "type": "qix.GenericObjectProperties"
-        }
-      }
-    },
-    "RenderConfig": {
-      "description": "Configuration for rendering a visualisation, either creating or fetching an existing object.",
-      "kind": "interface",
-      "entries": {
-        "element": {
-          "description": "Target html element to render in to",
-          "type": "HTMLElement"
-        },
-        "options": {
-          "description": "Options passed into the visualisation",
-          "optional": true,
-          "type": "object"
-        },
-        "onRender": {
-          "description": "Callback function called after rendering successfully",
-          "optional": true,
-          "kind": "function",
-          "params": []
-        },
-        "onError": {
-          "description": "Callback function called if an error occurs. Also called with AbortError when signal aborts.",
-          "optional": true,
-          "kind": "function",
-          "params": [
-            {
-              "type": "#/definitions/RenderError"
-            }
-          ]
-        },
-        "plugins": {
-          "description": "plugins passed into the visualisation",
-          "optional": true,
-          "kind": "array",
-          "items": {
-            "type": "#/definitions/Plugin"
-          }
-        },
-        "signal": {
-          "description": "Optional AbortSignal to cancel the render operation. When aborted, destroy() is called for cleanup before onError() is called with the AbortError.",
-          "optional": true,
-          "type": "AbortSignal"
-        },
-        "id": {
-          "description": "For existing objects: Engine identifier of object to render",
-          "optional": true,
-          "type": "string"
-        },
-        "type": {
-          "description": "For creating objects: Type of visualisation to render",
-          "optional": true,
-          "type": "string"
-        },
-        "version": {
-          "description": "For creating objects: Version of visualization to render",
-          "optional": true,
-          "type": "string"
-        },
-        "fields": {
-          "description": "For creating objects: Data fields to use",
-          "optional": true,
-          "kind": "union",
-          "items": [
-            {
-              "kind": "array",
-              "items": {
-                "type": "#/definitions/Field"
-              }
-            }
-          ]
-        },
-        "extendProperties": {
-          "description": "For creating objects: Whether to deeply extend properties or not. If false then subtrees will be overwritten.",
-          "optional": true,
-          "defaultValue": false,
-          "type": "boolean"
-        },
-        "properties": {
-          "description": "For creating objects: Explicit properties to set",
-          "optional": true,
-          "type": "qix.GenericObjectProperties"
-        }
-      },
-      "examples": [
-        "// A config for Creating objects:\nconst createConfig = {\n  type: 'bar',\n  element: document.querySelector('.bar'),\n  extendProperties: true,\n  fields: ['[Country names]', '=Sum(Sales)'],\n  properties: {\n    legend: {\n      show: false,\n    },\n  }\n};\nnebbie.render(createConfig);\n// A config for rendering an existing object:\nconst renderConfig = {\n  id: 'jG5LP',\n  element: document.querySelector('.line'),\n};\nnebbie.render(renderConfig);\n// Using AbortSignal to cancel rendering:\nconst controller = new AbortController();\nconst abortConfig = {\n  type: 'bar',\n  element: document.querySelector('.bar'),\n  fields: ['Country', '=Sum(Sales)'],\n  signal: controller.signal,\n  onError: (err) => {\n    if (err.name === 'AbortError') {\n      console.log('Render was cancelled');\n    } else {\n      console.error('Render failed:', err);\n    }\n  }\n};\nconst vizPromise = nebbie.render(abortConfig);\n// Cancel the render operation\ncontroller.abort();"
-      ]
-    },
-    "LibraryField": {
-      "kind": "interface",
-      "entries": {
-        "qLibraryId": {
-          "type": "string"
-        },
-        "type": {
-          "kind": "union",
-          "items": [
-            {
-              "kind": "literal",
-              "value": "'dimension'"
-            },
-            {
-              "kind": "literal",
-              "value": "'measure'"
-            }
-          ]
-        }
-      }
-    },
-    "Plugin": {
-      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
-      "stability": "experimental",
-      "availability": {
-        "since": "1.2.0"
-      },
-      "kind": "interface",
-      "entries": {
-        "info": {
-          "description": "Object that can hold various meta info about the plugin",
-          "kind": "object",
-          "entries": {
-            "name": {
-              "description": "The name of the plugin",
-              "type": "string"
-            }
-          }
-        },
-        "fn": {
-          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
-          "type": "function"
-        }
-      },
-      "examples": [
-        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
-      ]
-    },
     "LoadType": {
       "kind": "interface",
       "params": [
@@ -2209,6 +2208,33 @@
           "type": "object"
         }
       }
+    },
+    "Plugin": {
+      "description": "An object literal containing meta information about the plugin and a function containing the plugin implementation.",
+      "stability": "experimental",
+      "availability": {
+        "since": "1.2.0"
+      },
+      "kind": "interface",
+      "entries": {
+        "info": {
+          "description": "Object that can hold various meta info about the plugin",
+          "kind": "object",
+          "entries": {
+            "name": {
+              "description": "The name of the plugin",
+              "type": "string"
+            }
+          }
+        },
+        "fn": {
+          "description": "The implementation of the plugin. Input and return value is up to the plugin implementation to decide based on its purpose.",
+          "type": "function"
+        }
+      },
+      "examples": [
+        "const plugin = {\n  info: {\n    name: \"example-plugin\",\n    type: \"meta-type\",\n  },\n  fn: () => {\n    // Plugin implementation goes here\n  }\n};"
+      ]
     },
     "RenderError": {
       "extends": [

--- a/apis/stardust/types/index.d.ts
+++ b/apis/stardust/types/index.d.ts
@@ -365,6 +365,8 @@ declare namespace stardust {
 
     type SearchMode = boolean | "toggle";
 
+    type ToolbarMode = "attach" | "detach" | "auto";
+
     type FieldEventTypes = "selectionActivated" | "selectionDeactivated";
 
     class FieldInstance {
@@ -398,6 +400,7 @@ declare namespace stardust {
             search?: stardust.SearchMode;
             showLock?: boolean;
             toolbar?: boolean;
+            toolbarMode?: stardust.ToolbarMode;
             checkboxes?: boolean;
             dense?: boolean;
             stateName?: string;
@@ -628,6 +631,16 @@ declare namespace stardust {
 
     }
 
+    /**
+     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
+     */
+    interface Plugin {
+        info: {
+            name: string;
+        };
+        fn: ()=>void;
+    }
+
     type Field = string | qix.NxDimension | qix.NxMeasure | stardust.LibraryField;
 
     /**
@@ -668,16 +681,6 @@ declare namespace stardust {
     interface LibraryField {
         qLibraryId: string;
         type: "dimension" | "measure";
-    }
-
-    /**
-     * An object literal containing meta information about the plugin and a function containing the plugin implementation.
-     */
-    interface Plugin {
-        info: {
-            name: string;
-        };
-        fn: ()=>void;
     }
 
     interface LoadType {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

The requirements show up strangely when the chart is too small, this fixes that by removing the "1 of 2 dimension" texts when its too small to fit,

Additionally adds a toolbarMode to the listbox API to allow for better control over how it is displayed, needed when the inline listbox is used inside a different popover.

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
