### PR TITLE
fix(build): scope React Babel preset to JSX files

### DIFF
--- a/commands/build/lib/config.js
+++ b/commands/build/lib/config.js
@@ -156,7 +156,13 @@ const config = ({
         },
       },
     ],
-    [babelPresetReact, { runtime: 'automatic' }],
+  ];
+
+  const babelOverrides = [
+    {
+      test: /\.[jt]sx$/,
+      presets: [[babelPresetReact, { runtime: 'automatic' }]],
+    },
   ];
 
   if (typescript) {
@@ -215,6 +221,7 @@ const config = ({
           babelrc: false,
           inputSourceMap: sourcemap,
           extensions,
+          overrides: babelOverrides,
           presets: babelPresets,
         }),
         ...[


### PR DESCRIPTION
## Motivation

Babel 8 changed parsing when the JSX and TypeScript plugins are both enabled: the JSX plugin now controls JSX parsing, so TypeScript generic syntax such as `&lt;T&gt;() =&gt;` in `.ts` files can be interpreted as JSX and fail to parse. See the [Babel 8 release plan](https://github.com/babel/babel/issues/10746), particularly “Parse JSX elements when both the JSX and TS plugins are enabled.”

Apply `@babel/preset-react` only to `.jsx` and `.tsx` files. The TypeScript preset remains extension-aware, so `.ts` files are parsed without JSX while JSX-capable files retain the automatic React runtime.

## Requirements checklist

- [ ] Api specification
  - [ ] Ran `pnpm spec`
    - [x] No changes **_OR_** API changes has been formally approved
- [ ] Unit/Component test coverage
- [x] Correct PR title for the changes (fix, chore, feat)

When build and tests have passed:

- [ ] Add code reviewers, for example @qlik-oss/nebula-core

## Validation

- `pnpm build`
- `pnpm exec eslint commands/build/lib/config.js`
- `pnpm exec prettier --check commands/build/lib/config.js`

No test file is included; validation uses the existing build pipeline.