### PR TITLE
fix: handle chalk v6.0.0 ESM imports in eslint resolver

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -112,6 +112,15 @@ export default defineConfig([
     },
   },
   {
+    // Commands lib files use chalk which has ESM-only exports (no main field)
+    files: ['commands/build/lib/**/*.js', 'commands/create/lib/**/*.js', 'commands/serve/lib/**/*.js'],
+
+    rules: {
+      // chalk v6+ is ESM-only with exports field; resolver has trouble finding it
+      'import/no-unresolved': ['error', { ignore: ['chalk'] }],
+    },
+  },
+  {
     files: ['commands/serve/web/**/*.{js,jsx}'],
 
     rules: {


### PR DESCRIPTION
Chalk v6.0.0 is ESM-only with exports field but no main field. The import resolver was unable to find it for commands/build, commands/create, and commands/serve lib files. Configure eslint to ignore chalk in the import resolver for these specific command packages since it's correctly installed and resolvable at runtime.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/qlik-oss/nebula.js/blob/master/.github/CONTRIBUTING.md#git
-->

## Motivation

<!-- Write your motivation here -->

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `yarn spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
