### PR TITLE
chore: add cloud-listbox-popover example for testing listbox in popover

### DIFF
--- a/examples/cloud-listbox-popover/.gitignore
+++ b/examples/cloud-listbox-popover/.gitignore
@@ -1,0 +1,5 @@
+.parcel-cache/
+dist/
+node_modules/
+.yarn/install-state.gz
+yarn.lock

--- a/examples/cloud-listbox-popover/README.md
+++ b/examples/cloud-listbox-popover/README.md
@@ -1,0 +1,76 @@
+# cloud-listbox-popover
+
+A test mashup for verifying how a listbox behaves when embedded in a popover via `embed.field().mount()` against a Qlik cloud tenant.
+
+## Prerequisites
+
+- Node.js and Yarn installed
+- Access to a Qlik cloud tenant with a web integration ID whitelisted for `http://localhost:1234`
+
+> **Note:** This example is always wired to the **local** nebula.js source via `resolutions` in `package.json`. Stardust loads from `dist/stardust.dev.js` — changes to source only take effect after rebuilding (see Part 2).
+
+---
+
+## Part 1 — Setup and start
+
+### 1. Configure the tenant
+
+Open your app on the tenant. Copy the tenant hostname and app UUID from the URL:
+```
+https://<tenant>/sense/app/<APP_ID>/...
+```
+
+Edit `connect.js` and fill in the three values:
+```js
+const TENANT = 'your-tenant.eu.qlik.com';
+const WEB_INTEGRATION_ID = 'your-web-integration-id';
+const APP_ID = 'your-app-id-here';
+```
+
+Create the web integration in the Qlik Management Console (**Web integrations → Create new**) and add `http://localhost:1234` as an allowed origin.
+
+### 2. Set the field name
+
+Edit `index.js` and set `FIELD` to any dimension that exists in your app:
+```js
+const FIELD = 'Alpha';
+```
+
+### 3. Install dependencies
+
+```sh
+cd examples/cloud-listbox-popover
+yarn install
+```
+
+### 4. Start the server
+
+```sh
+kill $(lsof -ti :1234) 2>/dev/null; yarn start
+```
+
+Opens at `http://localhost:1234`. On first load you will be redirected to the Qlik login page — sign in and you will be sent back automatically. Press `Cmd+Shift+R` to bypass the cache.
+
+---
+
+## Part 2 — After making a local change
+
+Parcel does not watch `dist/` or `node_modules/`, so it must be restarted after every source rebuild. The `rebuild` script does all three steps in one go: rebuilds stardust with rollup, kills the old Parcel process, clears its cache, and starts fresh.
+
+```sh
+cd examples/cloud-listbox-popover
+yarn run rebuild
+```
+
+> **Important:** Use `yarn run rebuild`, not `yarn rebuild`. In yarn berry, `yarn rebuild` is a built-in command that rebuilds native addons — it will not run the script above.
+
+Hard-refresh the browser once it opens: `Cmd+Shift+R`.
+
+> **Tip:** Console logs inside a component's render function only fire when the component mounts or updates — open the popover after refreshing to trigger the render.
+
+---
+
+## What to verify
+
+Click **"Open listbox popover"** and inspect the listbox inside the 220px container.
+

--- a/examples/cloud-listbox-popover/connect.js
+++ b/examples/cloud-listbox-popover/connect.js
@@ -1,0 +1,26 @@
+import enigma from 'enigma.js';
+import schema from 'enigma.js/schemas/12.1657.0.json';
+import { Auth, AuthType } from '@qlik/sdk';
+
+// Replace these with your own values — see README for instructions
+const TENANT = '';
+const WEB_INTEGRATION_ID = '';
+const APP_ID = '';
+
+export default async function connect() {
+  const auth = new Auth({
+    authType: AuthType.WebIntegration,
+    autoRedirect: true,
+    host: TENANT,
+    webIntegrationId: WEB_INTEGRATION_ID,
+  });
+
+  if (!auth.isAuthenticated()) {
+    auth.authenticate();
+    return null;
+  }
+
+  const wsUrl = await auth.generateWebsocketUrl(APP_ID);
+  const global = await enigma.create({ schema, url: wsUrl }).open();
+  return global.openDoc(APP_ID);
+}

--- a/examples/cloud-listbox-popover/index.html
+++ b/examples/cloud-listbox-popover/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Listbox popover test</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        background: #eee;
+        margin: 24px;
+      }
+
+      .trigger {
+        padding: 8px 16px;
+        font-size: 14px;
+        cursor: pointer;
+      }
+
+      /* Simulates a popover: fixed size, no explicit width on the mount target */
+      .popover {
+        display: none;
+        position: fixed;
+        top: 60px;
+        left: 40px;
+        width: 220px;
+        height: 320px;
+        background: white;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+        border-radius: 4px;
+        overflow: hidden;
+        z-index: 100;
+      }
+
+      .popover.open {
+        display: block;
+      }
+
+      /* Mount target: height only — no width — this is what the fix addresses */
+      .popover-listbox {
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <button class="trigger">Open listbox popover</button>
+    <div class="popover">
+      <div class="popover-listbox"></div>
+    </div>
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/examples/cloud-listbox-popover/index.js
+++ b/examples/cloud-listbox-popover/index.js
@@ -1,0 +1,25 @@
+import { embed } from '@nebula.js/stardust';
+import connect from './connect';
+
+// Change to any dimension field that exists in your app
+const FIELD = 'Alpha';
+
+async function init() {
+  const app = await connect();
+  if (!app) return; // auth redirect in progress
+
+  const nebbie = embed(app);
+
+  const popover = document.querySelector('.popover');
+  let mounted = false;
+
+  document.querySelector('.trigger').addEventListener('click', () => {
+    popover.classList.toggle('open');
+    if (!mounted) {
+      mounted = true;
+      nebbie.field(FIELD).then((f) => f.mount(document.querySelector('.popover-listbox')));
+    }
+  });
+}
+
+init();

--- a/examples/cloud-listbox-popover/package.json
+++ b/examples/cloud-listbox-popover/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "cloud-listbox-popover",
+  "version": "1.0.0",
+  "description": "Test listbox width fix in a popover against a cloud tenant",
+  "scripts": {
+    "start": "parcel index.html --open --no-hmr --port 1234",
+    "rebuild": "(cd ../../apis/stardust && ../../node_modules/.bin/rollup --bundleConfigAsCjs --config ../../rollup.config.js) && kill $(lsof -ti :1234) 2>/dev/null; sleep 1 && rm -rf .parcel-cache && yarn start"
+  },
+  "dependencies": {
+    "@nebula.js/stardust": "latest",
+    "@qlik/sdk": "0.28.0",
+    "enigma.js": "2.11.0"
+  },
+  "devDependencies": {
+    "@babel/core": "7.29.6",
+    "parcel": "^2.7.0"
+  },
+  "resolutions": {
+    "@nebula.js/stardust": "portal:../../apis/stardust"
+  }
+}


### PR DESCRIPTION
## Motivation

Add a minimal example mashup for manually testing a listbox embedded in a popover against a Qlik cloud tenant. This is useful when working on changes to how a listbox renders inside a constrained container (e.g. a popover with a fixed width and no explicit width on the mount target).

## What's included

- `connect.js` — cloud auth via `@qlik/sdk` web integration
- `index.html` — a 220px popover container with a mount target that has only `height: 100%` (no width), matching the real embed-in-popover scenario
- `index.js` — mounts a field listbox into the popover on button click
- `test-local.sh` — script to build nebula, link the local stardust, and start the server in one step
- `README.md` — step-by-step instructions for running against a tenant and against a local nebula build

## How to test

See [examples/cloud-listbox-popover/README.md](examples/cloud-listbox-popover/README.md).


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
