### PR TITLE
chore: name convention of test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
             ./commands/serve/test/e2e/dev-route.spec.js-snapshots
 
   test-create:
-    name: ${{ matrix['picasso-template'] != 'none' && matrix['picasso-template'] || 'basic' }}${{ matrix.mashup && '-mashup' || '' }}${{ matrix.typescript && '-ts' || '' }}
+    name: test-create-${{ matrix['picasso-template'] != 'none' && matrix['picasso-template'] || 'basic' }}${{ matrix.mashup && '-mashup' || '' }}${{ matrix.typescript && '-ts' || '' }}
     runs-on: ubuntu-latest
     needs: build
     strategy:


### PR DESCRIPTION
## Motivation

Adding test-create as a prefix to all test-create job makes it easier to find and they follow convention of other test jobs

## Requirements checklist

<!-- Make sure you got these covered -->

- [ ] Api specification
  - [ ] Ran `pnpm spec`
    - [ ] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [ ] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core
